### PR TITLE
Deepen biomedical opportunity analysis (conformance scorecard, traceability, FDC spike)

### DIFF
--- a/Bibliographies.md
+++ b/Bibliographies.md
@@ -223,10 +223,15 @@ citation/implementation candidates; none enable live ingestion today.
     https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4792175/. Accessed 28 May 2026.
 
 30. U.S. Food and Drug Administration. *Clinical Decision Support Software —
-    Guidance for Industry and FDA Staff.* FDA (final guidance, 2022; updated
-    final guidance issued 29 Jan 2026),
+    Guidance for Industry and FDA Staff.* FDA, final guidance issued 28 Sep
+    2022 (the verifiable, stable reference used here for the four non-device-CDS
+    criteria). A 2026 revision is reported by secondary legal summaries, but the
+    exact final date is inconsistently stated across them (variously Jan and Mar
+    2026) and the authoritative FDA page could not be independently fetched in
+    this environment; the 2026 revision is therefore noted but **not** asserted
+    here as a verified date.
     https://www.fda.gov/regulatory-information/search-fda-guidance-documents/clinical-decision-support-software.
-    Accessed 28 May 2026.
+    Accessed 29 May 2026.
 
 31. Leta, Valentina, et al. "Gastrointestinal Barriers to Levodopa Transport and
     Absorption in Parkinson's Disease." *European Journal of Neurology*, vol. 30,
@@ -254,7 +259,7 @@ No source enables live ingestion without per-source license review.
 | `src.hl7.fhir.r5` | FHIR R5 MedicationKnowledge / NutritionIntake / Observation | HL7 International | R5 (2023) | hl7.org/fhir | open access (spec) | implementation candidate | mappings would be "inspired", not conformant | Representation only; synthetic data. |
 | `src.ohdsi.omop.cdm` | OMOP Common Data Model | OHDSI | current | ohdsi.github.io/CommonDataModel | open access (spec) | citation only | concept mapping demo only | No patient data; identity mapping only. |
 | `src.fair.principles.2016` | FAIR Guiding Principles | Wilkinson et al. | 2016 | doi:10.1038/sdata.2016.18 | open access | citation only | governance guidance | Documentation/governance only. |
-| `src.fda.cds.guidance` | FDA Clinical Decision Support Software guidance | U.S. FDA | 2022; updated 2026 | fda.gov/.../clinical-decision-support-software | open access | citation only (boundary) | regulatory guidance, not code | Defines the non-device boundary to preserve. |
+| `src.fda.cds.guidance` | FDA Clinical Decision Support Software guidance | U.S. FDA | final 2022 (2026 revision reported, date not independently verified here) | fda.gov/.../clinical-decision-support-software | open access | citation only (boundary) | regulatory guidance, not code; cite the verifiable 2022 final | Defines the non-device boundary to preserve. |
 | `src.leta.gi_barriers.2023` | GI barriers to levodopa transport/absorption | Leta et al., *Eur. J. Neurol.* | 2023 | doi:10.1111/ene.15734 | open access (institutional copies) | citation only | mechanism direction only | Educational direction; not dosing/diet advice. |
 | `src.daphnet.fog` | Daphnet Freezing of Gait dataset | Bächlin et al. (UCI) | 2010 | archive.ics.uci.edu/dataset/245 | open access (CC BY 4.0) | implementation candidate (synthetic-shape only) | demo architecture only | No PD detection/monitoring; synthetic signals only. |
 | `src.weargait.pd` | WearGait-PD wearables dataset | open-access dataset | 2024+ | (open-access; review terms) | open access (review) | citation only | additional gait reference | Architecture demo only; non-diagnostic. |
@@ -269,3 +274,17 @@ No source enables live ingestion without per-source license review.
   the bibliography entry.
 - This file is updated whenever a new mechanism citation is added. It is not a
   clinical evidence registry.
+- **Traceability is now test-enforced:** `test/source_ref_traceability_test.dart`
+  asserts every mechanism-layer `sourceRef` resolves in
+  `ModelAssumptionRegistry` (FAIR Reusable/Interoperable). Adding a mechanism
+  `sourceRef` without a registry entry fails CI.
+- HL7 FHIR R5 **NutritionIntake** (verified against hl7.org) is patient-centric
+  (`subject` → Patient/Group, with `consumedItem.type`/`amount`/`rate` and
+  `ingredientLabel`). Any ParkinSUM mapping is **FHIR-inspired, non-conformant,
+  and deliberately omits `subject`** (no PHI).
+- Planning artifacts derived from this bibliography:
+  `docs/BIOMEDICAL_ENGINEERING_OPPORTUNITY_MAP.md`,
+  `docs/BIOMEDICAL_STANDARDS_CONFORMANCE_SCORECARD.md`,
+  `docs/BIOMEDICAL_TRACEABILITY_MATRIX.md`,
+  `docs/design/SPIKE_FDC_FOUNDATION_PROVENANCE.md`,
+  `docs/BIOMEDICAL_ENGINEERING_BACKLOG.md`.

--- a/docs/BIOMEDICAL_STANDARDS_CONFORMANCE_SCORECARD.md
+++ b/docs/BIOMEDICAL_STANDARDS_CONFORMANCE_SCORECARD.md
@@ -1,0 +1,245 @@
+# Biomedical Standards Conformance Scorecard
+
+> Research-and-planning artifact. Scores ParkinSUM Companion's **current**
+> data/metadata model against recognized biomedical-informatics standards and
+> authoritative source schemas, with **code evidence** for every row and a
+> concrete, bounded delta to advance each gap. This is a gap analysis, not an
+> implementation, and it changes nothing about the project's intended use.
+>
+> Companion documents: `docs/BIOMEDICAL_ENGINEERING_OPPORTUNITY_MAP.md` (what to
+> build), `docs/BIOMEDICAL_TRACEABILITY_MATRIX.md` (opportunity↔source↔test↔
+> safety), `docs/design/SPIKE_FDC_FOUNDATION_PROVENANCE.md` (the top item, fully
+> specified), `docs/BIOMEDICAL_ENGINEERING_BACKLOG.md` (issue-ready tasks).
+
+## 0. Why this document exists (gap vs. the prior pass)
+
+The first opportunity-map pass surveyed sources and proposed work, but it never
+measured **where the current code already stands** against the standards it
+cited. Without a baseline, "map toward FHIR" and "align to FAIR" are
+aspirations, not engineering tasks. This scorecard fixes that: it reads the
+shipped entities/usecases, assigns an honest conformance level, and states the
+exact next increment. It is deliberately conservative about claims — see §2.
+
+## 1. Safety boundary reminder
+
+ParkinSUM is an **educational / research prototype**, **not a medical device**,
+and provides no diagnosis, treatment, medication timing, diet decisions,
+patient-care guidance, or clinical decision support. This scorecard implies **no
+clinical validation or standards certification**. Specifically:
+
+- "Aligned" below means *internal model + a clearly-labeled, **inspired,
+  non-conformant** view* — never a certified/conformant FHIR/OMOP artifact.
+- Any FHIR-inspired mapping MUST omit `subject`/Patient and all PHI: ParkinSUM
+  models synthetic food/medication metadata, **not** a patient record.
+- Provenance/identity work is metadata only; it never adds dose/timing
+  inference, and dose still passes through only from explicit user entry.
+- Missing source data stays missing (never 0); uncertainty is reported.
+
+## 2. Scoring scale (honest by construction)
+
+| Level | Symbol | Meaning |
+| --- | --- | --- |
+| Absent | ⬜ | The construct is not represented in the model. |
+| Inspired-Partial | 🟡 | Internal fields capture **some** of the construct's intent; no standard-shaped serialization/view. |
+| Inspired-Aligned | 🟢 | Internal model captures the intent **and** a clearly-labeled "*-inspired, non-conformant*" view/serialization exists, with tests. |
+
+There is **deliberately no "Conformant / Certified" level.** ParkinSUM does not
+claim conformance to FHIR, OMOP, SPL, or any standard, and must not. The ceiling
+of this scorecard is 🟢 *Inspired-Aligned*.
+
+## 3. Scorecard summary
+
+| # | Standard / construct | Current | Target (safe ceiling) | Opportunity | Backlog |
+| --- | --- | --- | --- | --- | --- |
+| S1 | HL7 FHIR R5 **MedicationKnowledge** | 🟡 | 🟢 | OPP-F1 | #8 |
+| S2 | HL7 FHIR R5 **NutritionIntake** | 🟡 | 🟢 | OPP-F2 | #9 |
+| S3 | HL7 FHIR R5 **Observation** (nutrient) | ⬜ | 🟡 | OPP-F2 | #9 |
+| S4 | **FDA SPL** + LOINC section identity | 🟡 | 🟢 | OPP-A1 | #1 |
+| S5 | **USDA FDC** FoodNutrient provenance (derivation/dataPoints/dataType) | 🟡 | 🟢 | OPP-B1 / OPP-B2 | #2 + spike |
+| S6 | **FAO/INFOODS** component identifiers (tagnames) | ⬜ | 🟡 | OPP-B3 | (map) |
+| S7 | **RxNorm / ATC** identity coding | ⬜ | 🟡 | OPP-A3 | (map) |
+| S8 | **OMOP CDM** concept identity (non-patient) | ⬜ | 🟡 | OPP-F1/F2 adjunct | (map) |
+| S9 | **FAIR** principles (source provenance) | 🟡 | 🟢 | OPP-F3 / OPP-D4 | #11, #12 |
+
+**Posture reading:** the model is strongest on **FAIR provenance** (a versioned
+in-code source registry, sourceRefs on every modeled assumption, and a
+source-access/license doc) and on **FDC amino-acid extraction**; it is weakest on
+**standard-shaped serialization** (no FHIR-inspired views yet) and **coded
+identity** (no RxCUI/ATC/INFOODS/OMOP concept ids). The highest evidence-value,
+lowest-risk increments are **S5 (FDC provenance)** and **S9 (FAIR guardrail
+regression)** — both deepen evidence-linkage without touching the safety
+boundary.
+
+## 4. Per-standard detail (with code evidence)
+
+### S1 — HL7 FHIR R5 MedicationKnowledge — 🟡 Inspired-Partial
+
+- **Standard:** `MedicationKnowledge` = "Information about a medication that is
+  used to support knowledge" (HL7 FHIR R5). Key elements: `code`,
+  `doseForm`, `ingredient` (item + strength), `definitional`, `monograph`,
+  `relatedMedicationKnowledge`, `regulatory`.
+- **Current state (evidence):** `DrugProductVariantMetadata`
+  (`lib/domain/entities/source_metadata.dart`) carries `genericName`,
+  `activeIngredients`, `strengthValue`+`strengthUnit`, `doseForm`, `route`,
+  `releaseType`, `productIdentifier` (NDC/DIN/EMA#/dm+d/PMDA/NMPA), `labelSection`,
+  `sourceRefs`, `limitationText`. This captures most MedicationKnowledge *intent*
+  (form, ingredient+strength, identifier) but exposes only a flat
+  `toJson()` — no FHIR-shaped element names, and **no coded `code`** (no
+  RxCUI/ATC).
+- **Delta to 🟢:** add a `toFhirInspiredMedicationKnowledge()` view (explicitly
+  "inspired, non-conformant") mapping fields → FHIR element names, plus a coded
+  `code` once RxCUI/ATC identity (S7) exists. No behavior change; serialization
+  only.
+- **Safety:** representation only; omit any patient linkage.
+
+### S2 — HL7 FHIR R5 NutritionIntake — 🟡 Inspired-Partial
+
+- **Standard (verified from hl7.org):** `NutritionIntake` top-level includes
+  `status`, `code`, **`subject` (Patient/Group)**, `occurrence[x]`,
+  `consumedItem` (`type` = food/fluid/enteral, `nutritionProduct`, `amount`,
+  **`rate`** for enteral, `notConsumed`), and `ingredientLabel` (nutrient/amount
+  pairs).
+- **Current state (evidence):** `MealComposition` + `FoodComponent`
+  (`lib/domain/entities/meal_composition.dart`) model the *consumedItem* intent:
+  `physicalForm` (solid/liquid/mixed) ≈ `consumedItem.type`, `portionGrams` ≈
+  `amount`, per-nutrient grams ≈ `ingredientLabel`, and the DB-backed usecase's
+  enteral-feed context ≈ `consumedItem.rate`. Componentized meal history (one
+  `FoodComponent` per logged item) already exists.
+- **Delta to 🟢:** add a `toFhirInspiredNutritionIntake()` view mapping to the
+  verified element names — **deliberately omitting `subject`/Patient** (no PHI).
+  Map `physicalForm`→`consumedItem.type`, `portionGrams`→`amount`, enteral
+  context→`rate`, amino-acid/macros→`ingredientLabel`.
+- **Safety (critical):** NutritionIntake is patient-centric in FHIR; the
+  ParkinSUM mapping must drop `subject` and stay synthetic, or it would imply a
+  patient record. Label the view "FHIR-inspired, non-conformant, no subject".
+
+### S3 — HL7 FHIR R5 Observation (nutrient) — ⬜ Absent
+
+- **Standard:** `Observation` = measurements/assertions (`code`, `value[x]`,
+  `component`, `derivedFrom`, `method`). FHIR notes Observation is *cumbersome*
+  for full nutrition detail (hence NutritionIntake) — so Observation is only a
+  secondary, per-nutrient representation.
+- **Current state:** nutrient values are modeled as typed fields, not as
+  Observation-shaped records. No mapping.
+- **Delta to 🟡:** an optional per-nutrient `toFhirInspiredObservation()` (e.g.
+  protein grams as an Observation with `method` carrying the FDC derivation from
+  S5). Lower priority than S2.
+- **Safety:** representation only.
+
+### S4 — FDA SPL + LOINC section identity — 🟡 Inspired-Partial
+
+- **Standard:** SPL documents and their sections are identified by **LOINC
+  document/section codes**; DailyMed SPL Web Services v2 expose `/spls/{SETID}`
+  and `/spls/{SETID}/history` (set id, version, effective date).
+- **Current state (evidence):** `DrugProductVariantMetadata.labelSection` is a
+  single free-text string; there is no LOINC section code, no `setId`, no
+  `labelVersion`, no `effectiveDate`. Adapters are `fixture_tested` (see
+  `docs/SOURCE_ACCESS_AND_LICENSES.md`).
+- **Delta to 🟢:** capture `sectionLoincCode`, `setId`, `labelVersion`,
+  `effectiveDate` from the SPL fixture parser; surface in the medication-context
+  trace so the engine can cite the exact section. Missing → recorded missing,
+  never guessed.
+- **Safety:** metadata/provenance only; mechanism evidence still requires
+  explicit label text.
+
+### S5 — USDA FDC FoodNutrient provenance — 🟡 Inspired-Partial
+
+- **Standard:** the FDC OpenAPI `FoodNutrient` (non-abridged) family carries, per
+  nutrient value, a derivation (`foodNutrientDerivation` with `code`/`description`
+  and nested `foodNutrientSource`), `dataPoints` (sample count), and
+  `min`/`max`/`median`; foods carry a `dataType` (Foundation / SR Legacy / FNDDS
+  / Branded). *(Exact field names to be re-verified against the live FDC OpenAPI
+  spec as step 0 of the spike — see `docs/design/SPIKE_FDC_FOUNDATION_PROVENANCE.md`.)*
+- **Current state (evidence):** `AminoAcidExtractor`
+  (`lib/data/datasources/remote/amino_acid_extractor.dart`) extracts 9 LNAA-set
+  nutrients by **verified number** (501,502,503,504,506,508,509,510,512) with a
+  name fallback, mg→g normalization, and a `partial` flag for unit-ambiguous
+  values. But `basis` is **hard-coded `per_100g`**, and it captures **no**
+  derivation code, sample count, analytical method, or `dataType`.
+- **Delta to 🟢:** capture derivation + dataPoints + dataType into
+  `FoodVariantMetadata` and a per-nutrient confidence flag consumed by
+  `MetadataCompletenessGate`; let `basis` be data-driven, not assumed. This is
+  the fully-specified spike.
+- **Safety:** provenance only; never fabricate a sample count or method; missing
+  → lower completeness, not higher confidence.
+
+### S6 — FAO/INFOODS component identifiers (tagnames) — ⬜ Absent
+
+- **Standard:** INFOODS defines ~800 component identifiers ("tagnames") encoding
+  method/expression/definition (e.g., `PROCNT` for protein, `FAT` for fat),
+  enabling cross-table comparability.
+- **Current state:** internal nutrient codes (`protein_g`, etc.) are app-local;
+  no tagname alignment.
+- **Delta to 🟡:** add an optional `tagname` to projected nutrient lines + a
+  documented mapping; standardizes missingness/confidence reporting.
+- **Safety:** documentation/standardization only.
+
+### S7 — RxNorm / ATC identity coding — ⬜ Absent
+
+- **Standard:** RxNorm RxCUI normalized drug identity; RxNav/RxClass `ATCPROD`
+  maps products to ATC L1–4.
+- **Current state (evidence):** RxNorm is `spec_only` in
+  `docs/SOURCE_ACCESS_AND_LICENSES.md`; `productIdentifier` holds
+  jurisdiction-local ids only; no RxCUI/ATC.
+- **Delta to 🟡:** a fixture parser mapping a synthetic RxNav response → RxCUI +
+  ATC for identity display only (explicitly **not** a mechanism source).
+- **Safety:** identity/coding only.
+
+### S8 — OMOP CDM concept identity (non-patient) — ⬜ Absent
+
+- **Standard:** OHDSI OMOP CDM is a person-centric observational model with
+  standardized vocabularies (concept_id). ParkinSUM has a concept-variant
+  crosswalk in its CDSS tables but no OMOP concept_id mapping.
+- **Current state:** crosswalk exists (`cdss_catalog_projection_service.dart`
+  consumes `concept_variant_crosswalk`); no OMOP concept ids.
+- **Delta to 🟡:** a **vocabulary-only** concept-id mapping demo (no person
+  table, no patient data) showing identity interoperability. OMOP's
+  person-centric tables are explicitly **out of scope** (PHI territory).
+- **Safety:** identity demo only; never instantiate person/observation_period.
+
+### S9 — FAIR principles (source provenance) — 🟡 Inspired-Partial
+
+- **Standard:** FAIR = Findable / Accessible / Interoperable / Reusable
+  (Wilkinson et al. 2016, *Scientific Data*, DOI 10.1038/sdata.2016.18).
+- **Current state (evidence):** **Findable/Reusable** are partly met —
+  `ModelAssumptionRegistry` (`lib/domain/usecases/model_assumption_registry.dart`)
+  gives every modeled assumption a stable `sourceId`, citation text, evidence
+  level, and `lastReviewed` date; `SOURCE_ACCESS_AND_LICENSES.md` records access
+  + license-review status. **Interoperable** is weaker (no machine-readable
+  license tags / persistent DOIs in-model).
+- **Delta to 🟢:** (a) a **traceability guard test** asserting every sourceRef
+  the mechanism layer emits resolves in the registry (shipped this pass — see
+  §6); (b) machine-readable license/access tags per source; (c) the
+  clinical-calibration guardrail regression (backlog #12).
+- **Safety:** governance/provenance; gates live ingestion behind review.
+
+## 5. Aggregate deltas, sequenced
+
+1. **Now (safe, this pass):** S9 traceability guard test + stale-entry
+   correction (shipped); this scorecard + traceability matrix + FDC spike.
+2. **Next (bounded importer/test):** S5 FDC provenance (spike), S4 SPL section
+   identity, plus the missingness/perturbation replay suites.
+3. **Then (standards views):** S1/S2/S3 FHIR-inspired serializations (no
+   subject), S7 RxNorm/ATC identity, S6 INFOODS tagnames, S8 OMOP concept demo.
+
+## 6. What shipped in this pass (evidence)
+
+- **S9 traceability guard** — `test/source_ref_traceability_test.dart` asserts
+  every `sourceRef` emitted by the mechanism layer (conflict engine, gastric
+  model, absorption model, amino-acid competition, protein-distribution model,
+  scoring parameter set) resolves to a `ModelAssumptionRegistry` entry with
+  citation text. This enforces FAIR "Reusable/Interoperable" at the test gate:
+  the engine cannot emit an unresolvable evidence reference.
+- **Stale registry correction** — `src.fdc.api.amino_acid_fields` in
+  `model_assumption_registry.dart` previously claimed the wrong nutrient numbers
+  ("505 leucine, 509 phenylalanine, 511 valine") and that the importer "does not
+  currently extract these fields." Both are now false (the amino-number fix
+  shipped earlier; the extractor does extract them). Corrected to the verified
+  mapping and current capability.
+
+## 7. Out of scope / rejected (unchanged from boundary)
+
+- ❌ Certified/conformant FHIR/OMOP artifacts or a real exchange endpoint.
+- ❌ Any `subject`/Patient linkage, person table, or real patient data.
+- ❌ Coded identity used to drive any clinical/dose/timing inference.
+- ❌ Treating standards alignment as clinical validation.

--- a/docs/BIOMEDICAL_TRACEABILITY_MATRIX.md
+++ b/docs/BIOMEDICAL_TRACEABILITY_MATRIX.md
@@ -1,0 +1,115 @@
+# Biomedical Opportunity Traceability Matrix & Risk Register
+
+> Research-and-planning artifact. Links every proposed opportunity to its
+> authoritative source, the app layer it touches, the metadata it requires, the
+> **test artifact** that would prove it, the **safety control** that bounds it,
+> and the **acceptance signal** that closes it — then registers the risks of
+> doing the work and how each is mitigated. Nothing here changes intended use.
+>
+> Companions: `BIOMEDICAL_ENGINEERING_OPPORTUNITY_MAP.md` (rationale),
+> `BIOMEDICAL_STANDARDS_CONFORMANCE_SCORECARD.md` (baseline),
+> `design/SPIKE_FDC_FOUNDATION_PROVENANCE.md` (top item),
+> `BIOMEDICAL_ENGINEERING_BACKLOG.md` (issue text).
+
+## 1. Why this document exists (gap vs. the prior pass)
+
+The opportunity map listed *what* and the backlog listed *how*, but nothing tied
+each opportunity end-to-end to a **named test** and a **named safety control**,
+and there was no **risk register**. For an engineering plan to be actionable and
+auditable, each row must answer: *if we build this, which test proves it works,
+which control proves it stayed safe, and what does "done" look like?* This
+document is that spine.
+
+## 2. Safety boundary reminder
+
+Educational / research prototype; **not a medical device**. No diagnosis,
+treatment, timing, diet, or clinical decision support. Synthetic / public-schema
+data only; dose passes through only from explicit user entry; missing ≠ zero; no
+live ingestion without opt-in + license review; AI never decides inside the
+conflict engine; no claim of clinical validation/calibration.
+
+## 3. Traceability matrix
+
+Columns: **OPP** = opportunity id (from the map) · **Source** = authoritative
+basis · **Layer** = app layer touched · **Required metadata** · **Test artifact**
+= the test that proves it (new or existing) · **Safety control** = the guard that
+keeps it in-bounds · **Acceptance signal** = observable "done" · **State** =
+shipped / ready / blocked.
+
+| OPP | Source | Layer | Required metadata | Test artifact | Safety control | Acceptance signal | State |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| **D4** clinical-calibration guardrail | FDA CDS criteria (2022 final) | replay runner (read-only) | none | `mechanistic_replay_runner_test.dart` calibration cases | every case asserts `not_clinically_calibrated` + `live_fetch_enabled==false` | all cases carry the guardrail; banned-phrase scan clean | **shipped** (prior PR) |
+| **F3** FAIR source-ref traceability | FAIR (Wilkinson 2016) | mechanism layer + registry | `sourceId` per assumption | `source_ref_traceability_test.dart` (**new this pass**) | every emitted `sourceRef` resolves in `ModelAssumptionRegistry` | test passes; no unresolvable ref | **shipped (this pass)** |
+| **B1** FDC FoodNutrient provenance | USDA FDC OpenAPI; Foundation Foods docs | nutrition importer → `FoodVariantMetadata` → completeness gate | derivation code, dataPoints, dataType, basis | new FDC fixture parser test (synthetic) | provenance only; missing→lower completeness, never fabricated | derivation+sample+dataType in trace for synthetic Foundation food; missing recorded missing | **ready** (spike written) |
+| **B2** fuller FDC amino-acid coverage | USDA FDC OpenAPI | `AminoAcidExtractor` → `AminoAcidProfile` | nutrient number, unit, basis, partial flag | extend `amino_acid_extraction_test.dart` | missing AA stays null; partial widens uncertainty | full LNAA set parsed when present; partial flagged | **ready** |
+| **A1** SPL/SmPC section provenance | DailyMed SPL WS v2; FDA SPL + LOINC | SPL adapters → `DrugProductVariantMetadata` | section LOINC, setId, version, effectiveDate | new SPL fixture parser test | metadata only; mechanism still needs label text | section LOINC+version+date in trace; missing→missing | ready |
+| **A2** release/dose-form/combination extraction | DailyMed SPL WS v2; EMA ePI | importer → variant metadata → absorption model | dose form, release type, per-ingredient strength | fixtures for IR/ER/3-component combo | never default a release type; unknown→wider uncertainty | release type drives openness profile; missing→insufficient | ready |
+| **A3** RxNorm/ATC identity | RxNorm RxNav/RxClass (ATCPROD) | crosswalk / authority scorer (identity) | RxCUI, ATC L1–4, tty | new RxNav fixture mapping test | identity only; explicitly not a mechanism source | synthetic RxNav JSON → RxCUI+ATC; no food-effect derived | ready |
+| **C1** enteral feeding educational scenario | Leta 2023; npj/Virmani 2023; SPL | replay scenarios + enteral context | feed mode, protein g/day (synthetic), refs | replay scenario + banned-phrase scan | educational caution only; "review with a professional"; no schedule | scenario runs, carries refs + caution, no prescriptive copy | partial (placeholder) |
+| **C2** iron/mineral co-event caution | Leta 2023 + a verified iron–levodopa citation | conflict engine co-event trace | co-event substance, refs, caution text | replay scenario + safety-phrase test | caution only if source-backed; no interaction score | caution appears only when cited; non-prescriptive | **blocked** (needs citation) |
+| **C3** MAO-B/tyramine caution | MAO-B SmPC/SPL + verified tyramine ref | educational caution copy + scenario | refs, jurisdiction, caution text | safety-phrase + source-presence gate test | no caution without source; no diet rule implied | gated on verified source; no diet prescription | **blocked** (needs citation) |
+| **C4** ER multi-dose stress tests | DailyMed ER label; Leta 2023 | replay + engine tests | release type, synthetic dose offsets | extend engine/replay tests | educational simulation only | ER widens/flattens window; max-overlap holds | ready |
+| **D1** source-quality perturbation | FAIR; internal scorer | replay runner + scorer (read-only) | candidate metadata variants | new perturbation scenarios in replay test | tests only; no behavior change | lower-authority variant never outranks high-conflict; deterministic | ready |
+| **D2** missingness stress suite | FDC docs; internal normalizer | replay runner | dropped nutrient fields | new missingness scenarios in replay test | tests only; missing≠zero | missing surfaces as missing + lowers confidence | ready |
+| **D3** counterfactual A/B pairs | internal | replay runner | paired scenario variants | new paired scenarios | tests only | asserted directional difference per pair | ready |
+| **F1** FHIR-inspired MedicationKnowledge | FHIR R5; RxNorm | serialization view over variant metadata | code(RxCUI/ATC), doseForm, ingredient, refs | mapper unit test (synthetic) | "inspired, non-conformant"; no subject/PHI | deterministic mapping to FHIR element names | ready |
+| **F2** FHIR-inspired NutritionIntake/Observation | FHIR R5; INFOODS | serialization view over composition | consumedItem.type, amount, rate, ingredientLabel | mapper unit test (synthetic) | no `subject`/Patient; synthetic only | deterministic mapping; subject omitted | ready |
+| **B3** INFOODS tagnames | FAO/INFOODS | nutrition metadata + provenance sidecar | tagname, expression/definition, confidence | mapping unit test | documentation/standardization only | nutrient lines carry tagname; doc'd mapping | ready |
+| **B4** prepared/raw/branded + decomposition | FDC dataType; INFOODS food matching | `FoodItem.preparationState/basisType` → component | dataType, prep state, basis | fixture per data type | missing prep→unknown, not guessed | form/water flow into composition | ready |
+| **E1** synthetic wearable/gait replay | Daphnet FoG (CC BY 4.0); WearGait-PD (shape only) | NEW isolated module (decoupled) | synthetic signal spec, sampling rate, window cfg | deterministic feature tests + non-diagnostic copy assertions | NO PD detection/monitoring; synthetic only; isolated from medication logic | feature pipeline runs on synthetic signals; isolation test passes | **deferred** (P3, large) |
+
+## 4. Dependency / sequencing graph
+
+```
+Phase α (this pass, safe/doc/test)
+  F3 traceability guard  ──┐
+  D4 calibration guard ────┼──► baseline locked
+  (scorecard, matrix, spike, biblio)
+
+Phase β (bounded importer/test)         Phase γ (standards views)
+  B1 FDC provenance ──► B2 fuller AA      A3 RxCUI/ATC ──► F1 MedKnowledge code
+  D1 perturbation                         F2 NutritionIntake (no subject)
+  D2 missingness                          B3 INFOODS tagnames
+  C1 enteral (placeholder→full)           B4 prepared/raw/branded
+  A1 SPL section ──► A2 release/combo      S8 OMOP concept demo (identity only)
+
+Blocked (need verified citation first)   Deferred (large, isolated)
+  C2 iron co-event                         E1 synthetic wearable/gait
+  C3 MAO-B/tyramine
+```
+
+Critical-path notes: **F1 depends on A3** (a coded `code` needs RxCUI/ATC).
+**B2 depends on B1's** basis/derivation plumbing. **C2/C3 are hard-blocked** on a
+verified, non-prescriptive citation — do not implement without one.
+
+## 5. Risk register
+
+Likelihood / Impact scale: L = low, M = medium, H = high. "Impact" weighs the
+**safety-boundary** and credibility cost, not just engineering cost.
+
+| Risk | Likelihood | Impact | Mitigation | Residual |
+| --- | --- | --- | --- | --- |
+| **R1 — Overclaiming standards conformance** (someone reads "FHIR mapping" as "FHIR-conformant / clinically interoperable") | M | H | Scorecard caps at 🟢 *Inspired-Aligned*; every mapper labeled "inspired, non-conformant"; no certification language anywhere | L |
+| **R2 — PHI leakage via FHIR `subject`** (NutritionIntake/Observation are patient-centric) | M | H | Mapping spec **omits `subject`/Patient**; synthetic-only tests; banned-phrase + no-PHI assertions | L |
+| **R3 — Citing an unverifiable source date** (e.g., asserting an exact FDA 2026 date that secondary sources dispute) | M | M | Anchor on the verifiable 2022 final guidance; flag the 2026 revision as *reported, not independently verified here*; never assert an unconfirmed date as fact | L |
+| **R4 — Fabricating missing provenance** (inventing a sample count / analytical method when FDC omits it) | L | H | "Missing ≠ zero" invariant; provenance fields nullable; tests assert missing→lower completeness, never higher confidence | L |
+| **R5 — Mechanism overreach in an educational caution** (iron / tyramine becoming a de-facto diet rule) | M | H | C2/C3 hard-blocked on a verified citation; caution copy gated on source presence; safety-phrase test; "review with a qualified professional" | L (while blocked) |
+| **R6 — Hidden dose default via importer realism** (release/strength extraction silently defaulting) | L | H | Dose passthrough invariant + existing `dosage_passthrough_test.dart`; unknown release/strength → wider uncertainty / insufficient, never a default | L |
+| **R7 — Wearable layer implying PD detection/monitoring** | M (if built) | H | E1 deferred; if built, a **separate isolated module**, synthetic signals only, explicit "no PD detection/monitoring" copy + isolation test; never wired to medication logic | L (deferred) |
+| **R8 — License/terms violation from live ingestion** | L | H | No live ingestion by default; opt-in smoke fetches metadata only, never stores raw payloads; per-source license-review gate in `SOURCE_ACCESS_AND_LICENSES.md` | L |
+| **R9 — Source-ref drift** (engine emits a `sourceRef` with no registry entry → broken evidence link) | M | M | **Traceability guard test shipped this pass** fails CI on any unresolvable mechanism-layer ref | L |
+| **R10 — Scope creep on a "planning" pass** (turning research into a broad refactor) | M | M | This pass ships docs + one bounded test + one stale-entry fix only; larger items stay in the backlog with explicit "not in scope" | L |
+
+## 6. Definition of done (per opportunity type)
+
+- **Importer field (A1/A2/B1/B2/B4):** synthetic fixture parser test green;
+  new field flows into the trace; missing→recorded missing (never 0);
+  `sourceRef` resolves in the registry; banned-phrase scan clean.
+- **Replay/validation (C1/C4/D1/D2/D3):** scenario uses explicit synthetic data;
+  asserts expected output type / severity / confidence / provenance; deterministic.
+- **Standards view (F1/F2/F3):** deterministic mapper unit test on synthetic
+  input; "inspired, non-conformant" label; no `subject`/PHI; no behavior change.
+- **Caution (C2/C3):** **verified citation present**; copy gated on source;
+  safety-phrase + source-presence tests; non-prescriptive.
+- **Showcase (E1):** isolated module; synthetic signals; non-diagnostic copy +
+  isolation tests; zero coupling to medication/conflict logic.

--- a/docs/design/SPIKE_FDC_FOUNDATION_PROVENANCE.md
+++ b/docs/design/SPIKE_FDC_FOUNDATION_PROVENANCE.md
@@ -1,0 +1,211 @@
+# Design Spike — USDA FDC Foundation-Foods nutrient provenance
+
+> **Status:** design-ready (not yet implemented). Implementation-ready
+> specification for opportunity **OPP-B1** / backlog **#2**, grounded in the
+> shipped code. This spike turns "capture FDC provenance" into a buildable,
+> testable task with a data contract, parser changes, integration points, a test
+> matrix, acceptance criteria, rollout, and a safety analysis.
+>
+> Educational / research prototype only. **Not a medical device.** Provenance
+> metadata only — no dose/timing/diet inference, no clinical calibration,
+> synthetic fixtures only, missing ≠ zero.
+
+## 0. Step 0 — verify field names against the live FDC OpenAPI (required first)
+
+The FDC schema HTML/JSON/YAML is JS-rendered and was **not fetchable** in the
+planning environment, so the exact field names below are taken from the
+documented FDC OpenAPI `FoodNutrient` family and **must be confirmed** against
+the live spec before coding:
+
+- FDC Nutrient Data OpenAPI: `https://fdc.nal.usda.gov/api-spec/fdc_api.html`
+  (HTML), plus JSON/YAML variants linked from `https://fdc.nal.usda.gov/api-guide/`.
+- Foundation Foods Documentation: `https://fdc.nal.usda.gov/Foundation_Foods_Documentation/`.
+
+Acceptance for Step 0: a short note in the PR confirming the live field names for
+`foodNutrientDerivation.code`, `foodNutrientDerivation.description`,
+`foodNutrientSource`, `dataPoints`, `min`/`max`/`median`, and food-level
+`dataType`. If a name differs, update the data contract before implementing.
+
+## 1. Problem & current-state evidence
+
+ParkinSUM's nutrition chain treats an extracted nutrient amount as a bare number
+with a hard-coded basis and no indication of **how** that number was derived
+(measured analytically? calculated? imputed? from how many samples?). That is
+exactly the provenance the metadata-completeness gate and uncertainty model
+should consume — and exactly what FDC publishes.
+
+**Evidence from the shipped code:**
+
+- `lib/data/datasources/remote/amino_acid_extractor.dart`
+  - Extracts 9 LNAA-set nutrients by verified number (501,502,503,504,506,508,
+    509,510,512) with a name fallback; normalizes mg→g; sets a single `partial`
+    flag when a unit is missing/unrecognized.
+  - **Hard-codes** `const basis = 'per_100g'` and `const unit = 'g'`.
+  - Captures **no** derivation code, **no** `dataPoints` (sample count), **no**
+    analytical method, **no** food `dataType`.
+- `lib/domain/entities/amino_acid_profile.dart` — `AminoAcidProfile` has per-acid
+  grams, `unit`, `basis`, `nutrientIds`, `sourceRefs`, `partial`. No per-nutrient
+  derivation/confidence.
+- `lib/domain/entities/source_metadata.dart` — `FoodVariantMetadata` has
+  `basisType`, `servingUnit`, `preparationState`, `aminoAcidFieldsPresent`,
+  `extractionConfidence`, `sourceRefs`. No FDC `dataType`, no per-nutrient
+  derivation, no sample count.
+- `MetadataCompletenessGate` already grades candidate-food completeness and feeds
+  composition uncertainty — the natural consumer of a per-nutrient confidence
+  signal.
+
+Conformance baseline: **S5 = 🟡 Inspired-Partial**
+(`docs/BIOMEDICAL_STANDARDS_CONFORMANCE_SCORECARD.md`).
+
+## 2. Goal & non-goals
+
+**Goal:** capture FDC-published nutrient provenance (derivation, sample count,
+data type, real basis) as **optional, nullable** metadata, map it to a
+deterministic per-nutrient **confidence tier**, and let the completeness gate /
+uncertainty model consume it — moving S5 to 🟢 *Inspired-Aligned*.
+
+**Non-goals:** live FDC ingestion (API key required; stays opt-in smoke only);
+changing any mechanism magnitude; any clinical/dose/timing inference; inventing
+provenance when FDC omits it.
+
+## 3. Data contract (additive, nullable)
+
+All new fields are **optional and nullable** so existing call sites and fixtures
+are unaffected and "missing ≠ zero" holds.
+
+### 3.1 New value type — `NutrientDerivation`
+
+```
+class NutrientDerivation {           // new: domain/entities/nutrient_derivation.dart
+  final String? derivationCode;      // FDC foodNutrientDerivation.code (e.g. "A", "NC", "LCCD")
+  final String? derivationDescription; // human-readable
+  final String? sourceCode;          // FDC foodNutrientSource.code
+  final int? dataPoints;             // FDC dataPoints (sample count); null = unknown (NOT 0)
+  final double? min;                 // optional FDC min
+  final double? max;                 // optional FDC max
+  final double? median;              // optional FDC median
+
+  NutrientConfidenceTier get tier;   // derived; see §4
+}
+enum NutrientConfidenceTier { analytical, calculated, imputedOrAssumed, unknown }
+```
+
+### 3.2 `AminoAcidProfile` (additive)
+
+- Add `String? perNutrientBasis` — replaces the hard-coded assumption when FDC
+  reports a different basis; defaults to existing behavior when null.
+- Add `Map<String, NutrientDerivation>? derivations` keyed by nutrient field
+  name (e.g. `"leucine"`). Null/absent → unchanged behavior.
+
+### 3.3 `FoodVariantMetadata` (additive)
+
+- Add `String? fdcDataType` — Foundation / SR Legacy / FNDDS / Branded.
+- Add `NutrientConfidenceTier? aggregateNutrientConfidence` — the weakest tier
+  across present nutrients (conservative).
+
+> Every new field is nullable. A fixture or call site that omits them behaves
+> exactly as today. No field defaults to a fabricated value.
+
+## 4. Confidence-tier mapping (deterministic, documented)
+
+Map FDC `derivationCode` → `NutrientConfidenceTier` via a small, **sourced**
+table (registry-tagged `src.usda.fdc.foundation_docs` + the OpenAPI spec):
+
+| FDC derivation family (verify exact codes in Step 0) | Tier |
+| --- | --- |
+| Analytical / directly measured | `analytical` |
+| Calculated from other components / recipe | `calculated` |
+| Imputed / assumed / borrowed from similar food | `imputedOrAssumed` |
+| Missing or unrecognized code | `unknown` |
+
+Rules:
+- `dataPoints == null` does **not** raise the tier (unknown sample count never
+  implies higher confidence).
+- Tier is **prototype-heuristic** mapping of provenance → an ordinal signal; it
+  is **not** a measurement-uncertainty estimate and carries no clinical meaning.
+- The aggregate tier on `FoodVariantMetadata` is the **weakest** present tier
+  (conservative; a single imputed nutrient lowers the aggregate).
+
+## 5. Parser & integration changes
+
+1. **Extractor** (`amino_acid_extractor.dart`): when the FDC payload includes
+   `foodNutrientDerivation` / `dataPoints` / `foodNutrientSource` per nutrient,
+   build a `NutrientDerivation` and attach it to the profile's `derivations`
+   map; read the food-level `dataType`; let `basis` follow the payload when
+   present (fall back to `per_100g` only when absent, as today). All additive;
+   the existing return contract (null when no LNAA fields) is unchanged.
+2. **Completeness gate** (`metadata_completeness_gate.dart`): when an aggregate
+   nutrient confidence tier is present, fold it into the existing completeness
+   grade (e.g., `imputedOrAssumed`/`unknown` cannot reach the top grade). When
+   absent, behavior is unchanged.
+3. **Uncertainty:** a lower confidence tier widens composition/competition
+   uncertainty by one step (mirrors the existing partial-amino-acid widening),
+   tagged as a prototype heuristic. No magnitude in the mechanism layer changes.
+4. **Trace/report:** surface `fdcDataType`, `aggregateNutrientConfidence`, and
+   per-nutrient `derivationCode` in the existing food-variant trace and (where a
+   candidate is scored) the replay report — additive JSON keys only.
+
+## 6. Test matrix (synthetic fixtures only)
+
+| # | Fixture | Asserts |
+| --- | --- | --- |
+| T1 | Foundation food, analytical derivation, dataPoints=12 | tier `analytical`; dataType `Foundation`; derivation surfaced |
+| T2 | Calculated derivation | tier `calculated` |
+| T3 | Imputed/assumed derivation | tier `imputedOrAssumed`; aggregate confidence lowered; uncertainty widened |
+| T4 | Missing derivation block entirely | tier `unknown`; **no fabricated** sample count (`dataPoints == null`); completeness lowered, not raised |
+| T5 | Mixed nutrients (one analytical, one imputed) | aggregate tier = weakest (`imputedOrAssumed`) |
+| T6 | Non-`per_100g` basis present in payload | `perNutrientBasis` reflects payload; no silent `per_100g` assumption |
+| T7 | Legacy fixture (no provenance fields at all) | identical output to today (regression: additive only) |
+| T8 | `sourceRef` resolves | `src.usda.fdc.foundation_docs` present in registry (traceability guard) |
+| T9 | Banned-phrase scan | serialized trace carries no prescriptive/clinical phrasing |
+
+All fixtures are **synthetic payloads shaped on the public FDC schema** — never
+real FDC exports, never an API key.
+
+## 7. Acceptance criteria
+
+- A synthetic Foundation-food fixture yields derivation + dataPoints + dataType
+  in the food-variant trace; a missing derivation is recorded **missing**
+  (`null`), never as 0 or a guessed method.
+- Confidence tier is deterministic and conservative (weakest-wins aggregate;
+  unknown sample count never raises confidence).
+- Lower tier lowers completeness and widens uncertainty; absent provenance leaves
+  current behavior unchanged (T7 regression green).
+- Every new `sourceRef` resolves in `ModelAssumptionRegistry` (traceability guard
+  green); banned-phrase scan clean.
+- `dart format` + `flutter analyze` clean; full suite + replay green.
+
+## 8. Rollout
+
+- Purely additive + opt-in: no live ingestion. The opt-in live smoke harness
+  stays metadata-only and never stores raw payloads.
+- No flag needed (nullable fields are inert until a fixture/parser supplies
+  them), but the PR should land extractor + entity + gate + tests together so the
+  new fields are exercised on day one.
+
+## 9. Safety analysis
+
+- **Missing ≠ zero:** every provenance field is nullable; tests T4/T7 lock that a
+  missing derivation lowers (never raises) confidence and is never fabricated.
+- **No clinical claim:** confidence tier is an ordinal provenance signal, not a
+  measurement-uncertainty or clinical-accuracy estimate; documented as a
+  prototype heuristic with `src.usda.fdc.foundation_docs`.
+- **No dose/timing/diet inference:** nutrition-side metadata only; the medication
+  dose passthrough invariant is untouched.
+- **Provenance integrity:** new `sourceRef` gated by the traceability guard.
+
+## 10. Out of scope (this spike)
+
+- Live FDC ingestion / production parser (key + license review required).
+- Non-LNAA nutrient derivation beyond what the completeness gate consumes.
+- Any change to gastric/absorption/LNAA magnitudes.
+- INFOODS tagname alignment (separate item, OPP-B3).
+
+## 11. Effort & sequencing
+
+- **Effort:** medium (1 new value type + 2 additive entity fields + extractor
+  branch + gate fold-in + ~9 fixture tests). No refactor of existing seams.
+- **Sequence:** unblocks **OPP-B2** (fuller amino-acid coverage reuses the same
+  `derivations`/`basis` plumbing) and strengthens **OPP-D2** (missingness suite
+  gains a provenance dimension).
+- **Dependencies:** none hard; Step 0 field-name verification gates coding.

--- a/lib/domain/usecases/model_assumption_registry.dart
+++ b/lib/domain/usecases/model_assumption_registry.dart
@@ -253,17 +253,21 @@ class ModelAssumptionRegistry {
     title: 'USDA FoodData Central — amino-acid nutrient fields availability',
     sourceType: ModelSourceType.officialLabel,
     mechanismSupported:
-        'USDA FDC exposes amino-acid nutrient numbers (505 leucine, 509 '
-        'phenylalanine, 511 valine, etc.). Documentation of upstream-data '
-        'availability for future LNAA extraction.',
+        'USDA FDC exposes amino-acid nutrient numbers using the verified '
+        'mapping 501 tryptophan, 502 threonine, 503 isoleucine, 504 leucine, '
+        '506 methionine, 508 phenylalanine, 509 tyrosine, 510 valine, '
+        '512 histidine. ParkinSUM\'s AminoAcidExtractor extracts this LNAA set '
+        '(number-priority, name fallback, mg->g normalization, partial flag) '
+        'and feeds the LNAA competition layer.',
     limitation:
-        'ParkinSUM\'s FDC importer does not currently extract these fields. '
-        'Documented for future calibration only.',
+        'Documents upstream-data availability + extraction only; not patient '
+        'calibration. Per-nutrient FDC derivation/sample-count provenance is '
+        'not yet captured (see docs/design/SPIKE_FDC_FOUNDATION_PROVENANCE.md).',
     citationText:
         'USDA Agricultural Research Service. FDC Nutrient Data OpenAPI '
         'Documentation. USDA FoodData Central.',
     evidenceLevel: ModelEvidenceLevel.mechanism,
-    lastReviewed: '2026-05-27',
+    lastReviewed: '2026-05-29',
   );
 
   static const ModelAssumption pareProteinRedistribution = ModelAssumption(

--- a/test/source_ref_traceability_test.dart
+++ b/test/source_ref_traceability_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkinsum_companion/domain/entities/amino_acid_profile.dart';
+import 'package:parkinsum_companion/domain/entities/gastric_emptying_parameters.dart';
+import 'package:parkinsum_companion/domain/entities/meal_composition.dart';
+import 'package:parkinsum_companion/domain/entities/protein_source.dart';
+import 'package:parkinsum_companion/domain/entities/time_axis_events.dart';
+import 'package:parkinsum_companion/domain/usecases/meal_composition_normalizer.dart';
+import 'package:parkinsum_companion/domain/usecases/mechanistic_conflict_engine.dart';
+import 'package:parkinsum_companion/domain/usecases/medication_entry_validator.dart';
+import 'package:parkinsum_companion/domain/usecases/model_assumption_registry.dart';
+import 'package:parkinsum_companion/domain/usecases/next_meal_scoring_parameters.dart';
+import 'package:parkinsum_companion/domain/usecases/time_axis_builder.dart';
+
+/// FAIR "Reusable/Interoperable" guard (OPP-F3 / scorecard S9): every evidence
+/// `sourceRef` emitted by the deterministic **mechanism layer** must resolve to
+/// a `ModelAssumptionRegistry` entry that carries citation text. This locks the
+/// evidence-linkage invariant — the engine cannot emit an unresolvable
+/// reference, and adding a new mechanism sourceRef without registering it fails
+/// here. Importer/source-authority identity refs (e.g. `src.ciqual`,
+/// `src.nhs.dmd`) are a separate namespace and are intentionally out of scope.
+void main() {
+  final validator = MedicationEntryValidator();
+  final builder = TimeAxisBuilder();
+  final engine = MechanisticConflictEngine();
+  final normalizer = MealCompositionNormalizer();
+
+  bool resolves(String ref) => ModelAssumptionRegistry.byId(ref) != null;
+
+  MedicationTimelineEvent levodopa(String releaseType) {
+    final v = validator.validate(RawMedicationEntry(
+      activeIngredients: const ['carbidopa', 'levodopa'],
+      drugProductVariant: 'synthetic:demo',
+      strength: 100,
+      unit: 'mg',
+      form: 'tablet',
+      route: 'oral',
+      releaseType: releaseType,
+      jurisdiction: 'US',
+      sourceDocId: 'synthetic:demo',
+    ));
+    return MedicationTimelineEvent(id: 'm', minute: 30, context: v.normalized!);
+  }
+
+  // Collect every sourceRef the mechanism layer emits across representative
+  // evaluations (IR + ER) and both data paths (actual amino-acid fields +
+  // protein-source proxy), plus the two literature-informed parameter sets.
+  Set<String> collectMechanismRefs() {
+    final refs = <String>{};
+
+    // Parameter sets (provenance-tagged weights).
+    refs.addAll(GastricEmptyingParameterSet.literatureInformedDefault()
+        .unionSourceRefs);
+    for (final w
+        in NextMealScoringParameterSet.literatureInformedDefault().all) {
+      refs.addAll(w.sourceRefs);
+    }
+
+    FoodComponent food(
+            {AminoAcidProfile? aa, required ProteinSourceType src}) =>
+        FoodComponent(
+          id: 'f',
+          name: 'f',
+          physicalForm: MealPhysicalForm.solid,
+          proteinGrams: 26,
+          fatGrams: 6,
+          fiberGrams: 1,
+          carbohydrateGrams: 5,
+          calories: 220,
+          portionGrams: 160,
+          sourceDocId: 'synthetic',
+          proteinSource: src,
+          aminoAcidProfile: aa,
+        );
+
+    void runEval(MedicationTimelineEvent med, FoodComponent component) {
+      final composition =
+          normalizer.normalize(mealId: 'c', components: [component]);
+      final ctx = builder.build(
+        now: DateTime.utc(2026, 1, 1, 8),
+        medicationInputs: [
+          MedicationTimelineInput(
+            id: med.id,
+            takenAt: DateTime.utc(2026, 1, 1, 8, 0)
+                .add(Duration(minutes: med.minute)),
+            medicationContext: validator.validate(const RawMedicationEntry(
+              activeIngredients: ['carbidopa', 'levodopa'],
+              drugProductVariant: 'synthetic:demo',
+              strength: 100,
+              unit: 'mg',
+              form: 'tablet',
+              route: 'oral',
+              releaseType: 'immediate',
+              jurisdiction: 'US',
+              sourceDocId: 'synthetic:demo',
+            )),
+          ),
+        ],
+        mealInputs: [
+          MealTimelineInput(
+            id: 'meal',
+            startedAt: DateTime.utc(2026, 1, 1, 8),
+            compositionId: composition.id,
+            physicalForm: MealPhysicalForm.solid,
+          ),
+        ],
+      );
+      final r = engine.evaluate(
+          context: ctx, mealCompositionsById: {composition.id: composition});
+      refs.addAll(r.sourceRefs);
+      refs.addAll(r.primaryEmptyingProfile?.sourceRefs ?? const []);
+      refs.addAll(r.absorptionOpportunityWindow?.sourceRefs ?? const []);
+      final comp = r.competitionTimeline;
+      if (comp != null) {
+        refs.addAll(comp.sourceRefs);
+        refs.addAll(comp.lnaaSummary?.sourceRefs ?? const []);
+      }
+    }
+
+    // Actual amino-acid fields path (IR).
+    runEval(
+      levodopa('immediate'),
+      food(
+        src: ProteinSourceType.meat,
+        aa: const AminoAcidProfile(
+          leucine: 2.1,
+          isoleucine: 1.2,
+          valine: 1.3,
+          phenylalanine: 1.0,
+          tyrosine: 0.9,
+          tryptophan: 0.3,
+          basis: 'per_serving',
+          sourceRefs: ['src.fdc.api.amino_acid_fields'],
+        ),
+      ),
+    );
+    // Protein-source proxy path (ER) — exercises protein_source registry refs.
+    runEval(levodopa('extended'), food(src: ProteinSourceType.meat));
+
+    return refs;
+  }
+
+  test('every mechanism-layer sourceRef resolves in ModelAssumptionRegistry',
+      () {
+    final refs = collectMechanismRefs();
+    expect(refs, isNotEmpty);
+    final unresolved = refs.where((r) => !resolves(r)).toList()..sort();
+    expect(unresolved, isEmpty,
+        reason: 'Unregistered mechanism sourceRef(s): $unresolved. Add a '
+            'ModelAssumption to model_assumption_registry.dart (and a row in '
+            'Bibliographies.md) for each.');
+  });
+
+  test('registry entries are well-formed (id, citation, review date)', () {
+    expect(ModelAssumptionRegistry.all, isNotEmpty);
+    for (final a in ModelAssumptionRegistry.all) {
+      expect(a.sourceId, startsWith('src.'),
+          reason: 'sourceId must be namespaced: ${a.sourceId}');
+      expect(a.citationText.trim(), isNotEmpty,
+          reason: '${a.sourceId} missing citation text');
+      expect(a.lastReviewed, isNotEmpty,
+          reason: '${a.sourceId} missing lastReviewed');
+      // byId must round-trip every entry.
+      expect(ModelAssumptionRegistry.byId(a.sourceId), isNotNull);
+    }
+  });
+
+  test('sourceIds are unique', () {
+    final ids = ModelAssumptionRegistry.all.map((a) => a.sourceId).toList();
+    expect(ids.toSet().length, ids.length,
+        reason: 'duplicate sourceId present');
+  });
+}


### PR DESCRIPTION
## Summary

Round-2 enhancement of the biomedical-engineering planning pass. The first pass
(merged in #26) surveyed sources and produced an opportunity map + backlog; this
round adds the **task-oriented engineering artifacts it lacked** and fills its
gaps — a code-grounded conformance baseline, an end-to-end traceability/risk
spine, and an implementation-ready design spike — plus one small, safe, tested
code fix. It stays strictly within ParkinSUM's educational-prototype boundary:
no medical advice, no clinical claims, no real patient data, no hidden dosage
defaults, synthetic/public-schema sources only.

## What's new (and which prior gap it closes)

- **`docs/BIOMEDICAL_STANDARDS_CONFORMANCE_SCORECARD.md`** — the prior pass never
  measured *where the code already stands*. This scores the current model vs
  HL7 FHIR R5 (MedicationKnowledge / NutritionIntake / Observation), FDA SPL +
  LOINC, USDA FDC provenance, FAO/INFOODS, RxNorm/ATC, OMOP, and FAIR — **with
  code evidence per row** (entity/usecase + field), an honest 3-level *inspired*
  scale (deliberately **no** "conformant/certified" ceiling), and a concrete
  delta per gap.
- **`docs/BIOMEDICAL_TRACEABILITY_MATRIX.md`** — opportunity ↔ source ↔ app
  layer ↔ required metadata ↔ **named test artifact** ↔ **named safety control**
  ↔ acceptance signal, a dependency/sequencing graph, and a 10-row **risk
  register** (likelihood / impact / mitigation), plus a per-type Definition of
  Done.
- **`docs/design/SPIKE_FDC_FOUNDATION_PROVENANCE.md`** — the top P1 item (OPP-B1)
  turned into an implementation-ready spec: step-0 field verification, additive
  data contract, parser + completeness-gate integration, a 9-case test matrix,
  acceptance criteria, rollout, safety analysis, and effort/sequencing.

## Code (small, safe, tested)

- **`test/source_ref_traceability_test.dart`** — FAIR Reusable/Interoperable
  guard: drives the real mechanism layer (conflict engine, gastric/absorption
  models, LNAA competition, scoring + gastric parameter sets) across IR/ER and
  actual-AA/proxy paths, and asserts **every emitted `sourceRef` resolves in
  `ModelAssumptionRegistry`** (+ registry integrity + uniqueness). Adding a
  mechanism sourceRef without registering it now fails CI.
- **`model_assumption_registry.dart`** — correct the stale
  `src.fdc.api.amino_acid_fields` entry: wrong nutrient numbers (505/509/511) →
  the verified set (504 leucine, 508 phenylalanine, 510 valine, …), and remove
  the now-false "does not currently extract these fields" claim.

## Honesty corrections

- `Bibliographies.md` — the prior pass asserted an FDA CDS **"29 Jan 2026"**
  date. Secondary sources disagree (Jan/Mar 2026) and FDA.gov could not be
  independently fetched here, so this now anchors on the **verifiable 2022
  final** and flags the 2026 revision as *reported, date not verified here*.
  Also records that FHIR NutritionIntake is patient-centric → any ParkinSUM
  mapping omits `subject` (no PHI).

## Safety boundary

Unchanged and reinforced: educational/non-clinical; no diagnosis/treatment/
timing/diet/CDS; dose passthrough only from explicit user entry; missing ≠ zero;
no live ingestion without opt-in + license review; AI never decides in the
conflict engine; standards work is "inspired, non-conformant" and PHI-free.

## Tests / verification

- `dart format` + `flutter analyze` clean.
- Full suite: **348 tests pass** (+3 from the traceability guard).
- Mechanistic replay: **35/35**.
- `npm run public:preflight`: **0 BLOCKER**.
- `node tool/firestore_rules_contract_check.mjs`: **13/13**.

## Remaining limitations

Exact USDA FDC OpenAPI field names (derivation/dataPoints/dataType) are
documented from the spec but JS-rendered pages were not fetchable here — re-verify
as step 0 of the FDC spike. The 2026 FDA CDS revision date is unconfirmed. C2
(iron) and C3 (MAO-B/tyramine) remain hard-blocked on verified citations. E1
(synthetic wearable/gait) remains deferred (large, must stay isolated +
non-diagnostic). Everything past Phase α stays in the backlog, not implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)