### PR TITLE
Upgrade mechanistic meal-medication algorithm fidelity

### DIFF
--- a/lib/core/state/app_state.dart
+++ b/lib/core/state/app_state.dart
@@ -653,8 +653,11 @@ class AppState extends ChangeNotifier {
   /// Best-effort augmentation of the food repository with foods projected
   /// from CDSS observations. Educational simulation only; failures are
   /// swallowed because the persisted catalog already provides a working
-  /// baseline. The projection adds items via id-keyed merge (seed/persisted
-  /// items win for duplicate ids; projection-only items are appended).
+  /// baseline. The projection adds items via id-keyed merge; for duplicate
+  /// ids the richer entry wins (`_preferRicherFood`: source authority, then
+  /// completeness, preferring the projected entry on ties) so official
+  /// provenance + missingness metadata is not shadowed by a stale seed row.
+  /// Projection-only items are appended.
   Future<void> _augmentFoodRepoFromProjection() async {
     try {
       final projected =

--- a/lib/domain/usecases/mechanistic_conflict_engine.dart
+++ b/lib/domain/usecases/mechanistic_conflict_engine.dart
@@ -322,8 +322,10 @@ class MechanisticConflictEngine {
     );
   }
 
-  /// Most-recent meal at or before the dose time (within a 180-min lookahead),
-  /// falling back to the earliest meal. Pure selection — no side effects.
+  /// Latest meal whose start falls within the model lookahead window — up to
+  /// 180 minutes AFTER the dose (`m.minute <= med.minute + 180`), not only
+  /// meals at or before the dose. Falls back to the earliest meal when none
+  /// qualify. Pure selection — no side effects.
   ///
   /// Deterministic and independent of input order: meal events are sorted by
   /// minute (ties broken by id) before selection, so an unsorted

--- a/lib/domain/usecases/mechanistic_conflict_engine.dart
+++ b/lib/domain/usecases/mechanistic_conflict_engine.dart
@@ -324,16 +324,25 @@ class MechanisticConflictEngine {
 
   /// Most-recent meal at or before the dose time (within a 180-min lookahead),
   /// falling back to the earliest meal. Pure selection — no side effects.
+  ///
+  /// Deterministic and independent of input order: meal events are sorted by
+  /// minute (ties broken by id) before selection, so an unsorted
+  /// `mealEvents` list always yields the same primary meal.
   MealTimelineEvent? _primaryMealFor(
     MedicationTimelineEvent med,
     TimeAxisConflictContext context,
   ) {
     if (context.mealEvents.isEmpty) return null;
+    final sorted = [...context.mealEvents]..sort((a, b) {
+        final byMinute = a.minute.compareTo(b.minute);
+        return byMinute != 0 ? byMinute : a.id.compareTo(b.id);
+      });
     MealTimelineEvent? primaryMeal;
-    for (final m in context.mealEvents) {
+    for (final m in sorted) {
       if (m.minute <= med.minute + 180) primaryMeal = m;
     }
-    return primaryMeal ?? context.mealEvents.first;
+    // Fallback to the earliest meal (deterministic via the sort above).
+    return primaryMeal ?? sorted.first;
   }
 
   /// Evaluate a single dose against the meal timeline. Returns null when the

--- a/test/dosage_passthrough_test.dart
+++ b/test/dosage_passthrough_test.dart
@@ -7,12 +7,20 @@ import 'package:parkinsum_companion/domain/usecases/medication_entry_validator.d
 /// chain must come ONLY from the user-entered dosage note. No private default
 /// (the old hard-coded `strength: 100, unit: 'mg'`) may ever be injected.
 ///
-/// This mirrors EXACTLY the dose-building logic in both
-/// `NextMealRecommendationOrchestrator._buildMechanisticMedicationInputs` and
-/// `DatabaseBackedMealCheckUseCase._computeMechanisticTraceJson`:
-///   final dose = parser.parse(intake.dosageNote);
-///   strength: dose.explicit ? dose.value : null,
-///   unit:     dose.explicit ? dose.unit  : null,
+/// Two distinct consumers of `DosageNoteParser` are covered here:
+///
+/// - `RawMedicationEntry` validation uses `parse()` to obtain the explicit
+///   (value, unit) pair. This mirrors the dose-building logic in both
+///   `NextMealRecommendationOrchestrator._buildMechanisticMedicationInputs`
+///   and `DatabaseBackedMealCheckUseCase._computeMechanisticTraceJson`:
+///     final dose = parser.parse(intake.dosageNote);
+///     strength: dose.explicit ? dose.value : null,
+///     unit:     dose.explicit ? dose.unit  : null,
+///
+/// - `DrugRuntimeContext.dailyDoseMg` uses `parser.milligrams()` (which builds
+///   on `parse()` and converts the explicit value to milligrams, returning
+///   null for non-explicit notes or non-mass units). This is the path in
+///   `DatabaseBackedMealCheckUseCase._parseDoseMg`.
 void main() {
   final parser = DosageNoteParser();
   final validator = MedicationEntryValidator();

--- a/test/mechanistic_conflict_engine_test.dart
+++ b/test/mechanistic_conflict_engine_test.dart
@@ -260,6 +260,71 @@ void main() {
     );
   });
 
+  test('primary meal selection is independent of meal-event input order', () {
+    final now = DateTime.utc(2026, 1, 1, 8);
+    final refMinute = dateTimeToMinute(now);
+    final medContext = validator.validate(validLevodopa).normalized!;
+    final med = MedicationTimelineEvent(
+      id: 'med',
+      minute: refMinute + 30,
+      context: medContext,
+    );
+
+    // Two meals at the SAME minute with different compositions. Selection must
+    // be deterministic (tie-broken by id) regardless of list order.
+    const lowProtein = FoodComponent(
+      id: 'lp',
+      name: 'low protein',
+      physicalForm: MealPhysicalForm.solid,
+      proteinGrams: 1,
+      fatGrams: 0,
+      fiberGrams: 0,
+      carbohydrateGrams: 30,
+      calories: 130,
+      portionGrams: 150,
+      sourceDocId: 'synthetic:demo',
+    );
+    final compA =
+        normalizer.normalize(mealId: 'cA', components: const [lowProtein]);
+    final compB =
+        normalizer.normalize(mealId: 'cB', components: const [highProtein]);
+    final mealA = MealTimelineEvent(
+      id: 'a_meal',
+      minute: refMinute,
+      compositionId: 'cA',
+      physicalForm: MealPhysicalForm.solid,
+    );
+    final mealB = MealTimelineEvent(
+      id: 'b_meal',
+      minute: refMinute,
+      compositionId: 'cB',
+      physicalForm: MealPhysicalForm.solid,
+    );
+    final compositions = {'cA': compA, 'cB': compB};
+
+    MechanisticConflictResult evalWith(List<MealTimelineEvent> meals) =>
+        engine.evaluate(
+          context: TimeAxisConflictContext(
+            referenceMinute: refMinute,
+            medicationEvents: [med],
+            mealEvents: meals,
+          ),
+          mealCompositionsById: compositions,
+        );
+
+    final ordered = evalWith([mealA, mealB]);
+    final reversed = evalWith([mealB, mealA]);
+
+    // Same primary meal → identical modeled output regardless of input order.
+    expect(reversed.interactionScore, ordered.interactionScore);
+    expect(reversed.severityBand, ordered.severityBand);
+    expect(reversed.confidenceBand, ordered.confidenceBand);
+    expect(
+      reversed.primaryEmptyingProfile?.aggregateLagMinutes,
+      ordered.primaryEmptyingProfile?.aggregateLagMinutes,
+    );
+  });
+
   test('explanation always carries source refs and safety boundary text', () {
     final now = DateTime.utc(2026, 1, 1, 8);
     final ctx = makeContext(


### PR DESCRIPTION
## Summary

Upgrades the deterministic mechanistic meal–medication chain to be more
component-aware and literature-anchored, while staying an **educational/research
prototype** (not a medical device, not clinical software). No prescriptive or
clinical copy; medication dose passes through only from the user's explicit
entry; missing data stays missing (never 0).

> Note: this work was committed onto the `harden-medication-context-and-rule-evidence`
> integration branch as instructed; this PR targets `main` so the diff is
> reviewable. The headline change is the final commit
> `Upgrade mechanistic meal-medication algorithm fidelity`.

## Algorithm / model changes

- **Componentized meal history** — one `FoodComponent` per logged `MealItem`,
  joined to catalog `FoodItem` for physical form, energy (scaled to serving),
  and amino-acid profile (`mealItemToFoodComponent`). Missing catalog data stays
  null; logged macros are used as-is.
- **Gastric emptying** — added high-fat and high-calorie uncertainty-widening
  parameters to `GastricEmptyingParameterSet` (each with id/label/value/
  sourceRefs/evidence/limitation); the uncertainty band widens accordingly.
- **Levodopa absorption** — added a sampled **openness profile** on
  `AbsorptionOpportunityWindow` (IR sharp/short, ER flatter/longer; flattened on
  incomplete meal context). Competition overlap is now **openness-weighted**
  (flat-average fallback retained). Existing window fields kept for compatibility.
- **LNAA competition** — exposes absolute competing LNAA grams + per-serving;
  a **dose-relative ratio** only when an explicit user dose is present (never
  invented); flags **partial** amino-acid data and widens uncertainty;
  distinguishes intestinal-absorption competition from (cited, unquantified)
  BBB transport competition. Protein-source proxy retained as fallback.
- **Scoring weights** — moved the 8 candidate-scoring weights into a
  provenance-tagged `NextMealScoringParameterSet` (injectable) with a
  `conflictRemainsDominant` invariant so provenance/metadata can never outrank a
  high modeled conflict overlap. `scoringParameterSetId` surfaced per candidate.
- **Ranker eligibility** (verify) — added an end-to-end test proving the legacy
  heuristic does not silently set final order when mechanistic-primary is
  eligible, and flips to `heuristic_legacy_fallback` with reasons otherwise.
- **Replay/reporting** — new report fields (component count, gastric
  assumptions, absorption openness summary, LNAA actual-vs-proxy + partial +
  dose-relative, scoring set id) + scenarios (partial AA, high-calorie meal,
  explicit-dose LNAA, plus existing multi-dose/mixed/missing coverage).

## Safety boundary

Educational simulation only — no "safe/recommended/clinically optimized/take at
this time/adjust your medication" copy; "modeled overlap", "prototype heuristic",
"uncertainty widened", "review with a qualified professional" retained. New
magnitudes tagged `prototype_heuristic`. Disclaimers, evidence tracing, and
uncertainty reporting preserved. Banned-phrase safety test green over the full
serialized replay report.

## Tests

- `dart format` clean; `flutter analyze` clean.
- Full suite: **343 tests pass**.
- New: meal_history_componentization, gastric_emptying_model,
  absorption_openness_profile, lnaa_competition,
  mechanistic_primary_ranking_orchestrator; extended scorer + replay tests.
- Mechanistic replay runner: **35/35 scenarios**.
- `npm run public:preflight`: **0 BLOCKER**.

## Remaining limitations

Gastric-emptying magnitudes, absorption openness-curve shape, LNAA load factors
+ dose-relative ratio, and scoring weights remain prototype heuristics
(direction literature-anchored, magnitudes illustrative). No patient-specific
gastric-emptying or PK/PD prediction; no blood-concentration or dose-response
clinical claim. Meal-item physical form/calories depend on the catalog join —
absent → missing, not fabricated. Not clinically calibrated; not medical advice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)