### PR TITLE
Replay validation suites + enteral scenarios (D1/D2/C1)

### DIFF
--- a/lib/core/constants/mechanistic_replay_scenarios.dart
+++ b/lib/core/constants/mechanistic_replay_scenarios.dart
@@ -921,4 +921,126 @@ const List<MechanisticReplayScenario> mechanisticReplayScenarios = [
       ),
     ],
   ),
+
+  // --- D2: missingness stress suite (missing ≠ zero) ---------------------
+  MechanisticReplayScenario(
+    scenarioId: 's35_missing_calories_and_portion',
+    title: 'Protein present but calories + portion missing → lower composition '
+        'completeness + capped confidence (missing ≠ zero)',
+    expectedOutputType: ScenarioExpectedOutputType.educationalCaution,
+    expectedConfidenceCeiling: ConfidenceBand.medium,
+    medicationEntries: [_carbidopaLevodopaIr],
+    medicationMinutesOffsets: [MinutesOffset(30)],
+    meals: [
+      ScenarioMeal(
+        id: 'meal_missing_cal_portion',
+        offset: MinutesOffset(0),
+        physicalForm: MealPhysicalForm.solid,
+        components: [
+          FoodComponent(
+            id: 'food.missing_cal_portion',
+            name: 'high-protein item, calories+portion unknown (synthetic)',
+            physicalForm: MealPhysicalForm.solid,
+            proteinGrams: 30,
+            fatGrams: 6,
+            fiberGrams: 0,
+            carbohydrateGrams: 0,
+            calories: null, // missing — never treated as 0
+            portionGrams: null, // missing — never treated as 0
+            sourceDocId: 'synthetic:demo_food',
+          ),
+        ],
+      ),
+    ],
+    notes: 'Asserts missing calories/portion lower completeness + cap '
+        'confidence rather than fabricating 0.',
+  ),
+  MechanisticReplayScenario(
+    scenarioId: 's36_missing_all_macros_unknown_competition',
+    title:
+        'All macronutrients missing → unknown competition + insufficient/low '
+        'confidence (never fabricated)',
+    expectedOutputType: ScenarioExpectedOutputType.educationalInfo,
+    expectedConfidenceCeiling: ConfidenceBand.low,
+    medicationEntries: [_carbidopaLevodopaIr],
+    medicationMinutesOffsets: [MinutesOffset(30)],
+    meals: [
+      ScenarioMeal(
+        id: 'meal_all_missing',
+        offset: MinutesOffset(0),
+        physicalForm: MealPhysicalForm.unknown,
+        components: [
+          FoodComponent(
+            id: 'food.all_missing',
+            name: 'unknown food, no macros (synthetic)',
+            physicalForm: MealPhysicalForm.unknown,
+            proteinGrams: null,
+            fatGrams: null,
+            fiberGrams: null,
+            carbohydrateGrams: null,
+            calories: null,
+            portionGrams: null,
+            sourceDocId: 'synthetic:demo_food',
+          ),
+        ],
+      ),
+    ],
+    notes: 'Proves missing macros stay missing (unknown competition, lowered '
+        'confidence), never silently 0.',
+  ),
+
+  // --- C1: enteral feeding educational scenarios (non-prescriptive) ------
+  MechanisticReplayScenario(
+    scenarioId: 's37_enteral_continuous_low_protein',
+    title: 'Continuous enteral-style feed (low-protein liquid, sustained) — '
+        'educational context only, no schedule or timing advice',
+    expectedOutputType: ScenarioExpectedOutputType.noModeledInteraction,
+    medicationEntries: [_carbidopaLevodopaIr],
+    medicationMinutesOffsets: [MinutesOffset(30)],
+    meals: [
+      ScenarioMeal(
+        id: 'meal_enteral_continuous',
+        offset: MinutesOffset(0),
+        physicalForm: MealPhysicalForm.liquid,
+        components: [
+          FoodComponent(
+            id: 'food.enteral_continuous.synth',
+            name: 'continuous enteral feed, low protein (synthetic demo)',
+            physicalForm: MealPhysicalForm.liquid,
+            proteinGrams: 2,
+            fatGrams: 2,
+            fiberGrams: 0,
+            carbohydrateGrams: 12,
+            calories: 80,
+            portionGrams: 250,
+            sourceDocId: 'synthetic:demo_food',
+          ),
+        ],
+      ),
+    ],
+    notes: 'Enteral feeding changes protein delivery + gastric context. '
+        'Educational simulation only; not a feeding schedule or timing '
+        'recommendation. Review with a qualified professional.',
+  ),
+  MechanisticReplayScenario(
+    scenarioId: 's38_enteral_bolus_protein',
+    title: 'Bolus enteral-style feed (protein-containing liquid) near a dose — '
+        'educational context only, no schedule or timing advice',
+    // A liquid bolus empties quickly, so in this configuration the model finds
+    // no modeled interaction by the time the absorption window opens.
+    expectedOutputType: ScenarioExpectedOutputType.noModeledInteraction,
+    medicationEntries: [_carbidopaLevodopaIr],
+    medicationMinutesOffsets: [MinutesOffset(20)],
+    meals: [
+      ScenarioMeal(
+        id: 'meal_enteral_bolus',
+        offset: MinutesOffset(0),
+        physicalForm: MealPhysicalForm.liquid,
+        components: [_smoothieLiquidProtein],
+      ),
+    ],
+    notes: 'Bolus enteral feed modeled as a protein-containing liquid meal. '
+        'Educational simulation only; not a feeding schedule or timing '
+        'recommendation. Review with a qualified professional.',
+  ),
 ];

--- a/test/mechanistic_replay_runner_test.dart
+++ b/test/mechanistic_replay_runner_test.dart
@@ -127,6 +127,40 @@ void main() {
     expect(findBannedSubstrings(encoded), isEmpty);
   });
 
+  // D2 — missingness stress suite. Proves missing ≠ zero end-to-end: missing
+  // nutrient inputs lower composition completeness and confidence rather than
+  // being silently treated as 0.
+  test('missing calories/portion lowers completeness, never fabricated (D2)',
+      () {
+    final report = runner.run();
+    final c = report.cases
+        .firstWhere((c) => c.scenarioId == 's35_missing_calories_and_portion');
+    expect(c.mealContextCompleteness, lessThan(1.0));
+    expect(c.confidenceBand, isNot('high'));
+  });
+
+  test('all-macros-missing → unknown competition + insufficient/low (D2)', () {
+    final report = runner.run();
+    final c = report.cases.firstWhere(
+        (c) => c.scenarioId == 's36_missing_all_macros_unknown_competition');
+    expect(c.aminoAcidCompetitionBand, 'unknown');
+    expect(['insufficient', 'low'], contains(c.confidenceBand));
+  });
+
+  // C1 — enteral feeding educational scenarios stay non-prescriptive.
+  test('enteral scenarios run and stay non-prescriptive (C1)', () {
+    final report = runner.run();
+    final enteral = report.cases
+        .where((c) =>
+            c.scenarioId.startsWith('s37') || c.scenarioId.startsWith('s38'))
+        .toList();
+    expect(enteral.length, 2);
+    for (final c in enteral) {
+      expect(c.pass, isTrue, reason: '${c.scenarioId}: ${c.failureReason}');
+      expect(c.bannedPhraseHits, isEmpty);
+    }
+  });
+
   // Clinical-calibration guardrail regression (OPP-D4 / backlog #12). Locks in
   // the non-device educational boundary: every replay case must report it is
   // not clinically calibrated, must not enable live fetch by default, and must

--- a/test/scorer_source_quality_perturbation_test.dart
+++ b/test/scorer_source_quality_perturbation_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkinsum_companion/domain/entities/mechanistic_candidate_score.dart';
+import 'package:parkinsum_companion/domain/entities/meal_composition.dart';
+import 'package:parkinsum_companion/domain/entities/time_axis_events.dart';
+import 'package:parkinsum_companion/domain/usecases/mechanistic_next_meal_scorer.dart';
+import 'package:parkinsum_companion/domain/usecases/next_meal_scoring_parameters.dart';
+import 'package:parkinsum_companion/domain/usecases/medication_entry_validator.dart';
+import 'package:parkinsum_companion/domain/usecases/time_axis_builder.dart';
+
+/// D1 — source-quality perturbation. Demonstrates graceful degradation: a
+/// candidate's score moves monotonically with its provenance/authority metadata
+/// (better provenance never *hurts*), AND — the safety invariant — provenance
+/// can never let a worse-conflict candidate outrank a clearly better-conflict
+/// one. Conflict overlap stays dominant. Deterministic; tests only.
+void main() {
+  final scorer = MechanisticNextMealScorer();
+  final validator = MedicationEntryValidator();
+  final builder = TimeAxisBuilder();
+
+  TimeAxisConflictContext ctx() {
+    final now = DateTime.utc(2026, 1, 1, 8);
+    final v = validator.validate(const RawMedicationEntry(
+      activeIngredients: ['carbidopa', 'levodopa'],
+      drugProductVariant: 'synthetic:demo',
+      strength: 100,
+      unit: 'mg',
+      form: 'tablet',
+      route: 'oral',
+      releaseType: 'immediate',
+      jurisdiction: 'US',
+      sourceDocId: 'synthetic:demo',
+    ));
+    return builder.build(
+      now: now,
+      medicationInputs: [
+        MedicationTimelineInput(
+            id: 'm',
+            takenAt: now.add(const Duration(minutes: 30)),
+            medicationContext: v),
+      ],
+      mealInputs: const [],
+      userDefinedWindow: UserDefinedMealWindow(
+        window: TimelineWindow(
+          startMinute: dateTimeToMinute(now) + 60,
+          endMinute: dateTimeToMinute(now) + 120,
+        ),
+        source: 'test',
+      ),
+    );
+  }
+
+  CandidateFood food(String id, {required double protein}) => CandidateFood(
+        id: id,
+        name: id,
+        regionalFoodLibraryRef: 'synthetic',
+        declaredPhysicalForm: MealPhysicalForm.solid,
+        components: [
+          FoodComponent(
+            id: id,
+            name: id,
+            physicalForm: MealPhysicalForm.solid,
+            proteinGrams: protein,
+            fatGrams: 2,
+            fiberGrams: 1,
+            carbohydrateGrams: 20,
+            calories: 150,
+            portionGrams: 150,
+            sourceDocId: 'synthetic',
+          ),
+        ],
+      );
+
+  CandidateMetadata meta({
+    required double authority,
+    required double provenance,
+    required double completeness,
+  }) =>
+      CandidateMetadata(
+        completeness: completeness,
+        authorityScore: authority,
+        jurisdictionMatchScore: authority,
+        provenanceQuality: provenance,
+        jurisdiction: 'US',
+      );
+
+  double scoreOf(List<MechanisticCandidateScore> s, String id) =>
+      s.firstWhere((e) => e.candidateFoodId == id).finalCandidateScore;
+
+  test('higher source quality never lowers a candidate score (monotonic)', () {
+    final c = food('a', protein: 5);
+    final low = scorer.score(
+      baseContext: ctx(),
+      baseMealCompositionsById: const {},
+      candidates: [c],
+      candidateMetadata: {
+        'a': meta(authority: 0.1, provenance: 0.1, completeness: 0.3)
+      },
+    );
+    final high = scorer.score(
+      baseContext: ctx(),
+      baseMealCompositionsById: const {},
+      candidates: [c],
+      candidateMetadata: {
+        'a': meta(authority: 0.9, provenance: 0.9, completeness: 1.0)
+      },
+    );
+    expect(scoreOf(high, 'a'), greaterThanOrEqualTo(scoreOf(low, 'a')));
+  });
+
+  test('provenance influence is bounded below the conflict-overlap weight', () {
+    // Two IDENTICAL-composition candidates differing ONLY in source-quality
+    // metadata (best vs worst). Provenance breaks the tie in the better
+    // candidate's favour, but the score gap it can create must stay bounded by
+    // the combined provenance weights — which the conflict-dominant invariant
+    // keeps below the conflict-overlap weight. So provenance is a bounded
+    // refinement, never the dominant term.
+    final best = food('best', protein: 8);
+    final worst = food('worst', protein: 8); // identical composition
+    final scores = scorer.score(
+      baseContext: ctx(),
+      baseMealCompositionsById: const {},
+      candidates: [best, worst],
+      candidateMetadata: {
+        'best': meta(authority: 1.0, provenance: 1.0, completeness: 1.0),
+        'worst': meta(authority: 0.0, provenance: 0.0, completeness: 0.0),
+      },
+    );
+    final gap = scoreOf(scores, 'best') - scoreOf(scores, 'worst');
+    final params = NextMealScoringParameterSet.literatureInformedDefault();
+    // Better provenance ranks at least as high (tie-break direction).
+    expect(gap, greaterThanOrEqualTo(0.0));
+    // ...but the provenance-driven swing cannot exceed the summed provenance
+    // weights, which are strictly below the dominant conflict-overlap weight.
+    expect(gap, lessThanOrEqualTo(params.provenanceWeightSum + 1e-9));
+    expect(params.provenanceWeightSum, lessThan(params.conflictOverlap.value));
+  });
+
+  test('deterministic: identical inputs → identical scores', () {
+    final c = food('a', protein: 10);
+    final m = {'a': meta(authority: 0.5, provenance: 0.5, completeness: 0.8)};
+    final r1 = scorer.score(
+        baseContext: ctx(),
+        baseMealCompositionsById: const {},
+        candidates: [c],
+        candidateMetadata: m);
+    final r2 = scorer.score(
+        baseContext: ctx(),
+        baseMealCompositionsById: const {},
+        candidates: [c],
+        candidateMetadata: m);
+    expect(scoreOf(r1, 'a'), scoreOf(r2, 'a'));
+  });
+}


### PR DESCRIPTION
## Summary

Phase β validation hardening — **pure tests + synthetic scenarios, no model
behavior change**. Educational prototype only; missing≠zero; non-prescriptive.

## D2 — missingness stress suite
- `s35` (protein present, calories + portion **missing**) → composition
  completeness < 1.0 and confidence capped — never fabricated as 0.
- `s36` (all macros missing) → **unknown** competition band + insufficient/low
  confidence. Proves "missing ≠ zero" end-to-end.

## D1 — source-quality perturbation (scorer-level)
The replay runner does not thread `CandidateMetadata`, so this is a focused
scorer test:
- better provenance **never lowers** a score (monotonic);
- for identical-composition candidates, the provenance-driven score gap is
  **bounded by the summed provenance weights**, which the conflict-dominant
  invariant keeps strictly below the conflict-overlap weight → provenance is a
  bounded refinement, never the dominant term;
- deterministic (identical inputs → identical scores).

> Note: I initially wrote a stronger "provenance can never flip ranking"
> assertion; it was *wrong* — `conflictRemainsDominant` guarantees the weight
> ordering, not that conflict overrides provenance regardless of gap size (when
> two candidates' conflict overlaps are close, provenance legitimately breaks
> the tie). The committed test asserts the accurate, bounded invariant.

## C1 — enteral feeding educational scenarios
- `s37` continuous low-protein liquid feed; `s38` bolus protein liquid feed.
- Both carry explicit "educational only, not a schedule/timing recommendation,
  review with a qualified professional" notes and pass the banned-phrase scan.

## Tests / verification
`dart format` + `flutter analyze` clean; **368 tests pass**; mechanistic replay
**39/39**; public preflight **0 BLOCKER**; firestore rules **13/13**.

## Safety boundary
Tests/scenarios only; no behavior change; synthetic data; non-prescriptive;
missing≠zero; conflict-dominant invariant reaffirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)