### PR TITLE
Tighten dose parsing + share merged candidate list across scoring paths

### DIFF
--- a/lib/core/state/app_state.dart
+++ b/lib/core/state/app_state.dart
@@ -665,13 +665,62 @@ class AppState extends ChangeNotifier {
         for (final f in existing) f.id: f,
       };
       for (final p in projected) {
-        byId.putIfAbsent(p.id, () => p);
+        final current = byId[p.id];
+        // Do NOT blindly let a seed/persisted food win over a projected CDSS
+        // food with the same id. Prefer the richer official/projected entry so
+        // its provenance + missingness metadata survives into the runtime repo.
+        byId[p.id] = (current == null) ? p : _preferRicherFood(current, p);
       }
       services.foodRepository.replaceAll(byId.values.toList(growable: false));
     } catch (_) {
       // Projection unavailable on this device (e.g. CDSS DB empty);
       // existing seed/persisted catalog remains active.
     }
+  }
+
+  /// Choose between an existing (seed/persisted) food and a projected food
+  /// sharing the same id. Compares source-authority provenance first, then
+  /// metadata completeness; on a tie prefers `projected` so freshly imported
+  /// official provenance + missingness metadata is retained rather than
+  /// shadowed by a stale seed row.
+  FoodItem _preferRicherFood(FoodItem existing, FoodItem projected) {
+    final ep = _provenanceRank(existing);
+    final pp = _provenanceRank(projected);
+    if (pp != ep) return pp > ep ? projected : existing;
+    final ec = _completenessRank(existing);
+    final pc = _completenessRank(projected);
+    if (pc != ec) return pc > ec ? projected : existing;
+    return projected; // tie → keep projected provenance/missingness
+  }
+
+  /// Coarse source-authority rank (higher = more authoritative). Mirrors the
+  /// orchestrator's conservative mapping: synthetic < seed/local < cdss <
+  /// recognized official import family.
+  int _provenanceRank(FoodItem f) {
+    final s = f.sourceSystem.toLowerCase();
+    if (s.contains('synthetic')) return 0;
+    if (s.contains('seed') || s == 'local_seed') return 1;
+    if (s == 'cdss') return 2;
+    return 3;
+  }
+
+  /// Metadata completeness rank (higher = richer): present nutrient fields plus
+  /// presence of amino-acid profile, basis type, and source food code.
+  int _completenessRank(FoodItem f) {
+    const core = [
+      'proteinG',
+      'carbsG',
+      'fatG',
+      'fiberG',
+      'sodiumMg',
+      'energyKcal',
+      'waterG',
+    ];
+    var score = core.where((c) => !f.missingNutrientFields.contains(c)).length;
+    if (f.aminoAcidProfile != null) score++;
+    if ((f.basisType ?? '').isNotEmpty) score++;
+    if ((f.sourceFoodCode ?? '').isNotEmpty) score++;
+    return score;
   }
 
   /// Pull every row from the `locale_resource_bundle` table and install it

--- a/lib/domain/usecases/database_backed_meal_check_usecase.dart
+++ b/lib/domain/usecases/database_backed_meal_check_usecase.dart
@@ -721,11 +721,13 @@ class DatabaseBackedMealCheckUseCase {
     );
   }
 
-  double? _parseDoseMg(String? dosageNote) {
-    if (dosageNote == null || dosageNote.trim().isEmpty) return null;
-    final match = RegExp(r'(\d+(?:\.\d+)?)').firstMatch(dosageNote);
-    return match == null ? null : double.tryParse(match.group(1)!);
-  }
+  /// Daily dose in mg derived ONLY from an explicit user-entered dosage note
+  /// (value + recognized mass unit) via `DosageNoteParser`. Never infers a
+  /// number from free text: "levodopa 100", bare "100", or a slashed combo
+  /// yield null so the rule engine treats the dose as unknown instead of
+  /// fabricating 100 mg.
+  double? _parseDoseMg(String? dosageNote) =>
+      _dosageNoteParser.milligrams(dosageNote);
 
   InteractionSeverity _mapSeverity(String decision) {
     switch (decision) {

--- a/lib/domain/usecases/dosage_note_parser.dart
+++ b/lib/domain/usecases/dosage_note_parser.dart
@@ -71,4 +71,34 @@ class DosageNoteParser {
     if (!_allowedUnits.contains(unitRaw)) return ParsedDose.none;
     return ParsedDose(value: value, unit: unitRaw, explicit: true);
   }
+
+  /// Dose in milligrams derived ONLY from an explicit value + recognized MASS
+  /// unit. Returns null when the note is not explicit (e.g. "levodopa 100",
+  /// bare "100", "25/100", empty) or when the unit is non-mass (e.g. "5 ml").
+  /// Never infers a number from free text — this is what populates
+  /// `DrugRuntimeContext.dailyDoseMg`.
+  double? milligrams(String? dosageNote) {
+    final dose = parse(dosageNote);
+    if (!dose.explicit || dose.value == null) return null;
+    switch (dose.unit) {
+      case 'mg':
+      case 'milligram':
+      case 'milligrams':
+        return dose.value;
+      case 'g':
+      case 'gram':
+      case 'grams':
+        return dose.value! * 1000.0;
+      case 'mcg':
+      case 'ug':
+      case 'µg':
+      case 'μg':
+      case 'microgram':
+      case 'micrograms':
+        return dose.value! / 1000.0;
+      default:
+        // Non-mass units (e.g. ml) are not a mg dose → unknown.
+        return null;
+    }
+  }
 }

--- a/lib/domain/usecases/next_meal_recommendation_orchestrator.dart
+++ b/lib/domain/usecases/next_meal_recommendation_orchestrator.dart
@@ -85,23 +85,31 @@ class NextMealRecommendationOrchestrator {
     required NextMealRecommendationRequest request,
     required List<FoodItem> candidateFoods,
   }) async {
+    // Project + merge once so the conservative path AND the mechanistic
+    // enrichment path score the SAME candidate list. Projected (official/CDSS)
+    // foods win id collisions, preserving their provenance + missingness
+    // metadata for both ranking surfaces.
+    final projectedFoods = await projectionService.projectFoods();
+    final mergedCandidates = _mergeCandidates(
+      projectedFoods,
+      candidateFoods.isEmpty ? buildP0FoodCatalog() : candidateFoods,
+    );
     final base = await _recommendCore(
       request: request,
-      candidateFoods: candidateFoods,
+      mergedCandidates: mergedCandidates,
     );
     return _enrichWithMechanistic(
       base: base,
       request: request,
-      candidateFoods: candidateFoods,
+      candidateFoods: mergedCandidates,
     );
   }
 
   Future<NextMealRecommendationResult> _recommendCore({
     required NextMealRecommendationRequest request,
-    required List<FoodItem> candidateFoods,
+    required List<FoodItem> mergedCandidates,
   }) async {
     final i18n = AppI18n.fromLocaleTag(request.userProfile.displayLocale);
-    final projectedFoods = await projectionService.projectFoods();
     final projectedDrugDetails =
         await _projectActiveDrugDetails(request.activeDrugs);
     final latestMeal = request.history.isEmpty
@@ -119,11 +127,6 @@ class NextMealRecommendationOrchestrator {
             meal: latestMeal,
             i18n: i18n,
           );
-    final mergedCandidates = _mergeCandidates(
-      projectedFoods,
-      candidateFoods.isEmpty ? buildP0FoodCatalog() : candidateFoods,
-    );
-
     final baseline = conservativeRecommender.call(
       history: request.history,
       drugs: request.activeDrugs,

--- a/test/dosage_passthrough_test.dart
+++ b/test/dosage_passthrough_test.dart
@@ -80,6 +80,36 @@ void main() {
     });
   });
 
+  // `DosageNoteParser.milligrams` is exactly what populates
+  // `DrugRuntimeContext.dailyDoseMg` in DatabaseBackedMealCheckUseCase.
+  group('milligrams() = dailyDoseMg source (no fabricated number)', () {
+    test('"100 mg" -> dailyDoseMg 100', () {
+      expect(parser.milligrams('100 mg'), 100);
+    });
+
+    test('"levodopa 100" -> null (must NOT become 100 mg)', () {
+      expect(parser.milligrams('levodopa 100'), isNull);
+    });
+
+    test('bare "100" -> null', () {
+      expect(parser.milligrams('100'), isNull);
+    });
+
+    test('empty / null -> null', () {
+      expect(parser.milligrams(''), isNull);
+      expect(parser.milligrams(null), isNull);
+    });
+
+    test('unit conversion: "0.5 g" -> 500 mg, "200 mcg" -> 0.2 mg', () {
+      expect(parser.milligrams('0.5 g'), 500);
+      expect(parser.milligrams('200 mcg'), 0.2);
+    });
+
+    test('non-mass unit "5 ml" -> null (not a mg dose)', () {
+      expect(parser.milligrams('5 ml'), isNull);
+    });
+  });
+
   group('Dose passes through to medication context without a default', () {
     test('user enters "100 mg" -> validator receives strength 100 mg', () {
       final result = validator.validate(buildEntry('100 mg'));

--- a/test/projected_candidate_metadata_test.dart
+++ b/test/projected_candidate_metadata_test.dart
@@ -1,0 +1,175 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkinsum_companion/core/db/cdss_database.dart';
+import 'package:parkinsum_companion/core/models/drug_definition.dart';
+import 'package:parkinsum_companion/core/models/food_item.dart';
+import 'package:parkinsum_companion/core/models/intake.dart';
+import 'package:parkinsum_companion/domain/entities/amino_acid_profile.dart';
+import 'package:parkinsum_companion/domain/entities/next_meal_recommendation_models.dart';
+import 'package:parkinsum_companion/domain/entities/time_axis_events.dart';
+import 'package:parkinsum_companion/core/models/user_profile.dart';
+import 'package:parkinsum_companion/domain/usecases/cdss_catalog_projection_service.dart';
+import 'package:parkinsum_companion/domain/usecases/get_food_recommendations_usecase.dart';
+import 'package:parkinsum_companion/domain/usecases/next_meal_recommendation_orchestrator.dart';
+
+/// Guards issue 2: mechanistic candidate scoring + CandidateMetadata are built
+/// from the SAME merged/projected candidate list the conservative path uses —
+/// not the original candidateFoods. Projected (official/CDSS) foods win id
+/// collisions so their provenance + completeness metadata reaches the scorer.
+void main() {
+  // A rich, official-style projected food (USDA food-composition table).
+  FoodItem projectedUsda(String id, {String jurisdiction = 'US'}) => FoodItem(
+        id: id,
+        name: 'projected official food',
+        category: FoodCategory.protein,
+        sourceSystem: 'USDA_FDC',
+        sourceFoodCode: '173688',
+        jurisdiction: jurisdiction,
+        proteinG: 26,
+        carbsG: 0,
+        fatG: 5,
+        fiberG: 0,
+        sodiumMg: 70,
+        energyKcal: 200,
+        basisType: 'per_100g',
+        aminoAcidProfile: const AminoAcidProfile(leucine: 2.1, valine: 1.3),
+      );
+
+  // A poor seed food sharing the same id (would win under the old putIfAbsent).
+  FoodItem seedDuplicate(String id) => FoodItem(
+        id: id,
+        name: 'seed food',
+        category: FoodCategory.protein,
+        sourceSystem: 'LOCAL_SEED',
+        jurisdiction: 'GLOBAL',
+        proteinG: 0,
+        carbsG: 0,
+        fatG: 0,
+        fiberG: 0,
+        sodiumMg: 0,
+        missingNutrientFields: const {
+          'proteinG',
+          'carbsG',
+          'fatG',
+          'fiberG',
+          'sodiumMg',
+          'energyKcal',
+          'waterG',
+        },
+      );
+
+  NextMealRecommendationRequest requestWithWindow() {
+    final now = DateTime.utc(2026, 1, 1, 8);
+    return NextMealRecommendationRequest(
+      userProfile: UserProfile.defaults().copyWith(
+        registrationRegion: 'US',
+        contentJurisdictionOverride: const ['US'],
+      ),
+      history: const [],
+      activeDrugs: [
+        DrugDefinition(
+          id: 'drug_levodopa',
+          genericName: 'levodopa',
+          brandNames: const ['Sinemet'],
+          tags: const [DrugTag.levodopaLike],
+          notes: '',
+          route: 'oral',
+          dosageForm: 'tablet',
+          releaseType: 'immediate',
+          jurisdiction: 'US',
+        ),
+      ],
+      intakes: [
+        Intake(
+          id: 'intake_1',
+          drugId: 'drug_levodopa',
+          takenAt: now.add(const Duration(minutes: 30)),
+          dosageNote: '100 mg',
+        ),
+      ],
+      now: now,
+      userConsentedToAi: false,
+      userDefinedWindow: UserDefinedMealWindow(
+        window: TimelineWindow(
+          startMinute: dateTimeToMinute(now) + 60,
+          endMinute: dateTimeToMinute(now) + 120,
+        ),
+        source: 'test',
+      ),
+    );
+  }
+
+  test('projected food metadata reaches MechanisticNextMealScorer', () async {
+    final orchestrator = NextMealRecommendationOrchestrator(
+      conservativeRecommender: GetFoodRecommendationsUseCase(),
+      projectionService:
+          _FakeProjectionService([projectedUsda('food_official')]),
+      localAiAdapter: null,
+    );
+
+    final result = await orchestrator.recommend(
+      request: requestWithWindow(),
+      candidateFoods: const [],
+    );
+
+    final scores = result.mechanisticCandidateScores;
+    expect(scores, isNotNull);
+    final official =
+        scores!.firstWhere((s) => s.candidateFoodId == 'food_official');
+    // The projected source system + real provenance/completeness reached the
+    // scorer — NOT the neutral 0.5 defaults used when metadata is absent.
+    expect(official.sourceSystem, 'USDA_FDC');
+    expect(official.insufficientContext, isFalse);
+    expect(official.provenanceQualityScore, greaterThan(0.5));
+    expect(official.metadataCompletenessScore, greaterThan(0.5));
+    expect(official.sourceAuthorityScore, greaterThan(0.3));
+  });
+
+  test(
+      'duplicate seed/projected food id prefers the richer official/projected '
+      'metadata for mechanistic scoring', () async {
+    final orchestrator = NextMealRecommendationOrchestrator(
+      conservativeRecommender: GetFoodRecommendationsUseCase(),
+      // Projection emits the rich USDA entry for the shared id.
+      projectionService: _FakeProjectionService([projectedUsda('food_dup')]),
+      localAiAdapter: null,
+    );
+
+    final result = await orchestrator.recommend(
+      request: requestWithWindow(),
+      // Caller supplies a poor seed entry with the SAME id.
+      candidateFoods: [seedDuplicate('food_dup')],
+    );
+
+    final scores = result.mechanisticCandidateScores;
+    expect(scores, isNotNull);
+    final dup = scores!.firstWhere((s) => s.candidateFoodId == 'food_dup');
+    // The official/projected entry won the merge → its provenance drives
+    // scoring, not the seed's empty metadata.
+    expect(dup.sourceSystem, 'USDA_FDC');
+    expect(dup.sourceSystem, isNot('LOCAL_SEED'));
+    expect(dup.provenanceQualityScore, greaterThan(0.5));
+  });
+}
+
+/// Test double: returns injected projected foods without touching a database.
+class _FakeProjectionService extends CdssCatalogProjectionService {
+  _FakeProjectionService(this._foods) : super(database: const _StubDb());
+
+  final List<FoodItem> _foods;
+
+  @override
+  Future<List<FoodItem>> projectFoods() async => _foods;
+
+  @override
+  Future<ProjectedDrugDetail?> projectDrugDetail(DrugDefinition drug) async =>
+      null;
+}
+
+/// Minimal CdssDatabase stub; no method is exercised because the projection
+/// service methods used by the orchestrator are overridden above.
+class _StubDb implements CdssDatabase {
+  const _StubDb();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}


### PR DESCRIPTION
1. dailyDoseMg now derives only from DosageNoteParser.milligrams (explicit value + recognized mass unit). Removed the permissive regex that turned "levodopa 100" into 100 mg; ambiguous/missing notes → null (unknown dose).
2. recommend() projects + merges candidates once and passes the SAME merged list to both the conservative path and _enrichWithMechanistic, so mechanistic scoring + CandidateMetadata use the actual merged list (not the raw candidateFoods).
3. AppState._augmentFoodRepoFromProjection no longer lets seed/persisted foods blindly win over projected CDSS foods with the same id; it merges by source authority then completeness, preferring projected on ties so official provenance + missingness metadata survives.

Tests: dailyDoseMg-source mg conversion ("levodopa 100"→null, "100 mg"→100, unit conversions, ml→null); projected food metadata reaches the scorer; duplicate seed/projected id prefers the richer official/projected metadata. flutter analyze clean; 318 tests pass.

## Summary

Describe the change and why it is needed.

## Public Prototype Boundary

- [ ] This PR does not include personal health information.
- [ ] This PR does not include real medication schedules, symptoms, private health records, Firebase tokens, service account keys, raw audit logs, user exports, real emails, full UIDs, signing files, or local credential paths.
- [ ] This PR uses synthetic or sample data only for examples, screenshots, tests, and docs.
- [ ] This PR does not claim clinical validation, legal approval, privacy certification, medical-device status, treatment guidance, or real-world health suitability.

## Touched Areas

- [ ] CDSS-style rule logic or result copy
- [ ] Firebase rules, Auth, Firestore paths, or operator tooling
- [ ] Privacy, disclaimer, support, or security text
- [ ] Public demo behavior
- [ ] Importers, provenance, or release evidence
- [ ] GitHub Pages, release notes, issue templates, or contributor docs
- [ ] Synthetic data, demo media, screenshots, or accessibility

## Validation

- [ ] `npm run public:preflight`
- [ ] `node tool/firestore_rules_contract_check.mjs`
- [ ] `flutter analyze`
- [ ] `flutter test --concurrency=1`
- [ ] Documentation-only/manual review: explain below if local tooling was not run.

## Notes For Reviewers

List any files, screenshots, docs pages, or rule evidence that need close review.
