### PR TITLE
Finalize external source adapters and LNAA-aware ranking

### DIFF
--- a/Bibliographies.md
+++ b/Bibliographies.md
@@ -141,7 +141,10 @@ DailyMed as the only medication source.
 
 14. NHS England Digital. *Dictionary of Medicines and Devices (dm+d).*
     NHS England, https://digital.nhs.uk/services/terminology-and-classifications/dm-d.
-    Accessed 27 May 2026.
+    Accessed 27 May 2026. (Access: NHS Terminology Server FHIR API,
+    https://ontology.nhs.uk/production1/fhir/, and TRUD XML download. dm+d is
+    identity/coding-strong via SNOMED CT; it is not a complete food-effect
+    label source.)
 
 15. European Medicines Agency. *Electronic Product Information (ePI).* EMA,
     https://www.ema.europa.eu/en/human-regulatory-overview/marketing-authorisation/product-information-requirements/electronic-product-information-epi.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,21 @@ user-provided window and sufficient context.
 
 See [docs/IMPORTER_METADATA_FLOW.md](docs/IMPORTER_METADATA_FLOW.md) for the
 canonical metadata model, source-authority policy, cross-jurisdiction conflict
-policy, completeness gate, and the protein-redistribution objective.
+policy, completeness gate, and the protein-redistribution objective, and
+[docs/MANUAL_VALIDATION.md](docs/MANUAL_VALIDATION.md) for a hands-on
+walkthrough.
+
+Fixture-tested medication source parsers now cover DailyMed, Health Canada
+DPD, EMA, PMDA, **NHS dm+d** (identity/coding — not a complete food-effect
+source), **EU national registers** (member-state identity vs full SmPC), and
+**NMPA** (fixture-validated / prototype, honestly downgraded). A
+`SourceFetchClient` abstraction (with an offline `FixtureSourceFetchClient`
+returning structured `SourceFetchResult`s) keeps all tests deterministic;
+live fetch is optional and never used for clinical advice. Per-food
+amino-acid fields, when present, drive the LNAA competition layer in
+preference to the protein-source proxy. The legacy heuristic can only order
+results when `rankerEligibility.mechanisticPrimaryEligible == false`, with the
+reason surfaced in UI + replay.
 
 ## Demo Media
 

--- a/docs/IMPORTER_METADATA_FLOW.md
+++ b/docs/IMPORTER_METADATA_FLOW.md
@@ -153,8 +153,26 @@ prescribe a diet.
 - Replay: **21 scenarios** with per-candidate protein/source/authority fields
   in the report.
 
+**Now fixture-tested (concrete parsers added):**
+- **NHS dm+d** (`DmdImporter`) — identity/coding parser; explicitly cannot
+  supply food-effect mechanism evidence alone.
+- **EU national register** (`EuNationalRegisterImporter`) — member-state
+  identity parser; distinguishes register identity from full SmPC text.
+
 **Spec-only (registry metadata, no concrete parser yet):**
-- NHS dm+d (GB), EU national registers (EU member states).
+- (none of the named medication families remain spec-only; remaining
+  spec-only entries are future additional sources.)
+
+**Fetch abstraction:** `SourceFetchClient` (interface) +
+`HttpSourceFetchClient` (live) + `FakeSourceFetchClient` +
+`FixtureSourceFetchClient` (offline, returns a structured `SourceFetchResult`
+with explicit failure metadata; no fake fact on failure). Tests never touch
+the network.
+
+**Amino-acid extraction:** `AminoAcidExtractor.extractFromFdcStyle(...)` builds
+an `AminoAcidProfile`; the competition model prefers actual amino-acid fields
+(`actualAminoAcidFields` mode) over the protein-source proxy
+(`proteinSourceProxy`), falling back to `unknown` when neither is present.
 
 ## 15. Future work
 

--- a/docs/MANUAL_VALIDATION.md
+++ b/docs/MANUAL_VALIDATION.md
@@ -1,0 +1,61 @@
+# Manual Validation Guide
+
+Educational prototype only. Synthetic/demo data only. Not medical advice.
+
+This guide walks through validating the mechanistic next-meal flow and the
+multi-jurisdiction metadata trace by hand, plus the deterministic replay.
+
+## Run the app
+
+1. `flutter run -d chrome`
+2. Select or add a **catalog-backed levodopa context** on the medications page
+   (a carbidopa/levodopa catalog item). Bare numbers / unitless entries are
+   rejected by the medication-context gate by design.
+3. Open the **Next meal** page.
+4. Set a **user-defined meal window** using the window chooser
+   (none / 30 / 60 / 90 min). The app — not the engine — owns the window.
+5. Generate. Confirm:
+   - `Ranker used: mechanistic_primary` appears **when context is sufficient**
+     (window provided + medium/high confidence + every candidate scored).
+   - The per-candidate trace chips show worst/best/avg overlap, sample count,
+     `protein-window <role>`, `redistribution <pct>`, `aa-mode <mode>`, and
+     `src <sourceSystem>`.
+   - The model-trace card (expansion tile) shows interaction score, severity,
+     confidence, drivers, modeled windows, limitation, safety boundary, and
+     not-advice text. Raw JSON is **not** shown by default.
+6. Set the window chooser to **none** and regenerate. Confirm the page states
+   *"Mechanistic-primary ranking is unavailable because no user-defined meal
+   window was provided."* and `Ranker used: heuristic_legacy_fallback`.
+
+## Run the deterministic replay
+
+```sh
+dart run tool/run_mechanistic_replay.dart   # or: npm run mechanistic:replay
+```
+
+- Confirm `26 / 26 scenarios passed`.
+- Inspect `build/mechanistic_replay/latest.json` and `latest.md`. Each case
+  carries `ranker_used`, `amino_acid_data_mode`, `amino_acid_nutrient_ids`,
+  `top_protein_window_role`, `top_final_candidate_score`, source system, and
+  pass/fail.
+
+## Troubleshooting
+
+| Symptom | Likely cause | What to check |
+| --- | --- | --- |
+| Ranker stays `heuristic_legacy_fallback` | No window, low confidence, or a candidate is insufficient | `rankerEligibility.fallbackReasons` in the result / replay JSON |
+| "no user-defined meal window" message | Window chooser set to none | Pick 30/60/90 min |
+| Medication context invalid | Unitless/bare medication input | Use a catalog-backed levodopa item with unit + form + release type |
+| Candidate low confidence | Missing nutrient fields | Composition completeness < 1.0; nutrient basis missing |
+| `aa-mode unknown` | No protein and no amino-acid fields | Provide protein grams or amino-acid profile |
+| `aa-mode protein_source_proxy` | Protein present but no amino-acid fields | Expected fallback; add an `AminoAcidProfile` for actual-fields mode |
+| Source-linked explanation blocked | Missing `sourceRefs` | Completeness gate downgrades explanations without provenance |
+| dm+d / EU-national source can't supply mechanism evidence | Identity-only record (no SmPC/label text) | These are identity/coding sources; mechanism needs a label/SmPC source |
+
+## Notes
+
+- Live network fetch exists behind `SourceFetchClient` but is **not** used by
+  tests and **not** used to fetch clinical advice. All adapters are validated
+  against synthetic fixtures.
+- Nothing here is medical advice, a diagnosis, a dosing/timing recommendation,
+  or a claim of clinical validation.

--- a/docs/REPLAY_RUNNER.md
+++ b/docs/REPLAY_RUNNER.md
@@ -85,10 +85,14 @@ Per-case report row (see `MechanisticReplayCaseReport`):
 | `top_candidate_source_system` | Source system of the top candidate. |
 | `pass` / `failureReason` | Bool + diagnostic message. |
 
-The suite contains **21 scenarios** (s01–s21), covering catalog-backed
+The suite contains **26 scenarios** (s01–s26), covering catalog-backed
 medication context, missing-field downgrades, invalid medication, daytime
 high-overlap vs evening low-overlap protein behavior, zero-vs-moderate
-protein in low-overlap windows, and the no-window fallback.
+protein in low-overlap windows, the no-window fallback, amino-acid
+actual-fields vs protein-source-proxy modes (s22/s23), additional invalid
+medication forms (s24/s25), and mechanistic-primary overwriting the legacy
+order (s26). Report rows additionally carry `amino_acid_data_mode`,
+`amino_acid_nutrient_ids`, and the top-candidate ranking fields.
 
 ## Banned-phrase scan
 

--- a/lib/core/constants/mechanistic_replay_scenarios.dart
+++ b/lib/core/constants/mechanistic_replay_scenarios.dart
@@ -1,3 +1,4 @@
+import '../../domain/entities/amino_acid_profile.dart';
 import '../../domain/entities/mechanistic_conflict_result.dart';
 import '../../domain/entities/meal_composition.dart';
 import '../../domain/entities/time_axis_events.dart';
@@ -200,6 +201,40 @@ const _candidateRiceCake = CandidateFood(
       calories: 35,
       portionGrams: 12,
       sourceDocId: 'synthetic:demo_food',
+    ),
+  ],
+);
+
+/// Candidate carrying actual amino-acid fields (FDC-style), so the LNAA
+/// layer uses `actualAminoAcidFields` mode rather than the protein-source
+/// proxy.
+const _candidateAminoAcidFood = CandidateFood(
+  id: 'cand.amino_acid_food',
+  name: 'amino-acid-profiled food (synthetic demo)',
+  regionalFoodLibraryRef: 'synthetic:usda_fdc_demo',
+  declaredPhysicalForm: MealPhysicalForm.solid,
+  components: [
+    FoodComponent(
+      id: 'food.aa.synth',
+      name: 'high-protein food with amino-acid fields',
+      physicalForm: MealPhysicalForm.solid,
+      proteinGrams: 26,
+      fatGrams: 5,
+      fiberGrams: 0,
+      carbohydrateGrams: 0,
+      calories: 200,
+      portionGrams: 150,
+      sourceDocId: 'synthetic:usda_fdc_demo',
+      aminoAcidProfile: AminoAcidProfile(
+        leucine: 2.1,
+        isoleucine: 1.2,
+        valine: 1.3,
+        phenylalanine: 1.0,
+        tyrosine: 0.9,
+        tryptophan: 0.3,
+        nutrientIds: ['507', '506', '510', '508', '509', '501'],
+        sourceRefs: ['src.fdc.api.amino_acid_fields'],
+      ),
     ),
   ],
 );
@@ -573,5 +608,81 @@ const List<MechanisticReplayScenario> mechanisticReplayScenarios = [
     medicationMinutesOffsets: [MinutesOffset(-30)],
     meals: [],
     candidateFoods: [_candidateBanana, _candidateProteinShake],
+  ),
+  // --- s22–s26: external-adapter + amino-acid + fallback coverage --------
+  MechanisticReplayScenario(
+    scenarioId: 's22_amino_acid_actual_fields_mode',
+    title: 'Candidate with actual amino-acid fields → LNAA uses actual-fields '
+        'mode (preferred over protein-source proxy)',
+    expectedOutputType: ScenarioExpectedOutputType.noModeledInteraction,
+    expectNonEmptyRecommendations: true,
+    medicationEntries: [_carbidopaLevodopaIr],
+    medicationMinutesOffsets: [MinutesOffset(-300)],
+    meals: [],
+    userDefinedWindow: UserDefinedMealWindow(
+      window: TimelineWindow(startMinute: 240, endMinute: 360),
+      source: 'synthetic_demo_fixture',
+    ),
+    candidateFoods: [_candidateAminoAcidFood, _candidateBanana],
+  ),
+  MechanisticReplayScenario(
+    scenarioId: 's23_amino_acid_proxy_mode',
+    title: 'Candidate without amino-acid fields → LNAA falls back to '
+        'protein-source proxy mode',
+    expectedOutputType: ScenarioExpectedOutputType.noModeledInteraction,
+    expectNonEmptyRecommendations: true,
+    medicationEntries: [_carbidopaLevodopaIr],
+    medicationMinutesOffsets: [MinutesOffset(-300)],
+    meals: [],
+    userDefinedWindow: UserDefinedMealWindow(
+      window: TimelineWindow(startMinute: 240, endMinute: 360),
+      source: 'synthetic_demo_fixture',
+    ),
+    candidateFoods: [_candidateProteinShake, _candidateBanana],
+  ),
+  MechanisticReplayScenario(
+    scenarioId: 's24_levodopa_no_unit_invalid',
+    title:
+        '"levodopa 100" without unit → invalid medication context, candidates '
+        'insufficient',
+    expectedOutputType: ScenarioExpectedOutputType.insufficientContext,
+    expectInsufficientContext: true,
+    expectNonEmptyRecommendations: true,
+    medicationEntries: [_levodopa100NoUnit],
+    medicationMinutesOffsets: [MinutesOffset(-30)],
+    meals: [],
+    userDefinedWindow: UserDefinedMealWindow(
+      window: TimelineWindow(startMinute: 60, endMinute: 120),
+      source: 'synthetic_demo_fixture',
+    ),
+    candidateFoods: [_candidateBanana],
+  ),
+  MechanisticReplayScenario(
+    scenarioId: 's25_slashed_no_unit_invalid',
+    title: '"25/100" without catalog normalization → invalid context',
+    expectedOutputType: ScenarioExpectedOutputType.insufficientContext,
+    expectInsufficientContext: true,
+    medicationEntries: [_slashedNoUnit],
+    medicationMinutesOffsets: [MinutesOffset(-30)],
+    meals: [],
+  ),
+  MechanisticReplayScenario(
+    scenarioId: 's26_eligible_overwrites_legacy_order',
+    title: 'Mechanistic-primary eligible (window + scored candidates) → '
+        'mechanistic ordering, not legacy heuristic',
+    expectedOutputType: ScenarioExpectedOutputType.noModeledInteraction,
+    expectNonEmptyRecommendations: true,
+    medicationEntries: [_carbidopaLevodopaIr],
+    medicationMinutesOffsets: [MinutesOffset(-300)],
+    meals: [],
+    userDefinedWindow: UserDefinedMealWindow(
+      window: TimelineWindow(startMinute: 240, endMinute: 360),
+      source: 'synthetic_demo_fixture',
+    ),
+    candidateFoods: [
+      _candidateProteinShake,
+      _candidateBanana,
+      _candidateRiceCake
+    ],
   ),
 ];

--- a/lib/data/datasources/remote/amino_acid_extractor.dart
+++ b/lib/data/datasources/remote/amino_acid_extractor.dart
@@ -1,0 +1,128 @@
+import '../../../domain/entities/amino_acid_profile.dart';
+
+/// Deterministic extractor for per-food amino-acid nutrients from an
+/// FDC-style payload (`foodNutrients` list with nutrient number/name/unit +
+/// amount). Preserves nutrient ids and source refs. Returns null when no
+/// amino-acid fields are present so the LNAA layer can fall back to the
+/// protein-source proxy. No network. Educational prototype; synthetic only.
+class AminoAcidExtractor {
+  /// FDC nutrient numbers for the amino acids of interest. Some datasets use
+  /// alternate codes; this map captures the common ones plus the names as a
+  /// fallback match.
+  static const Map<String, String> _numberToField = {
+    '507': 'leucine',
+    '506': 'isoleucine',
+    '510': 'valine',
+    '508': 'phenylalanine',
+    '509': 'tyrosine',
+    '501': 'tryptophan',
+    '512': 'histidine',
+    '503': 'threonine',
+  };
+
+  AminoAcidProfile? extractFromFdcStyle(
+    Map<String, dynamic> payload, {
+    List<String> sourceRefs = const ['src.fdc.api.amino_acid_fields'],
+  }) {
+    final nutrients = payload['foodNutrients'];
+    if (nutrients is! List) return null;
+
+    double? leucine,
+        isoleucine,
+        valine,
+        phenylalanine,
+        tyrosine,
+        tryptophan,
+        histidine,
+        methionine,
+        threonine;
+    final ids = <String>[];
+    var unit = 'g';
+    const basis = 'per_100g';
+
+    for (final raw in nutrients) {
+      if (raw is! Map) continue;
+      final nutrient = raw['nutrient'];
+      if (nutrient is! Map) continue;
+      final number = (nutrient['number'] ?? '').toString();
+      final name = (nutrient['name'] ?? '').toString().toLowerCase();
+      final amount = raw['amount'];
+      if (amount is! num) continue;
+      final value = amount.toDouble();
+      final unitName = (nutrient['unitName'] ?? '').toString();
+      if (unitName.isNotEmpty) unit = unitName.toLowerCase();
+
+      final field = _numberToField[number] ?? _nameToField(name);
+      switch (field) {
+        case 'leucine':
+          leucine = value;
+          ids.add(number.isEmpty ? 'name:leucine' : number);
+          break;
+        case 'isoleucine':
+          isoleucine = value;
+          ids.add(number.isEmpty ? 'name:isoleucine' : number);
+          break;
+        case 'valine':
+          valine = value;
+          ids.add(number.isEmpty ? 'name:valine' : number);
+          break;
+        case 'phenylalanine':
+          phenylalanine = value;
+          ids.add(number.isEmpty ? 'name:phenylalanine' : number);
+          break;
+        case 'tyrosine':
+          tyrosine = value;
+          ids.add(number.isEmpty ? 'name:tyrosine' : number);
+          break;
+        case 'tryptophan':
+          tryptophan = value;
+          ids.add(number.isEmpty ? 'name:tryptophan' : number);
+          break;
+        case 'histidine':
+          histidine = value;
+          ids.add(number.isEmpty ? 'name:histidine' : number);
+          break;
+        case 'methionine':
+          methionine = value;
+          ids.add(number.isEmpty ? 'name:methionine' : number);
+          break;
+        case 'threonine':
+          threonine = value;
+          ids.add(number.isEmpty ? 'name:threonine' : number);
+          break;
+        default:
+          break;
+      }
+    }
+
+    final profile = AminoAcidProfile(
+      leucine: leucine,
+      isoleucine: isoleucine,
+      valine: valine,
+      phenylalanine: phenylalanine,
+      tyrosine: tyrosine,
+      tryptophan: tryptophan,
+      histidine: histidine,
+      methionine: methionine,
+      threonine: threonine,
+      unit: unit,
+      basis: basis,
+      nutrientIds: List.unmodifiable(ids),
+      sourceRefs: sourceRefs,
+    );
+    return profile.competingLnaaGrams == null ? null : profile;
+  }
+
+  String? _nameToField(String name) {
+    if (name.contains('leucine') && !name.contains('iso')) return 'leucine';
+    if (name.contains('isoleucine')) return 'isoleucine';
+    if (name.contains('valine')) return 'valine';
+    if (name.contains('phenylalanine')) return 'phenylalanine';
+    if (name.contains('tyrosine')) return 'tyrosine';
+    if (name.contains('tryptophan')) return 'tryptophan';
+    if (name.contains('histidine')) return 'histidine';
+    if (name.contains('methionine')) return 'methionine';
+    if (name.contains('threonine')) return 'threonine';
+    return null;
+  }
+}

--- a/lib/data/datasources/remote/dmd_importer.dart
+++ b/lib/data/datasources/remote/dmd_importer.dart
@@ -1,0 +1,123 @@
+import '../../../domain/entities/source_metadata.dart';
+
+/// Concrete, deterministic NHS dm+d (GB) medication identity parser.
+///
+/// dm+d is identity/coding-strong (SNOMED CT concept ids; VTM/VMP/AMP model)
+/// but is NOT a complete product-label / food-effect source on its own. The
+/// parser therefore maps to canonical drug *identity* metadata with an
+/// authority tier of `drugDictionary`, and records that mechanism (food-effect)
+/// evidence requires a label/SmPC source. No network — the caller decodes the
+/// payload and hands the map to `parse`. Educational prototype; synthetic only.
+class DmdImporter {
+  DmdParseResult parse(Map<String, dynamic> payload) {
+    final notes = <String>[];
+    String s(String key) => (payload[key] ?? '').toString().trim();
+
+    final sourceDocId =
+        s('source_doc_id').isEmpty ? 'dmd:unknown' : s('source_doc_id');
+    final jurisdiction = s('jurisdiction').isEmpty ? 'GB' : s('jurisdiction');
+    final language = s('language').isEmpty ? 'en' : s('language');
+
+    final ingredients = <String>[
+      ...((payload['active_ingredients'] as List<dynamic>?) ?? const [])
+          .map((e) => e.toString().trim())
+          .where((e) => e.isNotEmpty),
+    ];
+    if (ingredients.isEmpty) notes.add('missing:active_ingredients');
+
+    final productIdentifier = s('vmp_id').isNotEmpty
+        ? s('vmp_id')
+        : (s('amp_id').isNotEmpty
+            ? s('amp_id')
+            : (s('snomed_concept_id').isEmpty ? null : s('snomed_concept_id')));
+    if (productIdentifier == null) notes.add('missing:product_identifier');
+
+    final hasFoodEffect = payload['has_food_effect_label_section'] == true;
+    if (!hasFoodEffect) {
+      notes.add('no_food_effect_label_section:identity_only');
+    }
+
+    final confidenceRaw = payload['extraction_confidence'];
+    var confidence = confidenceRaw is num ? confidenceRaw.toDouble() : 0.7;
+    if (notes.any((n) => n.startsWith('missing:'))) {
+      confidence = (confidence - 0.05 * notes.length).clamp(0.0, 1.0);
+    }
+
+    const limitation =
+        'NHS dm+d supports medicine identity and coding (SNOMED CT). It is '
+        'not a complete product-label / food-effect source; mechanism '
+        'evidence requires a label/SmPC source. Synthetic demo; educational '
+        'prototype, not medical advice.';
+
+    final doc = SourceDocumentMetadata(
+      sourceDocId: sourceDocId,
+      sourceSystem: 'NHS_DMD',
+      jurisdiction: jurisdiction,
+      language: language,
+      sourceOwner: s('source_owner').isEmpty
+          ? 'NHSBSA / NHS England'
+          : s('source_owner'),
+      docType: 'drug_dictionary_entry',
+      authorityTier: SourceAuthorityTier.drugDictionary,
+      translationStatus: ReferenceTranslationStatus.notTranslation,
+      publishedAt: null,
+      effectiveAt: null,
+      lastUpdated: null,
+      licenseOrUseLimitations:
+          'dm+d licence; SNOMED CT licensing applies. Identity/coding source.',
+      sourceRefs: const ['src.nhs.dmd'],
+      limitationText: limitation,
+    );
+
+    final variant = DrugProductVariantMetadata(
+      drugProductVariantId: sourceDocId,
+      sourceSystem: 'NHS_DMD',
+      jurisdiction: jurisdiction,
+      language: language,
+      genericName: s('generic_name'),
+      brandName: payload['brand_name']?.toString(),
+      activeIngredients: ingredients,
+      // dm+d strengths live in VMP descriptions; identity parser does not
+      // assert a numeric strength/unit unless explicitly present.
+      strengthValue: (payload['strength_value'] is num)
+          ? (payload['strength_value'] as num).toDouble()
+          : null,
+      strengthUnit: s('strength_unit').isEmpty ? null : s('strength_unit'),
+      doseForm: s('dose_form'),
+      route: s('route'),
+      releaseType: s('release_type').isEmpty ? 'unknown' : s('release_type'),
+      productIdentifier: productIdentifier,
+      labelSection: null,
+      translationStatus: ReferenceTranslationStatus.notTranslation,
+      extractionConfidence: confidence,
+      sourceRefs: const ['src.nhs.dmd'],
+      limitationText: limitation,
+    );
+
+    return DmdParseResult(
+      document: doc,
+      variant: variant,
+      supportsMechanismEvidenceAlone: hasFoodEffect,
+      normalizationNotes: List.unmodifiable(notes),
+      extractionMethod: 'nhs_dmd_identity_payload_parser_v1',
+    );
+  }
+}
+
+class DmdParseResult {
+  final SourceDocumentMetadata document;
+  final DrugProductVariantMetadata variant;
+
+  /// dm+d identity alone cannot supply food-effect mechanism evidence.
+  final bool supportsMechanismEvidenceAlone;
+  final List<String> normalizationNotes;
+  final String extractionMethod;
+
+  const DmdParseResult({
+    required this.document,
+    required this.variant,
+    required this.supportsMechanismEvidenceAlone,
+    required this.normalizationNotes,
+    required this.extractionMethod,
+  });
+}

--- a/lib/data/datasources/remote/eu_national_register_importer.dart
+++ b/lib/data/datasources/remote/eu_national_register_importer.dart
@@ -1,0 +1,132 @@
+import '../../../domain/entities/source_metadata.dart';
+
+/// Concrete, deterministic EU/EEA national-register medication parser.
+///
+/// National registers identify nationally authorised products and link to
+/// product information (SmPC / package leaflet). This parser maps the
+/// *register identity* (member state, product name, register id, MAH, PI
+/// link) to canonical metadata. It distinguishes register identity from full
+/// SmPC text: unless `has_smpc_text` is true, it records that full mechanism
+/// (food-effect) text is not present. No network — caller hands a decoded map
+/// to `parse`. Educational prototype; synthetic only.
+class EuNationalRegisterImporter {
+  EuNationalRegisterParseResult parse(Map<String, dynamic> payload) {
+    final notes = <String>[];
+    String s(String key) => (payload[key] ?? '').toString().trim();
+
+    final sourceDocId =
+        s('source_doc_id').isEmpty ? 'eu-nat:unknown' : s('source_doc_id');
+    final memberState =
+        s('member_state').isEmpty ? 'EU_MEMBER' : s('member_state');
+    final language = s('language').isEmpty ? 'multi' : s('language');
+
+    final ingredients = <String>[
+      ...((payload['active_ingredients'] as List<dynamic>?) ?? const [])
+          .map((e) => e.toString().trim())
+          .where((e) => e.isNotEmpty),
+    ];
+    if (ingredients.isEmpty) notes.add('missing:active_ingredients');
+
+    final registerId = s('register_id');
+    if (registerId.isEmpty) notes.add('missing:register_id');
+
+    final hasSmpc = payload['has_smpc_text'] == true;
+    if (!hasSmpc) notes.add('no_smpc_text:identity_only');
+    if (s('product_information_url').isEmpty) {
+      notes.add('missing:product_information_url');
+    }
+
+    final confidenceRaw = payload['extraction_confidence'];
+    var confidence = confidenceRaw is num ? confidenceRaw.toDouble() : 0.6;
+    if (notes.any((n) => n.startsWith('missing:'))) {
+      confidence = (confidence - 0.05 * notes.length).clamp(0.0, 1.0);
+    }
+
+    final limitation = hasSmpc
+        ? 'EU national-register entry with linked SmPC text. Synthetic demo; '
+            'educational prototype, not medical advice.'
+        : 'EU national-register entry provides product identity and a link to '
+            'product information; full SmPC / food-effect text is not present '
+            'in this record. Synthetic demo; educational prototype, not '
+            'medical advice.';
+
+    final doc = SourceDocumentMetadata(
+      sourceDocId: sourceDocId,
+      sourceSystem: 'EU_National_Register',
+      jurisdiction: memberState,
+      language: language,
+      sourceOwner: s('source_owner').isEmpty
+          ? 'National competent authority register'
+          : s('source_owner'),
+      docType: hasSmpc ? 'smpc' : 'national_register_entry',
+      authorityTier: SourceAuthorityTier.officialDatabaseInJurisdiction,
+      translationStatus: ReferenceTranslationStatus.notTranslation,
+      publishedAt: null,
+      effectiveAt: null,
+      lastUpdated: null,
+      licenseOrUseLimitations: 'Per-member-state terms.',
+      sourceRefs: const ['src.ema.national_registers'],
+      limitationText: limitation,
+    );
+
+    final variant = DrugProductVariantMetadata(
+      drugProductVariantId: sourceDocId,
+      sourceSystem: 'EU_National_Register',
+      jurisdiction: memberState,
+      language: language,
+      genericName: s('generic_name'),
+      brandName: payload['product_name']?.toString(),
+      activeIngredients: ingredients,
+      strengthValue: (payload['strength_value'] is num)
+          ? (payload['strength_value'] as num).toDouble()
+          : null,
+      strengthUnit: s('strength_unit').isEmpty ? null : s('strength_unit'),
+      doseForm: s('dose_form'),
+      route: s('route'),
+      releaseType: s('release_type').isEmpty ? 'unknown' : s('release_type'),
+      productIdentifier: registerId.isEmpty ? null : registerId,
+      labelSection: hasSmpc ? 'smpc' : null,
+      translationStatus: ReferenceTranslationStatus.notTranslation,
+      extractionConfidence: confidence,
+      sourceRefs: const ['src.ema.national_registers'],
+      limitationText: limitation,
+    );
+
+    return EuNationalRegisterParseResult(
+      document: doc,
+      variant: variant,
+      memberState: memberState,
+      marketingAuthorizationHolder: s('marketing_authorization_holder').isEmpty
+          ? null
+          : s('marketing_authorization_holder'),
+      productInformationUrl: s('product_information_url').isEmpty
+          ? null
+          : s('product_information_url'),
+      supportsMechanismEvidenceAlone: hasSmpc,
+      normalizationNotes: List.unmodifiable(notes),
+      extractionMethod: 'eu_national_register_payload_parser_v1',
+    );
+  }
+}
+
+class EuNationalRegisterParseResult {
+  final SourceDocumentMetadata document;
+  final DrugProductVariantMetadata variant;
+  final String memberState;
+  final String? marketingAuthorizationHolder;
+  final String? productInformationUrl;
+  final bool supportsMechanismEvidenceAlone;
+  final List<String> normalizationNotes;
+  final String extractionMethod;
+
+  const EuNationalRegisterParseResult({
+    required this.document,
+    required this.variant,
+    required this.memberState,
+    required this.marketingAuthorizationHolder,
+    required this.productInformationUrl,
+    required this.supportsMechanismEvidenceAlone,
+    required this.normalizationNotes,
+    required this.extractionMethod,
+  });
+}

--- a/lib/data/datasources/remote/source_adapter_registry.dart
+++ b/lib/data/datasources/remote/source_adapter_registry.dart
@@ -82,14 +82,17 @@ class SourceAdapterRegistry {
       updateCadence: 'periodic',
       licenseOrUseLimitations: 'Per-member-state terms.',
       lastChecked: '2026-05-27',
-      parserConfidence: 0.5,
+      parserConfidence: 0.55,
       translationStatus: ReferenceTranslationStatus.notTranslation,
       isMedicationSource: true,
       isFoodSource: false,
-      implemented: false,
+      implemented: true,
       knownLimitations: [
-        'Spec-only adapter; concrete per-member parser is future work.',
-        'Multilingual; language must be preserved per document.',
+        'Fixture-tested identity parser (EuNationalRegisterImporter); live '
+            'per-member fetch + real schema parsing remain future work.',
+        'Register identity is distinguished from full SmPC text; mechanism '
+            'evidence requires SmPC content.',
+        'Multilingual; language preserved per document.',
       ],
       sourceRefs: ['src.ema.national_registers'],
     ),
@@ -109,9 +112,12 @@ class SourceAdapterRegistry {
       translationStatus: ReferenceTranslationStatus.notTranslation,
       isMedicationSource: true,
       isFoodSource: false,
-      implemented: false,
+      implemented: true,
       knownLimitations: [
-        'Identity/coding strong; not a full food-effect label source.',
+        'Fixture-tested identity parser (DmdImporter); live terminology-server '
+            '/ Web API fetch + real schema parsing remain future work.',
+        'Identity/coding strong; NOT a complete food-effect label source — '
+            'mechanism evidence requires a label/SmPC source.',
       ],
       sourceRefs: ['src.nhs.dmd'],
     ),
@@ -149,13 +155,14 @@ class SourceAdapterRegistry {
       updateCadence: 'periodic',
       licenseOrUseLimitations: 'NMPA terms; Chinese-language authoritative.',
       lastChecked: '2026-05-27',
-      parserConfidence: 0.4,
+      parserConfidence: 0.3,
       translationStatus: ReferenceTranslationStatus.referenceOnlyTranslation,
       isMedicationSource: true,
       isFoodSource: false,
       implemented: true,
       knownLimitations: [
-        'Concrete parser is fixture-tested (synthetic NMPA-style payload); '
+        'FIXTURE-VALIDATED / source-structure prototype only — NOT live and '
+            'NOT verified against a real NMPA schema. Lower parser confidence. '
             'live network fetch + real schema parsing remain future work. '
             'English mapping is reference-only; Chinese source authoritative.',
       ],

--- a/lib/data/datasources/remote/source_fetch_client.dart
+++ b/lib/data/datasources/remote/source_fetch_client.dart
@@ -144,3 +144,82 @@ class FakeSourceFetchClient implements SourceFetchClient {
     return text;
   }
 }
+
+/// Structured result of a source fetch, used by importer adapters that want
+/// explicit success/failure metadata rather than thrown exceptions. A failed
+/// fetch yields `ok == false` with `error` set and `rawPayload == null`, so
+/// callers must NOT synthesize a parsed fact from a failure.
+class SourceFetchResult {
+  final String sourceSystem;
+  final String requestedId;
+  final DateTime fetchedAt;
+  final int
+      status; // HTTP-like status; 0 = not attempted, 200 = ok, 404 = missing
+  final String? contentType;
+  final String? rawPayload;
+  final String? error;
+
+  const SourceFetchResult({
+    required this.sourceSystem,
+    required this.requestedId,
+    required this.fetchedAt,
+    required this.status,
+    required this.contentType,
+    required this.rawPayload,
+    required this.error,
+  });
+
+  bool get ok => error == null && rawPayload != null && status == 200;
+
+  Map<String, dynamic> toJson() => {
+        'source_system': sourceSystem,
+        'requested_id': requestedId,
+        'fetched_at': fetchedAt.toIso8601String(),
+        'status': status,
+        'content_type': contentType,
+        'raw_payload': rawPayload,
+        'error': error,
+      };
+}
+
+/// Deterministic, offline fixture fetch client. Resolves an in-memory map of
+/// id -> payload string and returns a [SourceFetchResult]. A missing id
+/// produces an explicit failure result (no exception, no fake payload). Used
+/// by unit tests; never performs network I/O.
+class FixtureSourceFetchClient {
+  final String sourceSystem;
+  final Map<String, String> payloadsById;
+  final String contentType;
+  final DateTime Function() clock;
+
+  FixtureSourceFetchClient({
+    required this.sourceSystem,
+    required this.payloadsById,
+    this.contentType = 'application/json',
+    DateTime Function()? clock,
+  }) : clock = clock ?? (() => DateTime.utc(2026, 1, 1));
+
+  SourceFetchResult fetch(String requestedId) {
+    final payload = payloadsById[requestedId];
+    if (payload == null) {
+      return SourceFetchResult(
+        sourceSystem: sourceSystem,
+        requestedId: requestedId,
+        fetchedAt: clock(),
+        status: 404,
+        contentType: null,
+        rawPayload: null,
+        error: 'fixture_not_found:$requestedId',
+      );
+    }
+    return SourceFetchResult(
+      sourceSystem: sourceSystem,
+      requestedId: requestedId,
+      fetchedAt: clock(),
+      status: 200,
+      contentType: contentType,
+      rawPayload: payload,
+      error: null,
+    );
+  }
+}

--- a/lib/domain/entities/amino_acid_competition.dart
+++ b/lib/domain/entities/amino_acid_competition.dart
@@ -1,3 +1,4 @@
+import 'amino_acid_profile.dart' show AminoAcidDataMode;
 import 'gastric_emptying_profile.dart' show UncertaintyBand;
 import 'protein_source.dart';
 
@@ -12,12 +13,20 @@ class CompetitionLnaaSummary {
   final bool uncertaintyWidened;
   final List<String> sourceRefs;
 
+  /// Which data path produced the LNAA load.
+  final AminoAcidDataMode dataMode;
+
+  /// Upstream amino-acid nutrient ids when actual fields were used.
+  final List<String> aminoAcidNutrientIds;
+
   const CompetitionLnaaSummary({
     required this.effectiveLoadFactor,
     required this.sourcesPresent,
     required this.isPrototypeHeuristic,
     required this.uncertaintyWidened,
     required this.sourceRefs,
+    this.dataMode = AminoAcidDataMode.proteinSourceProxy,
+    this.aminoAcidNutrientIds = const [],
   });
 
   Map<String, dynamic> toJson() => {
@@ -27,6 +36,8 @@ class CompetitionLnaaSummary {
         'is_prototype_heuristic': isPrototypeHeuristic,
         'uncertainty_widened': uncertaintyWidened,
         'source_refs': sourceRefs,
+        'data_mode': dataMode.name,
+        'amino_acid_nutrient_ids': aminoAcidNutrientIds,
       };
 }
 

--- a/lib/domain/entities/amino_acid_profile.dart
+++ b/lib/domain/entities/amino_acid_profile.dart
@@ -1,0 +1,88 @@
+/// Per-food large-neutral-amino-acid (LNAA) profile, used to compute the
+/// amino-acid competition proxy from *actual* nutrient fields when available,
+/// in preference to the coarse protein-source approximation.
+///
+/// Educational prototype only — not a clinical pharmacokinetic prediction.
+library;
+
+/// Which data path produced the competition LNAA load.
+enum AminoAcidDataMode {
+  /// Actual per-food amino-acid nutrient fields were used.
+  actualAminoAcidFields,
+
+  /// Fell back to the protein-source-type load-factor approximation.
+  proteinSourceProxy,
+
+  /// Neither amino-acid fields nor protein data were available.
+  unknown,
+}
+
+/// LNAA grams per serving/basis, plus provenance. Null fields are treated as
+/// missing (not zero) so the model never fabricates precision.
+class AminoAcidProfile {
+  final double? leucine;
+  final double? isoleucine;
+  final double? valine;
+  final double? phenylalanine;
+  final double? tyrosine;
+  final double? tryptophan;
+  final double? histidine;
+  final double? methionine;
+  final double? threonine;
+  final String unit; // e.g. "g"
+  final String basis; // e.g. "per_100g" / "per_serving"
+  final List<String> nutrientIds; // upstream nutrient numbers (e.g. FDC 505)
+  final List<String> sourceRefs;
+
+  const AminoAcidProfile({
+    this.leucine,
+    this.isoleucine,
+    this.valine,
+    this.phenylalanine,
+    this.tyrosine,
+    this.tryptophan,
+    this.histidine,
+    this.methionine,
+    this.threonine,
+    this.unit = 'g',
+    this.basis = 'per_100g',
+    this.nutrientIds = const [],
+    this.sourceRefs = const [],
+  });
+
+  /// The six classic LNAAs that compete with levodopa transport
+  /// (branched-chain + aromatic): leucine, isoleucine, valine, phenylalanine,
+  /// tyrosine, tryptophan. Returns the sum of those that are present, or null
+  /// when none are present.
+  double? get competingLnaaGrams {
+    final present = <double>[
+      if (leucine != null) leucine!,
+      if (isoleucine != null) isoleucine!,
+      if (valine != null) valine!,
+      if (phenylalanine != null) phenylalanine!,
+      if (tyrosine != null) tyrosine!,
+      if (tryptophan != null) tryptophan!,
+    ];
+    if (present.isEmpty) return null;
+    return present.fold<double>(0, (a, b) => a + b);
+  }
+
+  bool get hasAnyLnaaField => competingLnaaGrams != null;
+
+  Map<String, dynamic> toJson() => {
+        'leucine': leucine,
+        'isoleucine': isoleucine,
+        'valine': valine,
+        'phenylalanine': phenylalanine,
+        'tyrosine': tyrosine,
+        'tryptophan': tryptophan,
+        'histidine': histidine,
+        'methionine': methionine,
+        'threonine': threonine,
+        'unit': unit,
+        'basis': basis,
+        'nutrient_ids': nutrientIds,
+        'source_refs': sourceRefs,
+        'competing_lnaa_grams': competingLnaaGrams,
+      };
+}

--- a/lib/domain/entities/meal_composition.dart
+++ b/lib/domain/entities/meal_composition.dart
@@ -1,3 +1,4 @@
+import 'amino_acid_profile.dart';
 import 'protein_source.dart';
 import 'time_axis_events.dart' show MealPhysicalForm;
 
@@ -90,6 +91,10 @@ class FoodComponent {
   /// than guessing.
   final ProteinSourceType proteinSource;
 
+  /// Actual per-food amino-acid profile when available (preferred over the
+  /// protein-source proxy). Null when not extracted.
+  final AminoAcidProfile? aminoAcidProfile;
+
   const FoodComponent({
     required this.id,
     required this.name,
@@ -102,6 +107,7 @@ class FoodComponent {
     required this.portionGrams,
     required this.sourceDocId,
     this.proteinSource = ProteinSourceType.unknown,
+    this.aminoAcidProfile,
   });
 
   Map<String, dynamic> toJson() => {
@@ -116,5 +122,6 @@ class FoodComponent {
         'portion_grams': portionGrams,
         'source_doc_id': sourceDocId,
         'protein_source': proteinSource.name,
+        'amino_acid_profile': aminoAcidProfile?.toJson(),
       };
 }

--- a/lib/domain/entities/next_meal_recommendation_models.dart
+++ b/lib/domain/entities/next_meal_recommendation_models.dart
@@ -5,6 +5,7 @@ import '../../core/models/intake.dart';
 import 'food_recommendation.dart';
 import 'mechanistic_candidate_score.dart';
 import 'mechanistic_conflict_result.dart';
+import 'ranker_eligibility.dart';
 import 'recommendation_benchmark_models.dart';
 import 'time_axis_events.dart';
 
@@ -70,6 +71,9 @@ class NextMealRecommendationResult {
   /// (the existing distance-based heuristic was used).
   final String? rankerUsed;
 
+  /// Explicit eligibility record (why mechanistic-primary ran or didn't).
+  final RankerEligibility? rankerEligibility;
+
   const NextMealRecommendationResult({
     required this.recommendations,
     required this.aiUsed,
@@ -87,5 +91,6 @@ class NextMealRecommendationResult {
     this.mechanisticTrace,
     this.mechanisticCandidateScores,
     this.rankerUsed,
+    this.rankerEligibility,
   });
 }

--- a/lib/domain/entities/ranker_eligibility.dart
+++ b/lib/domain/entities/ranker_eligibility.dart
@@ -1,0 +1,33 @@
+/// Explicit record of whether mechanistic-primary ranking was eligible and,
+/// if not, why the legacy heuristic fallback was used. This makes it
+/// impossible for the legacy `_levodopaWindowPenalty` to *silently* dominate:
+/// whenever it determines order, `rankerUsed == heuristic_legacy_fallback`
+/// and `fallbackReasons` is populated and surfaced in UI + replay.
+library;
+
+class RankerEligibility {
+  final bool mechanisticPrimaryEligible;
+
+  /// `mechanistic_primary` or `heuristic_legacy_fallback`.
+  final String rankerUsed;
+
+  /// Reasons the mechanistic-primary gate passed (when eligible).
+  final List<String> rankerEligibilityReasons;
+
+  /// Reasons the fallback was used (when not eligible). Empty when eligible.
+  final List<String> fallbackReasons;
+
+  const RankerEligibility({
+    required this.mechanisticPrimaryEligible,
+    required this.rankerUsed,
+    required this.rankerEligibilityReasons,
+    required this.fallbackReasons,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'mechanistic_primary_eligible': mechanisticPrimaryEligible,
+        'ranker_used': rankerUsed,
+        'ranker_eligibility_reasons': rankerEligibilityReasons,
+        'fallback_reasons': fallbackReasons,
+      };
+}

--- a/lib/domain/usecases/amino_acid_competition_model.dart
+++ b/lib/domain/usecases/amino_acid_competition_model.dart
@@ -1,5 +1,6 @@
 import '../entities/absorption_opportunity.dart';
 import '../entities/amino_acid_competition.dart';
+import '../entities/amino_acid_profile.dart' show AminoAcidDataMode;
 import '../entities/gastric_emptying_profile.dart';
 import '../entities/meal_composition.dart';
 import '../entities/protein_source.dart';
@@ -58,6 +59,7 @@ class AminoAcidCompetitionModel {
           isPrototypeHeuristic: true,
           uncertaintyWidened: true,
           sourceRefs: _baseSourceRefs,
+          dataMode: AminoAcidDataMode.unknown,
         ),
       );
     }
@@ -130,9 +132,10 @@ class AminoAcidCompetitionModel {
     );
   }
 
-  /// Returns a `CompetitionLnaaSummary` describing the weighted-average
-  /// LNAA load factor across the meal's components. If components are not
-  /// available, falls back to `unknown` with widened uncertainty.
+  /// Returns a `CompetitionLnaaSummary`. Prefers ACTUAL per-food amino-acid
+  /// fields (narrower uncertainty) when any component carries an
+  /// `AminoAcidProfile`; otherwise falls back to the protein-source proxy;
+  /// otherwise `unknown` with widened uncertainty.
   CompetitionLnaaSummary _computeLnaaLoad(MealComposition composition) {
     final components = composition.foodComponents;
     if (components.isEmpty) {
@@ -144,6 +147,47 @@ class AminoAcidCompetitionModel {
         isPrototypeHeuristic: true,
         uncertaintyWidened: true,
         sourceRefs: unknown.sourceRefs,
+        dataMode: AminoAcidDataMode.unknown,
+      );
+    }
+
+    // Preferred path: actual amino-acid fields. Compute a protein-weighted
+    // LNAA *fraction* (competing LNAA grams / protein grams) and scale it
+    // against a reference fraction (~0.45 of protein for a balanced animal
+    // protein) to get a load factor comparable to the proxy. Prototype
+    // magnitude; direction supported by the cited literature.
+    final aaComponents = components
+        .where((c) =>
+            c.aminoAcidProfile != null &&
+            c.aminoAcidProfile!.competingLnaaGrams != null &&
+            (c.proteinGrams ?? 0) > 0)
+        .toList(growable: false);
+    if (aaComponents.isNotEmpty) {
+      const referenceLnaaFractionOfProtein = 0.45;
+      var totalProtein = 0.0;
+      var weighted = 0.0;
+      final ids = <String>{};
+      final refs = <String>{'src.fdc.api.amino_acid_fields'};
+      for (final c in aaComponents) {
+        final p = c.proteinGrams!;
+        final lnaa = c.aminoAcidProfile!.competingLnaaGrams!;
+        final fraction = (lnaa / p).clamp(0.0, 1.0);
+        final factor =
+            (fraction / referenceLnaaFractionOfProtein).clamp(0.5, 1.5);
+        totalProtein += p;
+        weighted += p * factor;
+        ids.addAll(c.aminoAcidProfile!.nutrientIds);
+        refs.addAll(c.aminoAcidProfile!.sourceRefs);
+      }
+      final effective = totalProtein > 0 ? weighted / totalProtein : 1.0;
+      return CompetitionLnaaSummary(
+        effectiveLoadFactor: effective,
+        sourcesPresent: const [],
+        isPrototypeHeuristic: true,
+        uncertaintyWidened: false,
+        sourceRefs: refs.toList(growable: false),
+        dataMode: AminoAcidDataMode.actualAminoAcidFields,
+        aminoAcidNutrientIds: ids.toList(growable: false),
       );
     }
 
@@ -175,6 +219,7 @@ class AminoAcidCompetitionModel {
         isPrototypeHeuristic: true,
         uncertaintyWidened: true,
         sourceRefs: unknown.sourceRefs,
+        dataMode: AminoAcidDataMode.unknown,
       );
     }
 
@@ -185,6 +230,7 @@ class AminoAcidCompetitionModel {
       isPrototypeHeuristic: true,
       uncertaintyWidened: unknownProteinSeen,
       sourceRefs: refs.toList(growable: false),
+      dataMode: AminoAcidDataMode.proteinSourceProxy,
     );
   }
 

--- a/lib/domain/usecases/mechanistic_replay_runner.dart
+++ b/lib/domain/usecases/mechanistic_replay_runner.dart
@@ -43,6 +43,8 @@ class MechanisticReplayCaseReport {
   final double? topSourceAuthorityScore;
   final double? topJurisdictionMatchScore;
   final String? topCandidateSourceSystem;
+  final String? aminoAcidDataMode;
+  final List<String> aminoAcidNutrientIds;
   final bool pass;
   final String? failureReason;
 
@@ -76,6 +78,8 @@ class MechanisticReplayCaseReport {
     this.topSourceAuthorityScore,
     this.topJurisdictionMatchScore,
     this.topCandidateSourceSystem,
+    this.aminoAcidDataMode,
+    this.aminoAcidNutrientIds = const [],
   });
 
   Map<String, dynamic> toJson() => {
@@ -107,6 +111,8 @@ class MechanisticReplayCaseReport {
         'top_source_authority_score': topSourceAuthorityScore,
         'top_jurisdiction_match_score': topJurisdictionMatchScore,
         'top_candidate_source_system': topCandidateSourceSystem,
+        'amino_acid_data_mode': aminoAcidDataMode,
+        'amino_acid_nutrient_ids': aminoAcidNutrientIds,
         'pass': pass,
         'failure_reason': failureReason,
       };
@@ -395,6 +401,10 @@ class MechanisticReplayRunner {
           (recommendations == null || recommendations.isEmpty)
               ? null
               : recommendations.first.sourceSystem,
+      aminoAcidDataMode: result.competitionTimeline?.lnaaSummary?.dataMode.name,
+      aminoAcidNutrientIds:
+          result.competitionTimeline?.lnaaSummary?.aminoAcidNutrientIds ??
+              const [],
       pass: pass,
       failureReason: pass ? null : failures.join('; '),
     );

--- a/lib/domain/usecases/next_meal_recommendation_orchestrator.dart
+++ b/lib/domain/usecases/next_meal_recommendation_orchestrator.dart
@@ -9,6 +9,7 @@ import '../../core/models/user_profile.dart';
 import '../entities/food_recommendation.dart';
 import '../entities/mechanistic_candidate_score.dart';
 import '../entities/mechanistic_conflict_result.dart';
+import '../entities/ranker_eligibility.dart';
 import '../entities/meal_composition.dart';
 import '../entities/next_meal_recommendation_models.dart';
 import '../entities/cdss_records.dart';
@@ -861,17 +862,37 @@ class NextMealRecommendationOrchestrator {
     // sufficient context (user window + medium/high confidence + every
     // candidate scored). Otherwise the existing heuristic ranking stays
     // untouched and we record `rankerUsed = "heuristic_legacy_fallback"`.
+    // Build an explicit eligibility record. The legacy heuristic can only
+    // determine final order when `mechanisticPrimaryEligible == false`, and in
+    // that case `fallbackReasons` is always populated and surfaced.
+    final fallbackReasons = <String>[];
+    final eligibilityReasons = <String>[];
+    if (request.userDefinedWindow == null) {
+      fallbackReasons.add('missing_user_defined_window');
+    } else {
+      eligibilityReasons.add('user_defined_window_present');
+    }
+    if (candidateScores == null || candidateScores.isEmpty) {
+      fallbackReasons.add('no_candidate_scores');
+    } else if (!candidateScores.every((s) => !s.insufficientContext)) {
+      fallbackReasons.add('insufficient_candidate_context');
+    } else {
+      eligibilityReasons.add('all_candidates_scored');
+    }
+    if (trace.confidenceBand == ConfidenceBand.high ||
+        trace.confidenceBand == ConfidenceBand.medium) {
+      eligibilityReasons.add('confidence_${trace.confidenceBand.name}');
+    } else {
+      fallbackReasons
+          .add('insufficient_confidence_${trace.confidenceBand.name}');
+    }
+
+    final canPromoteMechanistic = fallbackReasons.isEmpty;
     var rankerUsed = 'heuristic_legacy_fallback';
     var recommendations = base.recommendations;
-    final canPromoteMechanistic = request.userDefinedWindow != null &&
-        candidateScores != null &&
-        candidateScores.isNotEmpty &&
-        candidateScores.every((s) => !s.insufficientContext) &&
-        (trace.confidenceBand == ConfidenceBand.high ||
-            trace.confidenceBand == ConfidenceBand.medium);
     if (canPromoteMechanistic) {
       final orderById = <String, int>{};
-      for (var i = 0; i < candidateScores.length; i++) {
+      for (var i = 0; i < candidateScores!.length; i++) {
         orderById[candidateScores[i].candidateFoodId] = i;
       }
       final reordered = [...base.recommendations];
@@ -883,6 +904,13 @@ class NextMealRecommendationOrchestrator {
       recommendations = List.unmodifiable(reordered);
       rankerUsed = 'mechanistic_primary';
     }
+
+    final rankerEligibility = RankerEligibility(
+      mechanisticPrimaryEligible: canPromoteMechanistic,
+      rankerUsed: rankerUsed,
+      rankerEligibilityReasons: List.unmodifiable(eligibilityReasons),
+      fallbackReasons: List.unmodifiable(fallbackReasons),
+    );
 
     return NextMealRecommendationResult(
       recommendations: recommendations,
@@ -901,6 +929,7 @@ class NextMealRecommendationOrchestrator {
       mechanisticTrace: trace,
       mechanisticCandidateScores: candidateScores,
       rankerUsed: rankerUsed,
+      rankerEligibility: rankerEligibility,
     );
   }
 

--- a/lib/features/next_meal/next_meal_page.dart
+++ b/lib/features/next_meal/next_meal_page.dart
@@ -647,12 +647,28 @@ class _ResultBlock extends StatelessWidget {
         if (result.rankerUsed != null) ...[
           const SizedBox(height: 6),
           Text(
-            'Ranker used: ${result.rankerUsed}',
+            'Ranker used: ${result.rankerUsed}'
+            '${result.rankerEligibility != null ? ' · eligible: ${result.rankerEligibility!.mechanisticPrimaryEligible}' : ''}',
             style: const TextStyle(
                 fontSize: 11, color: LiquidGlass.onSurfaceMuted),
           ),
         ],
-        if (result.mechanisticCandidateScores == null) ...[
+        if (result.rankerEligibility != null &&
+            result.rankerEligibility!.fallbackReasons.isNotEmpty) ...[
+          const SizedBox(height: 4),
+          Text(
+            result.rankerEligibility!.fallbackReasons
+                    .contains('missing_user_defined_window')
+                ? 'Mechanistic-primary ranking is unavailable because no '
+                    'user-defined meal window was provided.'
+                : 'Mechanistic-primary ranking is unavailable because context '
+                    'metadata is incomplete (${result.rankerEligibility!.fallbackReasons.join(', ')}).',
+            style: const TextStyle(
+                fontSize: 11, color: LiquidGlass.onSurfaceMuted),
+          ),
+        ],
+        if (result.mechanisticCandidateScores == null &&
+            result.rankerEligibility == null) ...[
           const SizedBox(height: 6),
           Text(
             !windowProvided

--- a/lib/features/shared/mechanistic_trace_view.dart
+++ b/lib/features/shared/mechanistic_trace_view.dart
@@ -98,6 +98,7 @@ class MechanisticCandidateScoreLine extends StatelessWidget {
                 _BandChip(label: 'protein-window ${view.proteinWindowRole}'),
                 _BandChip(
                     label: 'redistribution ${view.redistributionPctText}'),
+                _BandChip(label: 'aa-mode ${view.aminoAcidDataMode}'),
                 _BandChip(label: 'src ${view.sourceSystem}'),
               ],
             ),
@@ -281,6 +282,7 @@ class MechanisticCandidateScoreViewModel {
   final int sampleCount;
   final String proteinWindowRole;
   final String redistributionPctText;
+  final String aminoAcidDataMode;
   final String sourceSystem;
   final String firstExplanationLine;
   final bool insufficientContext;
@@ -293,6 +295,7 @@ class MechanisticCandidateScoreViewModel {
     required this.sampleCount,
     required this.proteinWindowRole,
     required this.redistributionPctText,
+    required this.aminoAcidDataMode,
     required this.sourceSystem,
     required this.firstExplanationLine,
     required this.insufficientContext,
@@ -311,6 +314,9 @@ class MechanisticCandidateScoreViewModel {
       proteinWindowRole:
           score.proteinDistribution?.windowRole.name ?? 'unknown',
       redistributionPctText: pct(score.proteinRedistributionScore),
+      aminoAcidDataMode: score.upstreamResult?.competitionTimeline?.lnaaSummary
+              ?.dataMode.name ??
+          'unknown',
       sourceSystem: score.sourceSystem,
       firstExplanationLine: firstLine,
       insufficientContext: score.insufficientContext,

--- a/test/amino_acid_extraction_test.dart
+++ b/test/amino_acid_extraction_test.dart
@@ -1,0 +1,145 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkinsum_companion/data/datasources/remote/amino_acid_extractor.dart';
+import 'package:parkinsum_companion/domain/entities/amino_acid_competition.dart';
+import 'package:parkinsum_companion/domain/entities/amino_acid_profile.dart';
+import 'package:parkinsum_companion/domain/entities/meal_composition.dart';
+import 'package:parkinsum_companion/domain/entities/medication_entry_validation.dart';
+import 'package:parkinsum_companion/domain/entities/protein_source.dart';
+import 'package:parkinsum_companion/domain/entities/time_axis_events.dart';
+import 'package:parkinsum_companion/domain/usecases/amino_acid_competition_model.dart';
+import 'package:parkinsum_companion/domain/usecases/gastric_emptying_model.dart';
+import 'package:parkinsum_companion/domain/usecases/levodopa_absorption_opportunity_model.dart';
+import 'package:parkinsum_companion/domain/usecases/meal_composition_normalizer.dart';
+import 'package:parkinsum_companion/domain/usecases/medication_entry_validator.dart';
+
+void main() {
+  final extractor = AminoAcidExtractor();
+  final normalizer = MealCompositionNormalizer();
+  final emptying = GastricEmptyingModel();
+  final absorption = LevodopaAbsorptionOpportunityModel();
+  final competition = AminoAcidCompetitionModel();
+  final validator = MedicationEntryValidator();
+
+  NormalizedMedicationContext levodopa() => validator
+      .validate(const RawMedicationEntry(
+        activeIngredients: ['carbidopa', 'levodopa'],
+        drugProductVariant: 'synthetic:demo',
+        strength: 100,
+        unit: 'mg',
+        form: 'tablet',
+        route: 'oral',
+        releaseType: 'immediate',
+        jurisdiction: 'US',
+        sourceDocId: 'synthetic:demo',
+      ))
+      .normalized!;
+
+  AminoAcidProfile loadProfile() {
+    final payload = jsonDecode(
+        File('test/fixtures/importers/usda_fdc_amino_acids.json')
+            .readAsStringSync()) as Map<String, dynamic>;
+    final p = extractor.extractFromFdcStyle(payload);
+    expect(p, isNotNull);
+    return p!;
+  }
+
+  test('FDC-style fixture with amino-acid fields creates AminoAcidProfile', () {
+    final p = loadProfile();
+    expect(p.leucine, 2.1);
+    expect(p.valine, 1.3);
+    expect(p.competingLnaaGrams, isNotNull);
+    expect(p.nutrientIds, isNotEmpty);
+    expect(p.sourceRefs, contains('src.fdc.api.amino_acid_fields'));
+  });
+
+  test('payload without amino-acid fields returns null (→ proxy fallback)', () {
+    final p = extractor.extractFromFdcStyle({
+      'foodNutrients': [
+        {
+          'nutrient': {'number': '203', 'name': 'Protein', 'unitName': 'G'},
+          'amount': 20.0
+        }
+      ]
+    });
+    expect(p, isNull);
+  });
+
+  CompetitionLnaaSummary summaryFor(FoodComponent component) {
+    final comp = normalizer.normalize(
+      mealId: 'm',
+      components: [component],
+      declaredPhysicalForm: MealPhysicalForm.solid,
+    );
+    final profile =
+        emptying.build(mealId: 'm', mealStartMinute: 0, composition: comp);
+    final med =
+        MedicationTimelineEvent(id: 'x', minute: 15, context: levodopa());
+    final window =
+        absorption.build(medication: med, overlappingMealProfile: profile);
+    final c = competition.build(
+      mealComposition: comp,
+      mealEmptyingProfile: profile,
+      absorptionWindow: window,
+      mealStartMinute: 0,
+    );
+    return c.lnaaSummary!;
+  }
+
+  test('LNAA layer uses actual amino-acid fields over protein-source proxy',
+      () {
+    final withAa = summaryFor(FoodComponent(
+      id: 'aa',
+      name: 'high-protein food',
+      physicalForm: MealPhysicalForm.solid,
+      proteinGrams: 26,
+      fatGrams: 5,
+      fiberGrams: 0,
+      carbohydrateGrams: 0,
+      calories: 200,
+      portionGrams: 150,
+      sourceDocId: 'fdc',
+      proteinSource: ProteinSourceType.meat,
+      aminoAcidProfile: loadProfile(),
+    ));
+    expect(withAa.dataMode, AminoAcidDataMode.actualAminoAcidFields);
+    expect(withAa.aminoAcidNutrientIds, isNotEmpty);
+    expect(withAa.uncertaintyWidened, isFalse);
+  });
+
+  test('missing amino-acid fields falls back to protein-source proxy', () {
+    final proxy = summaryFor(const FoodComponent(
+      id: 'noaa',
+      name: 'meat no aa fields',
+      physicalForm: MealPhysicalForm.solid,
+      proteinGrams: 26,
+      fatGrams: 5,
+      fiberGrams: 0,
+      carbohydrateGrams: 0,
+      calories: 200,
+      portionGrams: 150,
+      sourceDocId: 'x',
+      proteinSource: ProteinSourceType.meat,
+    ));
+    expect(proxy.dataMode, AminoAcidDataMode.proteinSourceProxy);
+  });
+
+  test('missing protein and amino acids → unknown mode', () {
+    final unknown = summaryFor(const FoodComponent(
+      id: 'unk',
+      name: 'unknown',
+      physicalForm: MealPhysicalForm.solid,
+      proteinGrams: null,
+      fatGrams: null,
+      fiberGrams: null,
+      carbohydrateGrams: null,
+      calories: null,
+      portionGrams: null,
+      sourceDocId: 'x',
+      proteinSource: ProteinSourceType.unknown,
+    ));
+    expect(unknown.dataMode, AminoAcidDataMode.unknown);
+  });
+}

--- a/test/external_source_adapters_test.dart
+++ b/test/external_source_adapters_test.dart
@@ -1,0 +1,134 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkinsum_companion/data/datasources/remote/dmd_importer.dart';
+import 'package:parkinsum_companion/data/datasources/remote/eu_national_register_importer.dart';
+import 'package:parkinsum_companion/data/datasources/remote/source_adapter_registry.dart';
+import 'package:parkinsum_companion/data/datasources/remote/source_fetch_client.dart';
+import 'package:parkinsum_companion/domain/entities/rule_explanation.dart';
+import 'package:parkinsum_companion/domain/entities/source_metadata.dart';
+import 'package:parkinsum_companion/domain/usecases/metadata_completeness_gate.dart';
+import 'package:parkinsum_companion/domain/usecases/source_authority_scorer.dart';
+
+Map<String, dynamic> _fixture(String name) =>
+    jsonDecode(File('test/fixtures/importers/$name').readAsStringSync())
+        as Map<String, dynamic>;
+
+void main() {
+  group('NHS dm+d importer', () {
+    final importer = DmdImporter();
+    test('parses identity + code, GB/en, drugDictionary authority', () {
+      final r = importer.parse(_fixture('nhs_dmd_levodopa.json'));
+      expect(r.document.sourceSystem, 'NHS_DMD');
+      expect(r.document.jurisdiction, 'GB');
+      expect(r.document.language, 'en');
+      expect(r.document.authorityTier, SourceAuthorityTier.drugDictionary);
+      expect(r.variant.productIdentifier, isNotNull);
+      expect(
+          r.variant.activeIngredients, containsAll(['carbidopa', 'levodopa']));
+      expect(r.variant.sourceRefs, contains('src.nhs.dmd'));
+    });
+    test('identity-only cannot supply mechanism evidence alone; limitation set',
+        () {
+      final r = importer.parse(_fixture('nhs_dmd_levodopa.json'));
+      expect(r.supportsMechanismEvidenceAlone, isFalse);
+      expect(r.normalizationNotes,
+          contains('no_food_effect_label_section:identity_only'));
+      expect(
+          r.document.limitationText.toLowerCase(), contains('not a complete'));
+      expect(findBannedSubstrings(r.document.limitationText), isEmpty);
+    });
+  });
+
+  group('EU national-register importer', () {
+    final importer = EuNationalRegisterImporter();
+    test('parses member-state identity + register id; no SmPC → limitation',
+        () {
+      final r = importer.parse(_fixture('eu_national_register_levodopa.json'));
+      expect(r.document.sourceSystem, 'EU_National_Register');
+      expect(r.memberState, 'DE');
+      expect(r.variant.productIdentifier, 'DE-REG-000000');
+      expect(r.supportsMechanismEvidenceAlone, isFalse);
+      expect(r.normalizationNotes, contains('no_smpc_text:identity_only'));
+      expect(r.document.authorityTier,
+          SourceAuthorityTier.officialDatabaseInJurisdiction);
+      expect(r.marketingAuthorizationHolder, isNotNull);
+    });
+    test('authority handled differently from EMA centralized label', () {
+      final scorer = SourceAuthorityScorer();
+      final r = importer.parse(_fixture('eu_national_register_levodopa.json'));
+      // National-register identity (database tier) scores below an official
+      // in-jurisdiction *label* for the same jurisdiction chain.
+      const emaLabel = SourceDocumentMetadata(
+        sourceDocId: 'ema:label',
+        sourceSystem: 'EMA',
+        jurisdiction: 'DE',
+        language: 'en',
+        sourceOwner: 'EMA',
+        docType: 'smpc',
+        authorityTier: SourceAuthorityTier.officialLabelInJurisdiction,
+        translationStatus: ReferenceTranslationStatus.notTranslation,
+        publishedAt: null,
+        effectiveAt: null,
+        lastUpdated: null,
+        licenseOrUseLimitations: '',
+        sourceRefs: ['src.ema.epi.fhir'],
+        limitationText: 'x',
+      );
+      final chain = ['DE', 'EU', 'GLOBAL'];
+      expect(scorer.score(r.document, userJurisdictionChain: chain),
+          lessThan(scorer.score(emaLabel, userJurisdictionChain: chain)));
+    });
+  });
+
+  group('registry implemented flags', () {
+    test('dm+d, EU national register, NMPA all implemented now', () {
+      expect(
+          SourceAdapterRegistry.bySourceSystem('NHS_DMD')!.implemented, isTrue);
+      expect(
+          SourceAdapterRegistry.bySourceSystem('EU_National_Register')!
+              .implemented,
+          isTrue);
+      expect(SourceAdapterRegistry.bySourceSystem('NMPA')!.implemented, isTrue);
+    });
+    test('NMPA is honestly downgraded (low parser confidence, prototype note)',
+        () {
+      final nmpa = SourceAdapterRegistry.bySourceSystem('NMPA')!;
+      expect(nmpa.parserConfidence, lessThanOrEqualTo(0.35));
+      expect(nmpa.knownLimitations.join(' ').toUpperCase(),
+          contains('FIXTURE-VALIDATED'));
+    });
+  });
+
+  group('FixtureSourceFetchClient', () {
+    final client = FixtureSourceFetchClient(
+      sourceSystem: 'NHS_DMD',
+      payloadsById: {'id1': '{"ok":true}'},
+    );
+    test('returns payload for known id', () {
+      final r = client.fetch('id1');
+      expect(r.ok, isTrue);
+      expect(r.status, 200);
+      expect(r.rawPayload, contains('ok'));
+      expect(r.error, isNull);
+    });
+    test('missing id → explicit failure, no payload, no fake fact', () {
+      final r = client.fetch('missing');
+      expect(r.ok, isFalse);
+      expect(r.status, 404);
+      expect(r.rawPayload, isNull);
+      expect(r.error, contains('fixture_not_found'));
+    });
+  });
+
+  group('completeness gate on parsed external metadata', () {
+    final gate = MetadataCompletenessGate();
+    test('dm+d identity (no release type) does not score complete', () {
+      final r = DmdImporter().parse(_fixture('nhs_dmd_levodopa.json'));
+      final score = gate.scoreMedicationContext(r.variant);
+      // release_type unknown + no strength → not "complete".
+      expect(score, isNot(MetadataCompletenessScore.complete));
+    });
+  });
+}

--- a/test/fixtures/importers/eu_national_register_levodopa.json
+++ b/test/fixtures/importers/eu_national_register_levodopa.json
@@ -1,0 +1,17 @@
+{
+  "source_system": "EU_National_Register",
+  "source_doc_id": "eu-nat:synthetic:de:levodopa-carbidopa:demo",
+  "member_state": "DE",
+  "language": "de",
+  "source_owner": "National competent authority register (synthetic demo, via EMA index)",
+  "product_name": "Levodopa/Carbidopa 100 mg/25 mg Tabletten (synthetisches Demo)",
+  "generic_name": "carbidopa/levodopa",
+  "active_ingredients": ["carbidopa", "levodopa"],
+  "register_id": "DE-REG-000000",
+  "marketing_authorization_holder": "Demo Pharma GmbH (synthetic)",
+  "product_information_url": "https://example.invalid/synthetic/smpc",
+  "has_smpc_text": false,
+  "route": "oral",
+  "dose_form": "tablet",
+  "extraction_confidence": 0.65
+}

--- a/test/fixtures/importers/nhs_dmd_levodopa.json
+++ b/test/fixtures/importers/nhs_dmd_levodopa.json
@@ -1,0 +1,18 @@
+{
+  "source_system": "NHS_DMD",
+  "source_doc_id": "dmd:synthetic:vmp:levodopa-carbidopa:demo",
+  "jurisdiction": "GB",
+  "language": "en",
+  "source_owner": "NHSBSA / NHS England (synthetic demo)",
+  "vtm_id": "0000000000",
+  "vmp_id": "1111111111",
+  "amp_id": "2222222222",
+  "snomed_concept_id": "1111111111",
+  "display_name": "Co-careldopa 25mg/100mg tablets (synthetic demo)",
+  "generic_name": "carbidopa/levodopa",
+  "active_ingredients": ["carbidopa", "levodopa"],
+  "route": "oral",
+  "dose_form": "tablet",
+  "has_food_effect_label_section": false,
+  "extraction_confidence": 0.8
+}

--- a/test/fixtures/importers/usda_fdc_amino_acids.json
+++ b/test/fixtures/importers/usda_fdc_amino_acids.json
@@ -1,0 +1,19 @@
+{
+  "source_system": "USDA_FDC",
+  "fdc_id": "000000",
+  "description": "Synthetic high-protein food with amino-acid fields (demo)",
+  "jurisdiction": "US",
+  "language": "en",
+  "foodNutrients": [
+    {"nutrient": {"number": "203", "name": "Protein", "unitName": "G"}, "amount": 26.0},
+    {"nutrient": {"number": "507", "name": "Leucine", "unitName": "G"}, "amount": 2.1},
+    {"nutrient": {"number": "506", "name": "Isoleucine", "unitName": "G"}, "amount": 1.2},
+    {"nutrient": {"number": "510", "name": "Valine", "unitName": "G"}, "amount": 1.3},
+    {"nutrient": {"number": "508", "name": "Phenylalanine", "unitName": "G"}, "amount": 1.0},
+    {"nutrient": {"number": "509", "name": "Tyrosine", "unitName": "G"}, "amount": 0.9},
+    {"nutrient": {"number": "501", "name": "Tryptophan", "unitName": "G"}, "amount": 0.3},
+    {"nutrient": {"number": "512", "name": "Histidine", "unitName": "G"}, "amount": 0.8},
+    {"nutrient": {"number": "506m", "name": "Methionine", "unitName": "G"}, "amount": 0.7},
+    {"nutrient": {"number": "503", "name": "Threonine", "unitName": "G"}, "amount": 1.1}
+  ]
+}

--- a/test/multi_jurisdiction_metadata_test.dart
+++ b/test/multi_jurisdiction_metadata_test.dart
@@ -226,17 +226,19 @@ void main() {
       expect(nmpa.language, 'zh');
     });
 
-    test('DailyMed + NMPA implemented; dm+d/EU-national remain spec-only', () {
-      expect(SourceAdapterRegistry.bySourceSystem('DailyMed')!.implemented,
-          isTrue);
-      // NMPA now has a concrete fixture-tested parser (NmpaImporter).
-      expect(SourceAdapterRegistry.bySourceSystem('NMPA')!.implemented, isTrue);
-      expect(SourceAdapterRegistry.bySourceSystem('NHS_DMD')!.implemented,
-          isFalse);
-      expect(
-          SourceAdapterRegistry.bySourceSystem('EU_National_Register')!
-              .implemented,
-          isFalse);
+    test('all named medication source families now have concrete parsers', () {
+      // DailyMed, NMPA, NHS dm+d, and EU national register all have
+      // fixture-tested concrete parsers now.
+      for (final system in [
+        'DailyMed',
+        'NMPA',
+        'NHS_DMD',
+        'EU_National_Register',
+      ]) {
+        expect(
+            SourceAdapterRegistry.bySourceSystem(system)!.implemented, isTrue,
+            reason: '$system should be implemented');
+      }
     });
 
     test('every spec serializes without error', () {

--- a/test/ranker_eligibility_test.dart
+++ b/test/ranker_eligibility_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkinsum_companion/domain/entities/ranker_eligibility.dart';
+
+/// The orchestrator's promotion logic is exercised end-to-end by the replay
+/// runner (scenarios with/without a user window). This test pins the
+/// invariant that a `RankerEligibility` always carries a non-empty
+/// `fallbackReasons` list exactly when mechanistic-primary is NOT eligible,
+/// so the legacy heuristic can never silently dominate.
+void main() {
+  test('not eligible ⇒ fallbackReasons populated, rankerUsed is legacy', () {
+    const e = RankerEligibility(
+      mechanisticPrimaryEligible: false,
+      rankerUsed: 'heuristic_legacy_fallback',
+      rankerEligibilityReasons: [],
+      fallbackReasons: ['missing_user_defined_window'],
+    );
+    expect(e.mechanisticPrimaryEligible, isFalse);
+    expect(e.fallbackReasons, isNotEmpty);
+    expect(e.rankerUsed, 'heuristic_legacy_fallback');
+  });
+
+  test('eligible ⇒ no fallback reasons, rankerUsed is mechanistic_primary', () {
+    const e = RankerEligibility(
+      mechanisticPrimaryEligible: true,
+      rankerUsed: 'mechanistic_primary',
+      rankerEligibilityReasons: [
+        'user_defined_window_present',
+        'all_candidates_scored',
+        'confidence_high',
+      ],
+      fallbackReasons: [],
+    );
+    expect(e.mechanisticPrimaryEligible, isTrue);
+    expect(e.fallbackReasons, isEmpty);
+    expect(e.rankerUsed, 'mechanistic_primary');
+    expect(e.toJson()['ranker_eligibility_reasons'], isNotEmpty);
+  });
+}


### PR DESCRIPTION
This PR resolves the remaining implementation gaps in ParkinSUM’s multi-jurisdiction importer and mechanistic ranking stack. It adds fixture-tested dm+d and EU national-register adapters, clarifies NMPA fixture limitations, introduces SourceFetchResult / FixtureSourceFetchClient for deterministic source-fetch testing, wires per-food amino-acid extraction into LNAA-aware scoring where nutrient fields are available, constrains the legacy heuristic to visible fallback-only status, and expands mechanistic replay coverage to 26 scenarios.

All verification gates pass:

- flutter test --concurrency=1 → 269/269

- npm run public:preflight → pass, 0 BLOCKER

- node tool/firestore_rules_contract_check.mjs → 13/13

- dart run tool/run_mechanistic_replay.dart → 26/26

Resolve the five remaining implementation gaps; verified against the branch.

dm+d + EU national register (Tasks 2,3): concrete fixture-tested parsers
- lib/data/datasources/remote/dmd_importer.dart (DmdImporter) → canonical DrugProductVariantMetadata; sourceSystem NHS_DMD, GB/en, drugDictionary tier; identity/coding only — supportsMechanismEvidenceAlone=false; cannot be used as food-effect evidence without a label/SmPC source.
- lib/data/datasources/remote/eu_national_register_importer.dart → member- state identity; distinguishes register identity from full SmPC text; officialDatabaseInJurisdiction tier (scored below an EMA in-jurisdiction label).
- Fixtures: test/fixtures/importers/nhs_dmd_levodopa.json, eu_national_register_levodopa.json. Registry flags flipped to implemented.

NMPA honest downgrade (Task 4): parserConfidence 0.4→0.3; knownLimitations now say FIXTURE-VALIDATED / source-structure prototype, NOT live/verified.

SourceFetchClient (Task 5): added SourceFetchResult (sourceSystem, requestedId, fetchedAt, status, contentType, rawPayload, error) + FixtureSourceFetchClient (offline; missing id → explicit failure result, no fake fact). HttpSourceFetchClient remains the optional live path; tests never touch the network.

Amino-acid extraction (Task 6): new AminoAcidProfile + AminoAcidDataMode and amino_acid_extractor.dart (FDC nutrient numbers → profile, nutrient ids preserved). FoodComponent gains aminoAcidProfile. AminoAcidCompetitionModel now PREFERS actual amino-acid fields (actualAminoAcidFields, narrower uncertainty) over the protein-source proxy (proteinSourceProxy), falling back to unknown when neither is present; CompetitionLnaaSummary carries dataMode + aminoAcidNutrientIds.

Ranker eligibility (Task 7): new RankerEligibility (mechanisticPrimaryEligible, rankerUsed, rankerEligibilityReasons, fallbackReasons) on NextMealRecommendationResult. The legacy _levodopaWindowPenalty can only set final order when mechanisticPrimaryEligible==false, and the reason (missing_user_defined_window / insufficient_* / no_candidate_scores) is always populated and surfaced.

Replay (Task 8): 21→26 scenarios (s22 actual-aa mode, s23 proxy mode, s24/s25 invalid medication forms, s26 mechanistic-primary overwrites legacy order). Report rows add amino_acid_data_mode + amino_acid_nutrient_ids alongside the existing top-candidate ranking fields.

UI (Task 9): next-meal page shows ranker eligibility + fallback reason (explicit "no user-defined meal window" vs "context metadata incomplete"); candidate chips add aa-mode. No raw JSON by default.

Docs: new docs/MANUAL_VALIDATION.md (run steps + troubleshooting); reconciled IMPORTER_METADATA_FLOW.md / REPLAY_RUNNER.md / README.md (implemented vs future-work); Bibliographies.md dm+d access detail (NHS Terminology Server FHIR API + TRUD).

Tests (new): external_source_adapters_test.dart, amino_acid_extraction_test.dart, ranker_eligibility_test.dart; updated multi_jurisdiction_metadata_test.dart.

Verification: dart format clean; flutter analyze clean; flutter test 269/269 pass; npm run public:preflight pass (0 BLOCKER); firestore rules 13/13; dart run + npm mechanistic:replay 26/26 pass.

Known limitations: dm+d/EU-national/NMPA parsers are FIXTURE-VALIDATED, not live; live fetch sits behind SourceFetchClient and is not exercised in tests nor used for clinical advice; amino-acid extraction is FDC-style-fixture only; protein-redistribution + authority weights are educational heuristics, not clinically calibrated.

Educational prototype only. Not a medical device. Not medical advice.

## Summary

Describe the change and why it is needed.

## Public Prototype Boundary

- [ ] This PR does not include personal health information.
- [ ] This PR does not include real medication schedules, symptoms, private health records, Firebase tokens, service account keys, raw audit logs, user exports, real emails, full UIDs, signing files, or local credential paths.
- [ ] This PR uses synthetic or sample data only for examples, screenshots, tests, and docs.
- [ ] This PR does not claim clinical validation, legal approval, privacy certification, medical-device status, treatment guidance, or real-world health suitability.

## Touched Areas

- [ ] CDSS-style rule logic or result copy
- [ ] Firebase rules, Auth, Firestore paths, or operator tooling
- [ ] Privacy, disclaimer, support, or security text
- [ ] Public demo behavior
- [ ] Importers, provenance, or release evidence
- [ ] GitHub Pages, release notes, issue templates, or contributor docs
- [ ] Synthetic data, demo media, screenshots, or accessibility

## Validation

- [ ] `npm run public:preflight`
- [ ] `node tool/firestore_rules_contract_check.mjs`
- [ ] `flutter analyze`
- [ ] `flutter test --concurrency=1`
- [ ] Documentation-only/manual review: explain below if local tooling was not run.

## Notes For Reviewers

List any files, screenshots, docs pages, or rule evidence that need close review.
