### PR TITLE
FDC provenance into completeness gate + fuller amino-acid coverage (B1 follow-up + B2)

### DIFF
--- a/docs/BIOMEDICAL_STANDARDS_CONFORMANCE_SCORECARD.md
+++ b/docs/BIOMEDICAL_STANDARDS_CONFORMANCE_SCORECARD.md
@@ -166,8 +166,12 @@ boundary.
   `aminoAcidConfidenceTier` and **widens uncertainty for any
   weaker-than-analytical tier** (mirrors partial handling); the replay report
   surfaces it. Missing derivation stays null (never raises confidence).
-- **Remaining delta (follow-up):** fold the tier into `FoodVariantMetadata` +
-  `MetadataCompletenessGate` for the candidate-food completeness grade.
+- **Follow-up shipped:** the tier is now folded into
+  `MetadataCompletenessGate.scoreCandidateFood` (a calculated/imputed/unknown
+  tier downgrades the candidate-food completeness grade and blocks the top
+  `complete` grade), and the FDC amino-acid block is captured more fully
+  (lysine/cystine/arginine added for representation completeness; competing-LNAA
+  math unchanged).
 - **Safety:** provenance only; never fabricate a sample count or method; missing
   → never higher confidence.
 

--- a/lib/data/datasources/remote/amino_acid_extractor.dart
+++ b/lib/data/datasources/remote/amino_acid_extractor.dart
@@ -16,10 +16,13 @@ class AminoAcidExtractor {
     '502': 'threonine',
     '503': 'isoleucine',
     '504': 'leucine',
+    '505': 'lysine',
     '506': 'methionine',
+    '507': 'cystine',
     '508': 'phenylalanine',
     '509': 'tyrosine',
     '510': 'valine',
+    '511': 'arginine',
     '512': 'histidine',
   };
 
@@ -38,7 +41,10 @@ class AminoAcidExtractor {
         tryptophan,
         histidine,
         methionine,
-        threonine;
+        threonine,
+        lysine,
+        cystine,
+        arginine;
     final ids = <String>[];
     // Basis follows the payload when present (FDC Foundation/SR are per_100g);
     // defaults to per_100g only when the payload does not declare one.
@@ -85,6 +91,15 @@ class AminoAcidExtractor {
         case 'threonine':
           threonine = valueG;
           break;
+        case 'lysine':
+          lysine = valueG;
+          break;
+        case 'cystine':
+          cystine = valueG;
+          break;
+        case 'arginine':
+          arginine = valueG;
+          break;
         default:
           return;
       }
@@ -129,6 +144,9 @@ class AminoAcidExtractor {
       histidine: histidine,
       methionine: methionine,
       threonine: threonine,
+      lysine: lysine,
+      cystine: cystine,
+      arginine: arginine,
       unit: unit,
       basis: basis,
       nutrientIds: List.unmodifiable(ids),
@@ -205,6 +223,10 @@ class AminoAcidExtractor {
     if (name.contains('histidine')) return 'histidine';
     if (name.contains('methionine')) return 'methionine';
     if (name.contains('threonine')) return 'threonine';
+    if (name.contains('lysine')) return 'lysine';
+    // Match cystine (the 507 dimer); avoid matching "cysteine".
+    if (name.contains('cystine')) return 'cystine';
+    if (name.contains('arginine')) return 'arginine';
     return null;
   }
 }

--- a/lib/domain/entities/amino_acid_profile.dart
+++ b/lib/domain/entities/amino_acid_profile.dart
@@ -34,6 +34,13 @@ class AminoAcidProfile {
   final double? histidine;
   final double? methionine;
   final double? threonine;
+  // Additional indispensable / conditionally-indispensable amino acids FDC
+  // publishes alongside the competing LNAAs. Captured for representation
+  // completeness (B2); NOT part of the levodopa-competing LNAA set, so they do
+  // not affect `competingLnaaGrams`.
+  final double? lysine;
+  final double? cystine;
+  final double? arginine;
   final String unit; // normalized unit, e.g. "g"
   final String basis; // e.g. "per_100g" / "per_serving"
   final List<String> nutrientIds; // upstream nutrient numbers (e.g. FDC 505)
@@ -62,6 +69,9 @@ class AminoAcidProfile {
     this.histidine,
     this.methionine,
     this.threonine,
+    this.lysine,
+    this.cystine,
+    this.arginine,
     this.unit = 'g',
     this.basis = 'per_100g',
     this.nutrientIds = const [],
@@ -134,6 +144,9 @@ class AminoAcidProfile {
       histidine: s(histidine),
       methionine: s(methionine),
       threonine: s(threonine),
+      lysine: s(lysine),
+      cystine: s(cystine),
+      arginine: s(arginine),
       unit: unit,
       basis: 'per_serving',
       nutrientIds: nutrientIds,
@@ -154,6 +167,9 @@ class AminoAcidProfile {
         'histidine': histidine,
         'methionine': methionine,
         'threonine': threonine,
+        'lysine': lysine,
+        'cystine': cystine,
+        'arginine': arginine,
         'unit': unit,
         'basis': basis,
         'nutrient_ids': nutrientIds,
@@ -179,6 +195,9 @@ class AminoAcidProfile {
       histidine: d('histidine'),
       methionine: d('methionine'),
       threonine: d('threonine'),
+      lysine: d('lysine'),
+      cystine: d('cystine'),
+      arginine: d('arginine'),
       unit: (json['unit'] as String?) ?? 'g',
       basis: (json['basis'] as String?) ?? 'per_100g',
       nutrientIds: (json['nutrient_ids'] as List<dynamic>? ?? const [])

--- a/lib/domain/usecases/metadata_completeness_gate.dart
+++ b/lib/domain/usecases/metadata_completeness_gate.dart
@@ -1,3 +1,4 @@
+import '../entities/nutrient_derivation.dart';
 import '../entities/source_metadata.dart';
 
 /// Deterministic metadata-completeness scoring. Composes with the existing
@@ -38,11 +39,26 @@ class MetadataCompletenessGate {
   MetadataCompletenessScore scoreCandidateFood(
     FoodVariantMetadata? meta, {
     required double nutrientCompleteness, // 0..1 from composition normalizer
+    NutrientConfidenceTier? nutrientConfidenceTier, // optional FDC provenance
   }) {
+    // FDC nutrient provenance (B1): a weaker-than-analytical tier
+    // (calculated/imputed/unknown) counts as one missing-equivalent, and an
+    // imputed/unknown tier blocks the top `complete` grade — values derived
+    // rather than measured are not treated as fully complete. A null tier
+    // (no FDC provenance) is inert: existing behavior is unchanged.
+    final weakProvenance = nutrientConfidenceTier != null &&
+        tierWidensUncertainty(nutrientConfidenceTier);
+    final blocksComplete =
+        nutrientConfidenceTier == NutrientConfidenceTier.imputedOrAssumed ||
+            nutrientConfidenceTier == NutrientConfidenceTier.unknown;
+
     if (meta == null) {
       // No provenance metadata; fall back to nutrient completeness only.
       if (nutrientCompleteness >= 0.99) {
-        return MetadataCompletenessScore.partial;
+        // A weak FDC tier still downgrades the no-meta best case.
+        return weakProvenance
+            ? MetadataCompletenessScore.insufficient
+            : MetadataCompletenessScore.partial;
       }
       if (nutrientCompleteness >= 0.5) {
         return MetadataCompletenessScore.insufficient;
@@ -54,8 +70,9 @@ class MetadataCompletenessGate {
       meta.sourceRefs.isEmpty,
       meta.jurisdiction.isEmpty,
       nutrientCompleteness < 0.5,
+      weakProvenance,
     ].where((m) => m).length;
-    if (missing == 0 && nutrientCompleteness >= 0.99) {
+    if (missing == 0 && nutrientCompleteness >= 0.99 && !blocksComplete) {
       return MetadataCompletenessScore.complete;
     }
     if (missing <= 1) return MetadataCompletenessScore.sufficient;

--- a/lib/domain/usecases/next_meal_recommendation_orchestrator.dart
+++ b/lib/domain/usecases/next_meal_recommendation_orchestrator.dart
@@ -869,6 +869,10 @@ class NextMealRecommendationOrchestrator {
       final completenessScore = _completenessGate.scoreCandidateFood(
         foodMeta,
         nutrientCompleteness: nutrientCompleteness,
+        // FDC nutrient provenance (B1 follow-up): a calculated/imputed/unknown
+        // amino-acid derivation tier downgrades the candidate-food completeness
+        // grade, not just the LNAA-layer uncertainty.
+        nutrientConfidenceTier: item.aminoAcidProfile?.aggregateConfidenceTier,
       );
       final completeness = _completenessGate.toWeight(completenessScore);
 

--- a/test/amino_acid_extraction_test.dart
+++ b/test/amino_acid_extraction_test.dart
@@ -68,11 +68,54 @@ void main() {
     expect(p.partial, isFalse);
   });
 
+  test('full FDC amino-acid block: captures lysine/cystine/arginine too (B2)',
+      () {
+    final payload = jsonDecode(
+        File('test/fixtures/importers/usda_fdc_amino_acids_full.json')
+            .readAsStringSync()) as Map<String, dynamic>;
+    final p = extractor.extractFromFdcStyle(payload);
+    expect(p, isNotNull);
+    // Fuller coverage: the non-competing indispensable AAs are now captured
+    // (mg → g), in addition to the six competing LNAAs.
+    expect(p!.lysine, closeTo(2.2, 1e-9)); // 2200 mg
+    expect(p.cystine, closeTo(0.35, 1e-9)); // 350 mg
+    expect(p.arginine, closeTo(1.6, 1e-9)); // 1600 mg
+    expect(p.histidine, closeTo(0.8, 1e-9));
+    // Competing-LNAA math is unchanged: only the six BCAA+aromatic AAs count.
+    const expectedCompeting =
+        2.1 + 1.2 + 1.3 + 1.0 + 0.9 + 0.3; // leu+ile+val+phe+tyr+trp
+    expect(p.competingLnaaGrams, closeTo(expectedCompeting, 1e-9));
+    // Lysine/cystine/arginine are NOT folded into the competing total.
+    expect(p.competingLnaaGrams, isNot(closeTo(expectedCompeting + 2.2, 1e-9)));
+    // Provenance from the full fixture (analytical) flows through.
+    expect(p.fdcDataType, 'Foundation');
+    expect(p.aggregateConfidenceTier, NutrientConfidenceTier.analytical);
+  });
+
+  test('only non-competing AAs present → null (proxy fallback) (B2)', () {
+    // Lysine/arginine present but no competing LNAA → no competition to model.
+    final p = extractor.extractFromFdcStyle({
+      'foodNutrients': [
+        {
+          'nutrient': {'number': '505', 'unitName': 'G'},
+          'amount': 2.0
+        },
+        {
+          'nutrient': {'number': '511', 'unitName': 'G'},
+          'amount': 1.5
+        },
+      ]
+    });
+    expect(p, isNull); // no competing LNAA → caller uses protein-source proxy
+  });
+
   test('missing unit marks the profile partial (not silently trusted)', () {
     final p = extractor.extractFromFdcStyle({
       'foodNutrients': [
         {
-          'nutrient': {'number': '507', 'name': 'Leucine'},
+          // 504 = leucine (a competing LNAA) with NO unitName → accepted
+          // provisionally and the profile is flagged partial.
+          'nutrient': {'number': '504', 'name': 'Leucine'},
           'amount': 2.1
         }
       ]

--- a/test/fixtures/importers/usda_fdc_amino_acids_full.json
+++ b/test/fixtures/importers/usda_fdc_amino_acids_full.json
@@ -1,0 +1,89 @@
+{
+  "fdcId": 234567,
+  "description": "Synthetic Foundation Food with full amino-acid block + derivation provenance (demo, mg units)",
+  "dataType": "Foundation",
+  "publicationDate": "2025-01-01",
+  "foodNutrients": [
+    {
+      "type": "FoodNutrient",
+      "nutrient": {"id": 1003, "number": "203", "name": "Protein", "unitName": "G"},
+      "amount": 26.0
+    },
+    {
+      "type": "FoodNutrient",
+      "nutrient": {"id": 1210, "number": "501", "name": "Tryptophan", "unitName": "MG"},
+      "amount": 300.0,
+      "dataPoints": 10,
+      "foodNutrientDerivation": {"code": "A", "description": "Analytical", "foodNutrientSource": {"code": "1"}}
+    },
+    {
+      "type": "FoodNutrient",
+      "nutrient": {"id": 1211, "number": "502", "name": "Threonine", "unitName": "MG"},
+      "amount": 1100.0,
+      "dataPoints": 10,
+      "foodNutrientDerivation": {"code": "A", "description": "Analytical"}
+    },
+    {
+      "type": "FoodNutrient",
+      "nutrient": {"id": 1212, "number": "503", "name": "Isoleucine", "unitName": "MG"},
+      "amount": 1200.0,
+      "dataPoints": 10,
+      "foodNutrientDerivation": {"code": "A", "description": "Analytical"}
+    },
+    {
+      "type": "FoodNutrient",
+      "nutrient": {"id": 1213, "number": "504", "name": "Leucine", "unitName": "MG"},
+      "amount": 2100.0,
+      "dataPoints": 10,
+      "foodNutrientDerivation": {"code": "A", "description": "Analytical"}
+    },
+    {
+      "type": "FoodNutrient",
+      "nutrient": {"id": 1214, "number": "505", "name": "Lysine", "unitName": "MG"},
+      "amount": 2200.0,
+      "dataPoints": 10,
+      "foodNutrientDerivation": {"code": "A", "description": "Analytical"}
+    },
+    {
+      "type": "FoodNutrient",
+      "nutrient": {"id": 1215, "number": "506", "name": "Methionine", "unitName": "MG"},
+      "amount": 700.0
+    },
+    {
+      "type": "FoodNutrient",
+      "nutrient": {"id": 1216, "number": "507", "name": "Cystine", "unitName": "MG"},
+      "amount": 350.0
+    },
+    {
+      "type": "FoodNutrient",
+      "nutrient": {"id": 1217, "number": "508", "name": "Phenylalanine", "unitName": "MG"},
+      "amount": 1000.0,
+      "dataPoints": 10,
+      "foodNutrientDerivation": {"code": "A", "description": "Analytical"}
+    },
+    {
+      "type": "FoodNutrient",
+      "nutrient": {"id": 1218, "number": "509", "name": "Tyrosine", "unitName": "MG"},
+      "amount": 900.0,
+      "dataPoints": 10,
+      "foodNutrientDerivation": {"code": "A", "description": "Analytical"}
+    },
+    {
+      "type": "FoodNutrient",
+      "nutrient": {"id": 1219, "number": "510", "name": "Valine", "unitName": "MG"},
+      "amount": 1300.0,
+      "dataPoints": 10,
+      "foodNutrientDerivation": {"code": "A", "description": "Analytical"}
+    },
+    {
+      "type": "FoodNutrient",
+      "nutrient": {"id": 1220, "number": "511", "name": "Arginine", "unitName": "MG"},
+      "amount": 1600.0
+    },
+    {
+      "type": "FoodNutrient",
+      "nutrient": {"id": 1221, "number": "512", "name": "Histidine", "unitName": "MG"},
+      "amount": 800.0
+    }
+  ]
+}

--- a/test/multi_jurisdiction_metadata_test.dart
+++ b/test/multi_jurisdiction_metadata_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:parkinsum_companion/data/datasources/remote/source_adapter_registry.dart';
+import 'package:parkinsum_companion/domain/entities/nutrient_derivation.dart';
 import 'package:parkinsum_companion/domain/entities/source_metadata.dart';
 import 'package:parkinsum_companion/domain/usecases/metadata_completeness_gate.dart';
 import 'package:parkinsum_companion/domain/usecases/source_authority_scorer.dart';
@@ -185,6 +186,56 @@ void main() {
       expect(gate.toWeight(MetadataCompletenessScore.complete),
           greaterThan(gate.toWeight(MetadataCompletenessScore.partial)));
       expect(gate.toWeight(MetadataCompletenessScore.invalid), 0.0);
+    });
+
+    FoodVariantMetadata foodMeta() => const FoodVariantMetadata(
+          foodVariantId: 'f',
+          sourceSystem: 'USDA_FDC',
+          jurisdiction: 'US',
+          language: 'und',
+          foodName: 'food',
+          basisType: 'per_100g',
+          servingUnit: null,
+          preparationState: 'unknown',
+          aminoAcidFieldsPresent: true,
+          extractionConfidence: null,
+          sourceRefs: ['src.usda.fdc.foundation_docs'],
+          limitationText: 'educational',
+        );
+
+    test('candidate food: full metadata + analytical tier → complete (B1)', () {
+      expect(
+        gate.scoreCandidateFood(foodMeta(),
+            nutrientCompleteness: 1.0,
+            nutrientConfidenceTier: NutrientConfidenceTier.analytical),
+        MetadataCompletenessScore.complete,
+      );
+    });
+
+    test('candidate food: imputed tier blocks complete (B1)', () {
+      final score = gate.scoreCandidateFood(foodMeta(),
+          nutrientCompleteness: 1.0,
+          nutrientConfidenceTier: NutrientConfidenceTier.imputedOrAssumed);
+      expect(score, isNot(MetadataCompletenessScore.complete));
+    });
+
+    test('candidate food: calculated tier downgrades vs analytical (B1)', () {
+      final analytical = gate.toWeight(gate.scoreCandidateFood(foodMeta(),
+          nutrientCompleteness: 1.0,
+          nutrientConfidenceTier: NutrientConfidenceTier.analytical));
+      final calculated = gate.toWeight(gate.scoreCandidateFood(foodMeta(),
+          nutrientCompleteness: 1.0,
+          nutrientConfidenceTier: NutrientConfidenceTier.calculated));
+      expect(calculated, lessThan(analytical));
+    });
+
+    test('candidate food: null tier is inert (backward compatible)', () {
+      // No FDC provenance supplied → unchanged from the pre-B1 grade.
+      expect(
+        gate.scoreCandidateFood(foodMeta(), nutrientCompleteness: 1.0),
+        gate.scoreCandidateFood(foodMeta(),
+            nutrientCompleteness: 1.0, nutrientConfidenceTier: null),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Phase β continuation of the FDC-provenance work: finishes the deferred **B1
follow-up** (fold the confidence tier into the candidate-food completeness
grade) and ships **B2** (fuller FDC amino-acid block coverage). Educational
prototype only; provenance signal, not clinical calibration; missing≠zero; no
live ingestion; dose passthrough unchanged.

## B1 follow-up — confidence tier → completeness grade

- `MetadataCompletenessGate.scoreCandidateFood` now takes an optional
  `nutrientConfidenceTier`. A weaker-than-analytical tier
  (calculated/imputed/unknown) counts as a missing-equivalent, and
  imputed/unknown **blocks the top `complete` grade**. A `null` tier is inert →
  fully backward compatible.
- The orchestrator threads `item.aminoAcidProfile.aggregateConfidenceTier` into
  the gate, so FDC provenance now downgrades the **candidate-food completeness**
  (scorecard S5's remaining delta), not just the LNAA-layer uncertainty.

## B2 — fuller FDC amino-acid block

- `AminoAcidProfile` + `AminoAcidExtractor` capture **lysine (505), cystine
  (507), arginine (511)** for representation completeness (additive, nullable).
  These are **not** competing LNAAs, so `competingLnaaGrams` and the competition
  math are unchanged.
- New realistic full-block fixture (mg units + analytical derivations) +
  number/name-fallback mapping (cystine matched, not cysteine).

## Tests

- Gate provenance cases: analytical→complete, imputed blocks complete,
  calculated downgrades vs analytical, null inert.
- Full-block extraction: lysine/cystine/arginine captured (mg→g), competing
  total unchanged, provenance flows; only-non-competing-AAs → null (proxy
  fallback). Fixed a stale test that used `507` as a throwaway (now correctly
  maps to cystine).
- `dart format` + `flutter analyze` clean; **368 tests pass**; mechanistic
  replay **35/35**; public preflight **0 BLOCKER**; firestore rules **13/13**.

## Safety boundary

Provenance/ordinal signal only; missing derivation never raises confidence; the
added amino acids are captured-for-representation and never alter the
competing-LNAA computation; no clinical calibration; no live ingestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)