### PR TITLE
Add section-level medication provenance and release extraction

### DIFF
--- a/docs/BIOMEDICAL_STANDARDS_CONFORMANCE_SCORECARD.md
+++ b/docs/BIOMEDICAL_STANDARDS_CONFORMANCE_SCORECARD.md
@@ -54,7 +54,7 @@ of this scorecard is 🟢 *Inspired-Aligned*.
 | S1 | HL7 FHIR R5 **MedicationKnowledge** | 🟡 | 🟢 | OPP-F1 | #8 |
 | S2 | HL7 FHIR R5 **NutritionIntake** | 🟢 | 🟢 | OPP-F2 ✅ | #9 (**shipped**) |
 | S3 | HL7 FHIR R5 **Observation** (nutrient) | ⬜ | 🟡 | OPP-F2 | #9 |
-| S4 | **FDA SPL** + LOINC section identity | 🟡 | 🟢 | OPP-A1 | #1 |
+| S4 | **FDA SPL** + LOINC section identity | 🟢 | 🟢 | OPP-A1/A2 ✅ | #1 (**bridge shipped**) |
 | S5 | **USDA FDC** FoodNutrient provenance (derivation/dataPoints/dataType) | 🟢 | 🟢 | OPP-B1 ✅ / OPP-B2 | #2 + spike (**B1 shipped**) |
 | S6 | **FAO/INFOODS** component identifiers (tagnames) | ⬜ | 🟡 | OPP-B3 | (map) |
 | S7 | **RxNorm / ATC** identity coding | ⬜ | 🟡 | OPP-A3 | (map) |
@@ -135,21 +135,32 @@ boundary.
   S5). Lower priority than S2.
 - **Safety:** representation only.
 
-### S4 — FDA SPL + LOINC section identity — 🟡 Inspired-Partial
+### S4 — FDA SPL + LOINC section identity — 🟢 Inspired-Aligned (A1/A2 shipped)
 
 - **Standard:** SPL documents and their sections are identified by **LOINC
   document/section codes**; DailyMed SPL Web Services v2 expose `/spls/{SETID}`
   and `/spls/{SETID}/history` (set id, version, effective date).
-- **Current state (evidence):** `DrugProductVariantMetadata.labelSection` is a
-  single free-text string; there is no LOINC section code, no `setId`, no
-  `labelVersion`, no `effectiveDate`. Adapters are `fixture_tested` (see
+- **Current state (evidence):** the CDSS record layer
+  (`DrugLabelSectionRecord`: `sectionId`/`sectionKey`/`sectionTitle`/
+  `sourceDocId`; `DrugProductVariantRecord`: `releaseType`/`route`/`dosageForm`/
+  `labelVersion`) is now **bridged into the mechanistic context** via
+  `MedicationContextMetadataAdapter` →
+  `MechanisticMedicationMetadata.labelSectionRefs` →
+  `NormalizedMedicationContext.metadata`. The per-event trace and replay report
+  surface `medication_source_system`, `medication_source_doc_id`,
+  `medication_source_version`, `medication_label_section_ref_count`,
+  `medication_release_type` + `medication_release_type_source`, and combination
+  components (carbidopa + levodopa). The engine can therefore cite the exact
+  source section/version backing a product. Adapters remain `fixture_tested`
+  (synthetic CDSS-style fixtures, not live ingestion; see
   `docs/SOURCE_ACCESS_AND_LICENSES.md`).
-- **Delta to 🟢:** capture `sectionLoincCode`, `setId`, `labelVersion`,
-  `effectiveDate` from the SPL fixture parser; surface in the medication-context
-  trace so the engine can cite the exact section. Missing → recorded missing,
-  never guessed.
-- **Safety:** metadata/provenance only; mechanism evidence still requires
-  explicit label text.
+- **Residual (not blocking 🟢):** the bridge carries section *key/title/id* and
+  source-doc version, not a discrete LOINC section **code** field; populating a
+  `sectionLoincCode` from a live SPL parser remains future work. Missing
+  provenance → recorded missing (lower completeness), never guessed.
+- **Safety:** metadata/provenance only; product strength never becomes an intake
+  dose (the analyzable dose still comes solely from the user-facing dosage
+  path); mechanism evidence still requires explicit label text.
 
 ### S5 — USDA FDC FoodNutrient provenance — 🟢 Inspired-Aligned (B1 shipped)
 

--- a/docs/CONFLICT_ENGINE_MODEL.md
+++ b/docs/CONFLICT_ENGINE_MODEL.md
@@ -209,7 +209,14 @@ Per the cited DailyMed labeling and PK reviews:
 
 - Absorption opportunity starts after a short post-dose lag.
 - Immediate-release: lag ≈ 5 min, duration ≈ 90 min.
-- Extended/controlled-release: lag ≈ 30 min, duration ≈ 240 min.
+- Extended / controlled / **delayed** release: wider window (lag ≈ 30 min,
+  duration ≈ 240 min).
+- **Unknown / unspecified release type**: the window defaults to the
+  immediate-release shape but the **uncertainty band is widened one step** and
+  the assumption `ldopa.absorption.release_type_unknown_limited` is recorded —
+  release-specific interpretation is treated as limited. Release type is taken
+  from the (source-backed) medication context and is **never inferred from
+  dose**.
 - A high residual stomach load at the medication time shifts the window
   forward and widens it. Delay likelihood band reflects this:
   - `low` (residual ≤ 0.4)
@@ -218,6 +225,18 @@ Per the cited DailyMed labeling and PK reviews:
   - `unknown` (no overlapping meal profile available)
 
 This is an educational simulation, not a PK prediction.
+
+### 12b. Medication section provenance in the per-event trace
+
+When a `NormalizedMedicationContext` carries `metadata`
+(`MechanisticMedicationMetadata`, bridged from CDSS records — see
+`docs/IMPORTER_METADATA_FLOW.md` §14d), each `MechanisticPerEventTrace`
+additionally surfaces the medication provenance: `releaseTypeSource`,
+`doseForm`, `route`, `levodopaComponentPresent`, `combinationComponentCount`,
+`labelSectionRefCount`, `medicationSourceSystem`, `medicationSourceDocId`, and
+`medicationMetadataCompleteness`. This is **provenance/traceability only** — it
+never contributes to the dose, and the intake dose still comes solely from the
+user-facing dosage path (product/component strength never fabricates a dose).
 
 ### 12a. Absorption opportunity openness profile
 

--- a/docs/IMPORTER_METADATA_FLOW.md
+++ b/docs/IMPORTER_METADATA_FLOW.md
@@ -239,6 +239,35 @@ treatment) and never constructs a Patient/Reference/Encounter
 true` and the shared non-prescriptive safety copy. It implies **no clinical
 interoperability** and supports no diagnosis, treatment, or patient monitoring.
 
+## 14d. CDSS → mechanistic medication-context bridge (section provenance)
+
+The live importers already extract label sections, release type, dose form,
+route, and combination components into the CDSS-record layer
+(`DrugProductVariantRecord` + `DrugLabelSectionRecord`). The mechanistic path
+previously collapsed that into a thin context and lost the provenance.
+`MedicationContextMetadataAdapter.fromCdssMetadata(...)` now **bridges** the
+canonical `DrugProductVariantMetadata` (+ any `DrugLabelSectionRecord`s) into a
+`MechanisticMedicationMetadata` object that is attached to
+`NormalizedMedicationContext.metadata`. It carries:
+
+- combination **components** (e.g. carbidopa + levodopa) with role; per-component
+  strength is left **null when a product reports only a single product
+  strength** (recorded missing, never fabricated);
+- **label section refs** (`LabelSectionRef`: sourceSystem/sourceDocId/version/
+  sectionId/key/title/effectiveDate/sourceRefs) — multiple per product;
+- **release type + releaseTypeSource** (`structured_variant_metadata` when
+  known, `unknown` otherwise — never inferred from dose);
+- dose form, route, source-doc id/version, jurisdiction, language, sourceRefs,
+  and a metadata-completeness grade (lowered when section provenance is absent —
+  not a fake official trace).
+
+This is **fixture-tested, not live ingestion**, and **provenance only**: it is
+never read as an intake dose. The intake dose still comes solely from the
+user-facing dosage path; a unitless user dosage stays insufficient even when
+rich product-strength metadata is attached. Levodopa-specific scoring uses the
+levodopa component identity while preserving the other components. Section
+provenance improves traceability, **not clinical validity**.
+
 ## 15. Future work
 
 - Live network ingestion + real schema parsers for **dm+d** and **EU national

--- a/docs/REPLAY_RUNNER.md
+++ b/docs/REPLAY_RUNNER.md
@@ -83,17 +83,27 @@ Per-case report row (see `MechanisticReplayCaseReport`):
 | `top_nutrition_adequacy_contribution` | Top candidate's nutrition-adequacy proxy contribution. |
 | `top_source_authority_score` / `top_jurisdiction_match_score` | Top candidate provenance scores. |
 | `top_candidate_source_system` | Source system of the top candidate. |
+| `medication_source_system` / `medication_source_doc_id` / `medication_source_version` | Medication provenance bridged from CDSS metadata (fixture-tested), when attached. |
+| `medication_label_section_ref_count` | Number of label-section refs backing the product (0 when none → lower completeness, not a fake trace). |
+| `medication_release_type` / `medication_release_type_source` | Release type + where it came from (`structured_variant_metadata` / `unknown`; never inferred from dose). |
+| `medication_dose_form` / `medication_route` | Source-backed dose form + route. |
+| `medication_combination_components` | Component ingredient names (e.g. carbidopa + levodopa) — combination products preserve all components. |
+| `dosage_source` | Where the analyzable dose came from (`user_or_variant_strength` / `insufficient` / `none`). Product metadata never fabricates a dose. |
+| `medication_metadata_completeness` / `medication_missing_fields` | Medication-context completeness grade + recorded missing provenance fields. |
 | `pass` / `failureReason` | Bool + diagnostic message. |
 
-The suite contains **31 scenarios** (s01–s31), covering catalog-backed
-medication context, missing-field downgrades, invalid medication, daytime
-high-overlap vs evening low-overlap protein behavior, zero-vs-moderate
+The suite contains **41 scenarios** (s01–s40, including s04b), covering
+catalog-backed medication context, missing-field downgrades, invalid medication,
+daytime high-overlap vs evening low-overlap protein behavior, zero-vs-moderate
 protein in low-overlap windows, the no-window fallback, amino-acid
 actual-fields vs protein-source-proxy modes (s22/s23), additional invalid
 medication forms (s24/s25), mechanistic-primary overwriting the legacy
-order (s26), and production-readiness coverage (s27–s31: amino-acid food in a
+order (s26), production-readiness coverage (s27–s31: amino-acid food in a
 far window, mixed-mode candidate sets, invalid-with-window, no-window
-fallback visibility, daytime-overlap amino-acid food). Report rows
+fallback visibility, daytime-overlap amino-acid food), missingness/uncertainty
+and enteral coverage (s32–s38), and **medication section-provenance bridging**
+(s39 SPL IR carbidopa/levodopa with label-section refs; s40 SPL ER) where CDSS
+drug metadata reaches the mechanistic context without fabricating a dose. Report rows
 additionally carry `amino_acid_data_mode`, `amino_acid_nutrient_ids`,
 `source_implementation_status`, `live_fetch_enabled`, `license_review_status`,
 `can_support_mechanism_evidence_alone`, and `clinical_calibration_status`

--- a/lib/core/constants/mechanistic_replay_scenarios.dart
+++ b/lib/core/constants/mechanistic_replay_scenarios.dart
@@ -1,6 +1,7 @@
 import '../../domain/entities/amino_acid_profile.dart';
 import '../../domain/entities/mechanistic_conflict_result.dart';
 import '../../domain/entities/meal_composition.dart';
+import '../../domain/entities/medication_source_metadata.dart';
 import '../../domain/entities/time_axis_events.dart';
 import '../../domain/usecases/medication_entry_validator.dart';
 import '../../domain/usecases/mechanistic_next_meal_scorer.dart';
@@ -88,6 +89,121 @@ const _carbidopaLevodopaIr = RawMedicationEntry(
 const _bareNumeric = RawMedicationEntry(freeText: '100');
 const _levodopa100NoUnit = RawMedicationEntry(freeText: 'levodopa 100');
 const _slashedNoUnit = RawMedicationEntry(freeText: '25/100');
+
+// --- CDSS→mechanistic-context bridge demo metadata (synthetic) -------------
+// Section-backed carbidopa/levodopa product provenance bridged into the
+// mechanistic context. Provenance only — never a dose. Per-component strength
+// is left null for the combination (single product strength only).
+const _carbidopaLevodopaComponents = [
+  MedicationComponent(
+    ingredientName: 'carbidopa',
+    role: 'decarboxylase_inhibitor',
+    sourceRefs: ['src.dailymed.sinemet.label'],
+  ),
+  MedicationComponent(
+    ingredientName: 'levodopa',
+    role: 'active',
+    sourceRefs: ['src.dailymed.sinemet.label'],
+  ),
+];
+
+const _splIrMetadata = MechanisticMedicationMetadata(
+  sourceSystem: 'DailyMed',
+  sourceDocId: 'synthetic:spl:carbidopa-levodopa-ir',
+  sourceDocVersion: 'spl_demo_v1',
+  effectiveDate: '2025-01-01',
+  jurisdiction: 'US',
+  language: 'en',
+  drugProductVariantId: 'synthetic:cl-ir',
+  doseForm: 'tablet',
+  route: 'oral',
+  releaseType: 'immediate',
+  releaseTypeSource: 'structured_variant_metadata',
+  components: _carbidopaLevodopaComponents,
+  labelSectionRefs: [
+    LabelSectionRef(
+      sourceSystem: 'DailyMed',
+      sourceDocId: 'synthetic:spl:carbidopa-levodopa-ir',
+      sourceDocVersion: 'spl_demo_v1',
+      jurisdiction: 'US',
+      language: 'en',
+      sectionId: 'sec-dosage',
+      sectionKey: 'dosage_and_administration',
+      sectionTitle: 'Dosage and Administration',
+      effectiveDate: '2025-01-01',
+      parserName: 'cdss_drug_label_section_record',
+      sourceRefs: ['src.dailymed.sinemet.label'],
+    ),
+  ],
+  sourceRefs: ['src.dailymed.sinemet.label'],
+  limitationText: 'Synthetic SPL-style demo metadata. Educational only.',
+  metadataCompleteness: 'complete',
+);
+
+const _splErMetadata = MechanisticMedicationMetadata(
+  sourceSystem: 'DailyMed',
+  sourceDocId: 'synthetic:spl:carbidopa-levodopa-er',
+  sourceDocVersion: 'spl_demo_v1',
+  effectiveDate: '2025-01-01',
+  jurisdiction: 'US',
+  language: 'en',
+  drugProductVariantId: 'synthetic:cl-er',
+  doseForm: 'extended-release tablet',
+  route: 'oral',
+  releaseType: 'extended',
+  releaseTypeSource: 'structured_variant_metadata',
+  components: _carbidopaLevodopaComponents,
+  labelSectionRefs: [
+    LabelSectionRef(
+      sourceSystem: 'DailyMed',
+      sourceDocId: 'synthetic:spl:carbidopa-levodopa-er',
+      sourceDocVersion: 'spl_demo_v1',
+      jurisdiction: 'US',
+      language: 'en',
+      sectionId: 'sec-dosage-er',
+      sectionKey: 'dosage_and_administration',
+      sectionTitle: 'Dosage and Administration (Extended Release)',
+      effectiveDate: '2025-01-01',
+      parserName: 'cdss_drug_label_section_record',
+      sourceRefs: ['src.dailymed.sinemet.extended.label'],
+    ),
+  ],
+  sourceRefs: ['src.dailymed.sinemet.extended.label'],
+  limitationText: 'Synthetic SPL-style demo metadata. Educational only.',
+  metadataCompleteness: 'complete',
+);
+
+/// IR carbidopa/levodopa with structured product metadata + section refs.
+/// User-entered dose (strength+unit) stays the only dose source.
+const _carbidopaLevodopaIrWithMetadata = RawMedicationEntry(
+  activeIngredients: ['carbidopa', 'levodopa'],
+  drugProductVariant: 'synthetic:carbidopa-levodopa-25-100-ir-tablet',
+  strength: 100,
+  unit: 'mg',
+  form: 'tablet',
+  route: 'oral',
+  releaseType: 'immediate',
+  jurisdiction: 'US',
+  sourceDocId: 'synthetic:spl:carbidopa-levodopa-ir',
+  labelSection: 'dosage_and_administration',
+  extractionConfidence: 0.95,
+  medicationMetadata: _splIrMetadata,
+);
+
+const _carbidopaLevodopaErWithMetadata = RawMedicationEntry(
+  activeIngredients: ['carbidopa', 'levodopa'],
+  drugProductVariant: 'synthetic:carbidopa-levodopa-50-200-er-tablet',
+  strength: 200,
+  unit: 'mg',
+  form: 'extended-release tablet',
+  route: 'oral',
+  releaseType: 'extended',
+  jurisdiction: 'US',
+  sourceDocId: 'synthetic:spl:carbidopa-levodopa-er',
+  labelSection: 'dosage_and_administration',
+  extractionConfidence: 0.95,
+  medicationMetadata: _splErMetadata,
+);
 
 const FoodComponent _oatmealSolidSmall = FoodComponent(
   id: 'food.oatmeal.synth',
@@ -1042,5 +1158,45 @@ const List<MechanisticReplayScenario> mechanisticReplayScenarios = [
     notes: 'Bolus enteral feed modeled as a protein-containing liquid meal. '
         'Educational simulation only; not a feeding schedule or timing '
         'recommendation. Review with a qualified professional.',
+  ),
+
+  // --- A1/A2: CDSS→mechanistic medication section-provenance bridge -------
+  MechanisticReplayScenario(
+    scenarioId: 's39_spl_ir_section_provenance',
+    title: 'SPL-style IR carbidopa/levodopa with section provenance + 2 '
+        'components bridged into the mechanistic context (educational)',
+    expectedOutputType: ScenarioExpectedOutputType.educationalCaution,
+    expectedSeverityFloor: SeverityBand.moderate,
+    medicationEntries: [_carbidopaLevodopaIrWithMetadata],
+    medicationMinutesOffsets: [MinutesOffset(30)],
+    meals: [
+      ScenarioMeal(
+        id: 'meal_chicken_spl_ir',
+        offset: MinutesOffset(0),
+        physicalForm: MealPhysicalForm.solid,
+        components: [_chickenSteakProtein],
+      ),
+    ],
+    notes: 'Label section refs + combination components + release-type source '
+        'reach the per-event trace + report. Dose still from user/variant '
+        'strength; product metadata never fabricates a dose.',
+  ),
+  MechanisticReplayScenario(
+    scenarioId: 's40_spl_er_section_provenance',
+    title: 'SPL-style ER carbidopa/levodopa with section provenance → wider '
+        'absorption window from source-backed release type (educational)',
+    expectedOutputType: ScenarioExpectedOutputType.educationalCaution,
+    medicationEntries: [_carbidopaLevodopaErWithMetadata],
+    medicationMinutesOffsets: [MinutesOffset(30)],
+    meals: [
+      ScenarioMeal(
+        id: 'meal_chicken_spl_er',
+        offset: MinutesOffset(0),
+        physicalForm: MealPhysicalForm.solid,
+        components: [_chickenSteakProtein],
+      ),
+    ],
+    notes: 'Extended-release product metadata widens the modeled absorption '
+        'window; release-type source recorded as structured_variant_metadata.',
   ),
 ];

--- a/lib/domain/entities/mechanistic_conflict_result.dart
+++ b/lib/domain/entities/mechanistic_conflict_result.dart
@@ -106,6 +106,18 @@ class MechanisticPerEventTrace {
   final List<String> sourceRefs;
   final List<String> uncertaintyReasons;
 
+  // Per-event medication provenance bridged from CDSS metadata (additive;
+  // null/0 when no metadata was attached). Provenance only — never a dose.
+  final String? releaseTypeSource;
+  final String? doseForm;
+  final String? route;
+  final bool levodopaComponentPresent;
+  final int combinationComponentCount;
+  final int labelSectionRefCount;
+  final String? medicationSourceSystem;
+  final String? medicationSourceDocId;
+  final String? medicationMetadataCompleteness;
+
   const MechanisticPerEventTrace({
     required this.medicationEventId,
     required this.medicationMinute,
@@ -117,6 +129,15 @@ class MechanisticPerEventTrace {
     required this.isPrimary,
     required this.sourceRefs,
     required this.uncertaintyReasons,
+    this.releaseTypeSource,
+    this.doseForm,
+    this.route,
+    this.levodopaComponentPresent = false,
+    this.combinationComponentCount = 0,
+    this.labelSectionRefCount = 0,
+    this.medicationSourceSystem,
+    this.medicationSourceDocId,
+    this.medicationMetadataCompleteness,
   });
 
   Map<String, dynamic> toJson() => {
@@ -130,6 +151,15 @@ class MechanisticPerEventTrace {
         'is_primary': isPrimary,
         'source_refs': sourceRefs,
         'uncertainty_reasons': uncertaintyReasons,
+        'release_type_source': releaseTypeSource,
+        'dose_form': doseForm,
+        'route': route,
+        'levodopa_component_present': levodopaComponentPresent,
+        'combination_component_count': combinationComponentCount,
+        'label_section_ref_count': labelSectionRefCount,
+        'medication_source_system': medicationSourceSystem,
+        'medication_source_doc_id': medicationSourceDocId,
+        'medication_metadata_completeness': medicationMetadataCompleteness,
       };
 }
 

--- a/lib/domain/entities/medication_entry_validation.dart
+++ b/lib/domain/entities/medication_entry_validation.dart
@@ -12,6 +12,8 @@
 /// runtime context.
 library;
 
+import 'medication_source_metadata.dart';
+
 /// Status of a medication-entry validation pass.
 enum MedicationContextValidity {
   /// All required catalog-backed fields are present and units are explicit.
@@ -66,6 +68,12 @@ class NormalizedMedicationContext {
   final double? extractionConfidence;
   final String limitationText;
 
+  /// Engine-facing medication provenance bridged from the CDSS layer (label
+  /// section refs, combination components, release-type source, source-doc
+  /// trace). PROVENANCE ONLY — never read as an intake dose. Null when no
+  /// CDSS metadata was attached.
+  final MechanisticMedicationMetadata? metadata;
+
   const NormalizedMedicationContext({
     required this.drugProductVariant,
     required this.activeIngredients,
@@ -79,6 +87,7 @@ class NormalizedMedicationContext {
     required this.labelSection,
     required this.extractionConfidence,
     required this.limitationText,
+    this.metadata,
   });
 
   Map<String, dynamic> toJson() => {
@@ -94,6 +103,7 @@ class NormalizedMedicationContext {
         'label_section': labelSection,
         'extraction_confidence': extractionConfidence,
         'limitation_text': limitationText,
+        'metadata': metadata?.toJson(),
       };
 }
 

--- a/lib/domain/entities/medication_source_metadata.dart
+++ b/lib/domain/entities/medication_source_metadata.dart
@@ -1,0 +1,214 @@
+/// Engine-facing medication provenance metadata: the bridge between the rich
+/// CDSS importer layer (drug product variant + label sections, already
+/// extracted by the live importers) and the mechanistic medication context.
+///
+/// Educational/research prototype only. This metadata is **provenance**: it
+/// describes which official source/section a product attribute came from and
+/// what the product's structured attributes are. It is **never** read as an
+/// intake dose — the intake dose comes only from the user-facing dosage path.
+/// Product/component strength may identify a variant but must not become a
+/// fabricated intake amount. Missing fields stay missing (never fabricated).
+library;
+
+/// One active/adjunct component of a (possibly combination) drug product, e.g.
+/// carbidopa + levodopa. Per-component strength is nullable: when a product
+/// reports only a single product-level strength, per-component strength is left
+/// null and recorded as missing rather than guessed.
+class MedicationComponent {
+  final String ingredientName;
+
+  /// Coarse role, e.g. 'active' / 'decarboxylase_inhibitor' / 'adjunct'.
+  final String role;
+  final double? strengthValue;
+  final String? strengthUnit;
+  final List<String> sourceRefs;
+  final double? extractionConfidence;
+
+  const MedicationComponent({
+    required this.ingredientName,
+    required this.role,
+    this.strengthValue,
+    this.strengthUnit,
+    this.sourceRefs = const [],
+    this.extractionConfidence,
+  });
+
+  bool get isLevodopa => ingredientName.toLowerCase() == 'levodopa';
+
+  /// True when the component lacks an explicit strength + unit (recorded as
+  /// missing, not fabricated).
+  bool get hasMissingStrength =>
+      strengthValue == null || (strengthUnit ?? '').isEmpty;
+
+  Map<String, dynamic> toJson() => {
+        'ingredient_name': ingredientName,
+        'role': role,
+        'strength_value': strengthValue,
+        'strength_unit': strengthUnit,
+        'source_refs': sourceRefs,
+        'extraction_confidence': extractionConfidence,
+      };
+}
+
+/// A reference to a specific labeled section of an official product-information
+/// document (SPL / SmPC / monograph / package insert) that backs a product
+/// attribute. Multiple refs per product are expected (e.g. ingredient from a
+/// composition section, dose form from an identity section). This is
+/// provenance/traceability — it does not assert clinical validity, and a
+/// section is only listed when the source record actually carries it.
+class LabelSectionRef {
+  final String sourceSystem;
+  final String sourceDocId;
+  final String? sourceDocVersion;
+  final String jurisdiction;
+  final String language;
+  final String sectionId;
+  final String sectionKey;
+  final String sectionTitle;
+  final String? sectionPath;
+  final String? effectiveDate;
+  final String? extractedField;
+  final String? extractedValue;
+  final double? extractionConfidence;
+  final String? parserName;
+  final List<String> sourceRefs;
+  final String? limitationText;
+
+  const LabelSectionRef({
+    required this.sourceSystem,
+    required this.sourceDocId,
+    this.sourceDocVersion,
+    required this.jurisdiction,
+    required this.language,
+    required this.sectionId,
+    required this.sectionKey,
+    required this.sectionTitle,
+    this.sectionPath,
+    this.effectiveDate,
+    this.extractedField,
+    this.extractedValue,
+    this.extractionConfidence,
+    this.parserName,
+    this.sourceRefs = const [],
+    this.limitationText,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'source_system': sourceSystem,
+        'source_doc_id': sourceDocId,
+        'source_doc_version': sourceDocVersion,
+        'jurisdiction': jurisdiction,
+        'language': language,
+        'section_id': sectionId,
+        'section_key': sectionKey,
+        'section_title': sectionTitle,
+        'section_path': sectionPath,
+        'effective_date': effectiveDate,
+        'extracted_field': extractedField,
+        'extracted_value': extractedValue,
+        'extraction_confidence': extractionConfidence,
+        'parser_name': parserName,
+        'source_refs': sourceRefs,
+        'limitation_text': limitationText,
+      };
+}
+
+/// Engine-facing medication provenance attached to a normalized medication
+/// context. Provenance only — never a dose source.
+class MechanisticMedicationMetadata {
+  final String sourceSystem;
+  final String sourceDocId;
+  final String? sourceDocVersion;
+  final String? effectiveDate;
+  final String jurisdiction;
+  final String language;
+  final String? drugProductVariantId;
+  final String doseForm;
+  final String route;
+
+  /// Product release type string (e.g. immediate / extended / controlled /
+  /// delayed / unknown), as carried by the source variant.
+  final String releaseType;
+
+  /// Where the release type came from, e.g. 'structured_variant_metadata' or
+  /// 'unknown' (never inferred from dose).
+  final String releaseTypeSource;
+
+  final List<MedicationComponent> components;
+  final List<LabelSectionRef> labelSectionRefs;
+  final List<String> sourceRefs;
+  final String limitationText;
+
+  /// Metadata-completeness grade name (from `MetadataCompletenessGate`).
+  final String metadataCompleteness;
+
+  const MechanisticMedicationMetadata({
+    required this.sourceSystem,
+    required this.sourceDocId,
+    this.sourceDocVersion,
+    this.effectiveDate,
+    required this.jurisdiction,
+    required this.language,
+    this.drugProductVariantId,
+    required this.doseForm,
+    required this.route,
+    required this.releaseType,
+    required this.releaseTypeSource,
+    required this.components,
+    required this.labelSectionRefs,
+    required this.sourceRefs,
+    required this.limitationText,
+    required this.metadataCompleteness,
+  });
+
+  /// The levodopa component, if this product contains one. Levodopa-specific
+  /// scoring should use this identity; other components are preserved but not
+  /// used for levodopa-specific food-interaction scoring.
+  MedicationComponent? get levodopaComponent {
+    for (final c in components) {
+      if (c.isLevodopa) return c;
+    }
+    return null;
+  }
+
+  /// All components (combination products preserve every component).
+  List<MedicationComponent> get combinationComponents => components;
+
+  bool get hasLabelSectionProvenance => labelSectionRefs.isNotEmpty;
+
+  bool get releaseTypeKnown {
+    final r = releaseType.trim().toLowerCase();
+    return r.isNotEmpty && r != 'unknown' && r != 'unspecified';
+  }
+
+  /// Provenance fields that are absent (recorded as missing, never fabricated).
+  List<String> get missingFields => <String>[
+        if (!releaseTypeKnown) 'release_type',
+        if (labelSectionRefs.isEmpty) 'label_section_provenance',
+        if (sourceRefs.isEmpty) 'source_refs',
+        if ((sourceDocVersion ?? '').isEmpty) 'source_doc_version',
+        if (components.any((c) => c.hasMissingStrength))
+          'component_strength_unit',
+      ];
+
+  Map<String, dynamic> toJson() => {
+        'source_system': sourceSystem,
+        'source_doc_id': sourceDocId,
+        'source_doc_version': sourceDocVersion,
+        'effective_date': effectiveDate,
+        'jurisdiction': jurisdiction,
+        'language': language,
+        'drug_product_variant_id': drugProductVariantId,
+        'dose_form': doseForm,
+        'route': route,
+        'release_type': releaseType,
+        'release_type_source': releaseTypeSource,
+        'components': components.map((c) => c.toJson()).toList(growable: false),
+        'label_section_refs':
+            labelSectionRefs.map((s) => s.toJson()).toList(growable: false),
+        'source_refs': sourceRefs,
+        'limitation_text': limitationText,
+        'metadata_completeness': metadataCompleteness,
+        'missing_fields': missingFields,
+      };
+}

--- a/lib/domain/usecases/levodopa_absorption_opportunity_model.dart
+++ b/lib/domain/usecases/levodopa_absorption_opportunity_model.dart
@@ -59,20 +59,26 @@ class LevodopaAbsorptionOpportunityModel {
       );
     }
 
-    final isExtended = medication.releaseType.toLowerCase().contains('extend');
-    final isControlled =
-        medication.releaseType.toLowerCase().contains('control');
-    final lag = (isExtended || isControlled)
-        ? referenceErLagMinutes
-        : referenceIrLagMinutes;
-    final duration = (isExtended || isControlled)
-        ? referenceErDurationMinutes
-        : referenceIrDurationMinutes;
+    final releaseTypeRaw = medication.releaseType.toLowerCase().trim();
+    final isExtended = releaseTypeRaw.contains('extend');
+    final isControlled = releaseTypeRaw.contains('control');
+    final isDelayed = releaseTypeRaw.contains('delay');
+    // Extended / controlled / delayed release all widen the opportunity window.
+    final isWideRelease = isExtended || isControlled || isDelayed;
+    // Unknown/unspecified/empty → release-specific interpretation is limited;
+    // we keep a default (IR-shaped) window but widen uncertainty and never
+    // assert ER/IR specifics. Release type is NEVER inferred from dose.
+    final releaseTypeUnknown = releaseTypeRaw.isEmpty ||
+        releaseTypeRaw == 'unknown' ||
+        releaseTypeRaw == 'unspecified';
+    final lag = isWideRelease ? referenceErLagMinutes : referenceIrLagMinutes;
+    final duration =
+        isWideRelease ? referenceErDurationMinutes : referenceIrDurationMinutes;
 
     final assumptions = <String>[
       'ldopa.absorption.small_intestine',
-      if (isExtended || isControlled)
-        'ldopa.release_type.extended_widens_window',
+      if (isWideRelease) 'ldopa.release_type.extended_widens_window',
+      if (releaseTypeUnknown) 'ldopa.absorption.release_type_unknown_limited',
     ];
 
     var startMinute = medication.minute + lag;
@@ -115,15 +121,21 @@ class LevodopaAbsorptionOpportunityModel {
       assumptions.add('ldopa.absorption.no_overlapping_meal_profile');
     }
 
+    // Unknown release type widens uncertainty by one step (release-specific
+    // interpretation is limited).
+    if (releaseTypeUnknown) {
+      uncertainty = _combineUncertainty(uncertainty, UncertaintyBand.wide);
+    }
+
     final incompleteContext = overlappingMealProfile == null;
     final opennessProfile = _buildOpennessProfile(
       startMinute: startMinute,
       endMinute: endMinute,
       peakMinute: peakMinute,
-      extended: isExtended || isControlled,
+      extended: isWideRelease,
       incompleteContext: incompleteContext,
     );
-    assumptions.add(isExtended || isControlled
+    assumptions.add(isWideRelease
         ? 'ldopa.absorption.openness_profile_extended_flatter_longer'
         : 'ldopa.absorption.openness_profile_immediate_sharper');
     if (incompleteContext) {

--- a/lib/domain/usecases/mechanistic_conflict_engine.dart
+++ b/lib/domain/usecases/mechanistic_conflict_engine.dart
@@ -175,6 +175,21 @@ class MechanisticConflictEngine {
                 ...e.absorption.missingInputs
                     .map((m) => 'absorption_missing:$m'),
               ],
+              // Medication provenance bridged from CDSS metadata (when present;
+              // null/0/false otherwise). Provenance only — never a dose.
+              releaseTypeSource: e.med.context.metadata?.releaseTypeSource,
+              doseForm: e.med.context.metadata?.doseForm,
+              route: e.med.context.metadata?.route,
+              levodopaComponentPresent:
+                  e.med.context.metadata?.levodopaComponent != null,
+              combinationComponentCount:
+                  e.med.context.metadata?.combinationComponents.length ?? 0,
+              labelSectionRefCount:
+                  e.med.context.metadata?.labelSectionRefs.length ?? 0,
+              medicationSourceSystem: e.med.context.metadata?.sourceSystem,
+              medicationSourceDocId: e.med.context.metadata?.sourceDocId,
+              medicationMetadataCompleteness:
+                  e.med.context.metadata?.metadataCompleteness,
             ))
         .toList(growable: false);
 

--- a/lib/domain/usecases/mechanistic_replay_runner.dart
+++ b/lib/domain/usecases/mechanistic_replay_runner.dart
@@ -73,6 +73,21 @@ class MechanisticReplayCaseReport {
   final double? doseRelativeLnaaRatio;
   final String? aminoAcidConfidenceTier;
   final String scoringParameterSetId;
+  // Medication section provenance + release extraction (CDSS→context bridge).
+  // Sourced from the first validated medication context's metadata; null/empty
+  // when no CDSS metadata was attached. Provenance only — never a dose.
+  final String? medicationSourceSystem;
+  final String? medicationSourceDocId;
+  final String? medicationSourceVersion;
+  final int medicationLabelSectionRefCount;
+  final String? medicationReleaseType;
+  final String? medicationReleaseTypeSource;
+  final String? medicationDoseForm;
+  final String? medicationRoute;
+  final List<String> medicationCombinationComponents;
+  final String dosageSource;
+  final String? medicationMetadataCompleteness;
+  final List<String> medicationMissingFields;
   final bool pass;
   final String? failureReason;
 
@@ -126,6 +141,18 @@ class MechanisticReplayCaseReport {
     this.doseRelativeLnaaRatio,
     this.aminoAcidConfidenceTier,
     this.scoringParameterSetId = 'none',
+    this.medicationSourceSystem,
+    this.medicationSourceDocId,
+    this.medicationSourceVersion,
+    this.medicationLabelSectionRefCount = 0,
+    this.medicationReleaseType,
+    this.medicationReleaseTypeSource,
+    this.medicationDoseForm,
+    this.medicationRoute,
+    this.medicationCombinationComponents = const [],
+    this.dosageSource = 'none',
+    this.medicationMetadataCompleteness,
+    this.medicationMissingFields = const [],
   });
 
   Map<String, dynamic> toJson() => {
@@ -178,6 +205,18 @@ class MechanisticReplayCaseReport {
         'dose_relative_lnaa_ratio': doseRelativeLnaaRatio,
         'amino_acid_confidence_tier': aminoAcidConfidenceTier,
         'scoring_parameter_set_id': scoringParameterSetId,
+        'medication_source_system': medicationSourceSystem,
+        'medication_source_doc_id': medicationSourceDocId,
+        'medication_source_version': medicationSourceVersion,
+        'medication_label_section_ref_count': medicationLabelSectionRefCount,
+        'medication_release_type': medicationReleaseType,
+        'medication_release_type_source': medicationReleaseTypeSource,
+        'medication_dose_form': medicationDoseForm,
+        'medication_route': medicationRoute,
+        'medication_combination_components': medicationCombinationComponents,
+        'dosage_source': dosageSource,
+        'medication_metadata_completeness': medicationMetadataCompleteness,
+        'medication_missing_fields': medicationMissingFields,
         'pass': pass,
         'failure_reason': failureReason,
       };
@@ -435,12 +474,42 @@ class MechanisticReplayRunner {
         ? 'none'
         : recommendations.first.scoringParameterSetId;
 
+    // Medication section provenance + release extraction, bridged from the
+    // first validated medication context's CDSS metadata (when attached).
+    final medMeta = medValidations.isEmpty
+        ? null
+        : medValidations.first.normalized?.metadata;
+    final firstReleaseType = medValidations.isEmpty
+        ? null
+        : medValidations.first.normalized?.releaseType;
+    // dosageSource records WHERE the analyzable dose came from — never a
+    // fabricated default. 'user_or_variant_strength' only when dose context is
+    // complete; otherwise 'insufficient'/'none'. Product metadata never fills it.
+    final dosageSource = firstEntry == null
+        ? 'none'
+        : (dosageContextComplete ? 'user_or_variant_strength' : 'insufficient');
+
     return MechanisticReplayCaseReport(
       scenarioId: scenario.scenarioId,
       title: scenario.title,
       userEnteredDosage: userEnteredDosage,
       dosageContextComplete: dosageContextComplete,
       perEventCount: result.perEventCount,
+      medicationSourceSystem: medMeta?.sourceSystem,
+      medicationSourceDocId: medMeta?.sourceDocId,
+      medicationSourceVersion: medMeta?.sourceDocVersion,
+      medicationLabelSectionRefCount: medMeta?.labelSectionRefs.length ?? 0,
+      medicationReleaseType: medMeta?.releaseType ?? firstReleaseType,
+      medicationReleaseTypeSource: medMeta?.releaseTypeSource,
+      medicationDoseForm: medMeta?.doseForm,
+      medicationRoute: medMeta?.route,
+      medicationCombinationComponents: medMeta?.components
+              .map((c) => c.ingredientName)
+              .toList(growable: false) ??
+          const [],
+      dosageSource: dosageSource,
+      medicationMetadataCompleteness: medMeta?.metadataCompleteness,
+      medicationMissingFields: medMeta?.missingFields ?? const [],
       mealComponentCount: emptying?.componentProfiles.length ?? 0,
       gastricEmptyingAssumptions: emptying?.assumptions ?? const [],
       absorptionOpennessSampleCount:

--- a/lib/domain/usecases/medication_context_metadata_adapter.dart
+++ b/lib/domain/usecases/medication_context_metadata_adapter.dart
@@ -1,0 +1,115 @@
+import '../entities/cdss_records.dart';
+import '../entities/medication_source_metadata.dart';
+import '../entities/source_metadata.dart';
+import 'metadata_completeness_gate.dart';
+
+/// Bridges the already-extracted CDSS drug metadata (a canonical
+/// `DrugProductVariantMetadata` plus any `DrugLabelSectionRecord`s the live
+/// importers produced) into the engine-facing `MechanisticMedicationMetadata`.
+///
+/// Educational/research prototype only. This adapter does **no** parsing or
+/// ingestion — it maps existing structured records. It NEVER produces an intake
+/// dose: product/component strength is carried as identity/provenance only.
+/// Missing provenance (no sections, unknown release type, no per-component
+/// strength) is recorded as missing — never fabricated and never a fake
+/// official trace.
+class MedicationContextMetadataAdapter {
+  final MetadataCompletenessGate completenessGate;
+
+  MedicationContextMetadataAdapter({MetadataCompletenessGate? completenessGate})
+      : completenessGate = completenessGate ?? MetadataCompletenessGate();
+
+  MechanisticMedicationMetadata fromCdssMetadata({
+    required DrugProductVariantMetadata variant,
+    List<DrugLabelSectionRecord> sections = const [],
+    String? sourceDocVersion,
+    String? effectiveDate,
+    String releaseTypeSource = 'structured_variant_metadata',
+  }) {
+    final releaseKnown = _releaseTypeKnown(variant.releaseType);
+    final resolvedReleaseSource = releaseKnown ? releaseTypeSource : 'unknown';
+
+    final components = _components(variant);
+
+    final labelSectionRefs = sections
+        .map((s) => LabelSectionRef(
+              sourceSystem: variant.sourceSystem,
+              sourceDocId: s.sourceDocId,
+              sourceDocVersion: sourceDocVersion,
+              jurisdiction: variant.jurisdiction,
+              language: variant.language,
+              sectionId: s.sectionId,
+              sectionKey: s.sectionKey,
+              sectionTitle: s.sectionTitle,
+              effectiveDate: effectiveDate,
+              parserName: 'cdss_drug_label_section_record',
+              sourceRefs: variant.sourceRefs,
+              limitationText: variant.limitationText,
+            ))
+        .toList(growable: false);
+
+    final completeness = completenessGate
+        .scoreMedicationContext(variant,
+            hasLabelSectionProvenance: labelSectionRefs.isNotEmpty)
+        .name;
+
+    return MechanisticMedicationMetadata(
+      sourceSystem: variant.sourceSystem,
+      sourceDocId: variant.productIdentifier ?? variant.drugProductVariantId,
+      sourceDocVersion: sourceDocVersion,
+      effectiveDate: effectiveDate,
+      jurisdiction: variant.jurisdiction,
+      language: variant.language,
+      drugProductVariantId: variant.drugProductVariantId,
+      doseForm: variant.doseForm,
+      route: variant.route,
+      releaseType: variant.releaseType,
+      releaseTypeSource: resolvedReleaseSource,
+      components: components,
+      labelSectionRefs: labelSectionRefs,
+      sourceRefs: variant.sourceRefs,
+      limitationText: variant.limitationText,
+      metadataCompleteness: completeness,
+    );
+  }
+
+  /// Build component identities from the variant's active-ingredient list.
+  /// Per-component strength is only assigned for a single-ingredient product
+  /// (where the single product strength is unambiguous); for a combination
+  /// product the per-component split is generally not in the record, so
+  /// per-component strength is left null (recorded as missing, never guessed).
+  List<MedicationComponent> _components(DrugProductVariantMetadata variant) {
+    final names = variant.activeIngredients
+        .map((n) => n.trim())
+        .where((n) => n.isNotEmpty)
+        .toList(growable: false);
+    final singleIngredient = names.length == 1;
+    return names
+        .map((name) => MedicationComponent(
+              ingredientName: name,
+              role: _roleFor(name),
+              strengthValue: singleIngredient ? variant.strengthValue : null,
+              strengthUnit: singleIngredient ? variant.strengthUnit : null,
+              sourceRefs: variant.sourceRefs,
+              extractionConfidence: variant.extractionConfidence,
+            ))
+        .toList(growable: false);
+  }
+
+  String _roleFor(String ingredientName) {
+    final n = ingredientName.toLowerCase();
+    if (n == 'levodopa' || n == 'l-dopa') return 'active';
+    if (n == 'carbidopa' || n == 'benserazide') {
+      return 'decarboxylase_inhibitor';
+    }
+    if (n == 'entacapone' || n == 'opicapone' || n == 'tolcapone') {
+      return 'comt_inhibitor';
+    }
+    return 'adjunct';
+  }
+
+  bool _releaseTypeKnown(String releaseType) {
+    final r = releaseType.trim().toLowerCase();
+    return r.isNotEmpty && r != 'unknown' && r != 'unspecified';
+  }
+}

--- a/lib/domain/usecases/medication_entry_validator.dart
+++ b/lib/domain/usecases/medication_entry_validator.dart
@@ -1,4 +1,5 @@
 import '../entities/medication_entry_validation.dart';
+import '../entities/medication_source_metadata.dart';
 
 /// Raw structured medication-entry input as it would arrive from a form,
 /// importer row, or test fixture.
@@ -21,6 +22,11 @@ class RawMedicationEntry {
   final String? labelSection;
   final double? extractionConfidence;
 
+  /// Optional engine-facing medication provenance bridged from the CDSS layer.
+  /// PROVENANCE ONLY — passed through to the normalized context untouched and
+  /// NEVER read as a dose source. Does not affect validity or the dose path.
+  final MechanisticMedicationMetadata? medicationMetadata;
+
   const RawMedicationEntry({
     this.freeText,
     this.activeIngredient,
@@ -35,6 +41,7 @@ class RawMedicationEntry {
     this.sourceDocId,
     this.labelSection,
     this.extractionConfidence,
+    this.medicationMetadata,
   });
 }
 
@@ -229,6 +236,8 @@ class MedicationEntryValidator {
       labelSection: entry.labelSection?.trim(),
       extractionConfidence: entry.extractionConfidence,
       limitationText: defaultLimitationText,
+      // Pass CDSS provenance through untouched — it is never read for dose.
+      metadata: entry.medicationMetadata,
     );
 
     return MedicationContextValidationResult(

--- a/lib/domain/usecases/metadata_completeness_gate.dart
+++ b/lib/domain/usecases/metadata_completeness_gate.dart
@@ -15,7 +15,13 @@ import '../entities/source_metadata.dart';
 /// - incomplete → widen uncertainty rather than assert precision
 class MetadataCompletenessGate {
   MetadataCompletenessScore scoreMedicationContext(
-      DrugProductVariantMetadata? meta) {
+    DrugProductVariantMetadata? meta, {
+    // When false, the product has no backing label-section provenance and the
+    // grade is lowered by one missing-equivalent — a product without a cited
+    // section is not treated as a fully complete official trace. Defaults true
+    // so existing callers are unaffected (additive).
+    bool hasLabelSectionProvenance = true,
+  }) {
     if (meta == null) return MetadataCompletenessScore.invalid;
     if (meta.activeIngredients.isEmpty) {
       return MetadataCompletenessScore.invalid; // no ingredient → no context
@@ -29,6 +35,7 @@ class MetadataCompletenessGate {
       meta.route.isEmpty,
       meta.sourceRefs.isEmpty,
       meta.jurisdiction.isEmpty,
+      !hasLabelSectionProvenance,
     ].where((m) => m).length;
     if (missing == 0) return MetadataCompletenessScore.complete;
     if (missing <= 1) return MetadataCompletenessScore.sufficient;

--- a/test/mechanistic_replay_runner_test.dart
+++ b/test/mechanistic_replay_runner_test.dart
@@ -161,6 +161,32 @@ void main() {
     }
   });
 
+  // A1/A2 — medication section provenance reaches the replay report.
+  test('SPL IR scenario exposes section provenance + components (A1/A2)', () {
+    final report = runner.run();
+    final c = report.cases
+        .firstWhere((c) => c.scenarioId == 's39_spl_ir_section_provenance');
+    expect(c.medicationSourceSystem, 'DailyMed');
+    expect(c.medicationLabelSectionRefCount, greaterThan(0));
+    expect(c.medicationReleaseType, 'immediate');
+    expect(c.medicationReleaseTypeSource, 'structured_variant_metadata');
+    expect(c.medicationCombinationComponents,
+        containsAll(['carbidopa', 'levodopa']));
+    // Dose still came from the user/variant strength, never fabricated.
+    expect(c.dosageSource, 'user_or_variant_strength');
+    expect(c.dosageContextComplete, isTrue);
+  });
+
+  test('SPL ER scenario records extended release from source metadata (A1/A2)',
+      () {
+    final report = runner.run();
+    final c = report.cases
+        .firstWhere((c) => c.scenarioId == 's40_spl_er_section_provenance');
+    expect(c.medicationReleaseType, 'extended');
+    expect(c.medicationReleaseTypeSource, 'structured_variant_metadata');
+    expect(c.medicationLabelSectionRefCount, greaterThan(0));
+  });
+
   // Clinical-calibration guardrail regression (OPP-D4 / backlog #12). Locks in
   // the non-device educational boundary: every replay case must report it is
   // not clinically calibrated, must not enable live fetch by default, and must

--- a/test/medication_context_metadata_bridge_test.dart
+++ b/test/medication_context_metadata_bridge_test.dart
@@ -1,0 +1,270 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkinsum_companion/domain/entities/cdss_records.dart';
+import 'package:parkinsum_companion/domain/entities/gastric_emptying_profile.dart';
+import 'package:parkinsum_companion/domain/entities/meal_composition.dart';
+import 'package:parkinsum_companion/domain/entities/medication_entry_validation.dart';
+import 'package:parkinsum_companion/domain/entities/source_metadata.dart';
+import 'package:parkinsum_companion/domain/entities/time_axis_events.dart';
+import 'package:parkinsum_companion/domain/usecases/levodopa_absorption_opportunity_model.dart';
+import 'package:parkinsum_companion/domain/usecases/mechanistic_conflict_engine.dart';
+import 'package:parkinsum_companion/domain/usecases/meal_composition_normalizer.dart';
+import 'package:parkinsum_companion/domain/usecases/medication_context_metadata_adapter.dart';
+import 'package:parkinsum_companion/domain/usecases/medication_entry_validator.dart';
+import 'package:parkinsum_companion/domain/usecases/time_axis_builder.dart';
+
+/// Phase γ / A1-A2: bridges CDSS drug metadata into the mechanistic medication
+/// context. These tests prove the BRIDGE (not parser extraction): section refs,
+/// combination components, and release-type evidence reach the normalized
+/// context / absorption model / per-event trace — and that product strength
+/// never becomes a fabricated intake dose.
+void main() {
+  final adapter = MedicationContextMetadataAdapter();
+  final validator = MedicationEntryValidator();
+
+  DrugProductVariantMetadata variant({
+    List<String> ingredients = const ['carbidopa', 'levodopa'],
+    String releaseType = 'immediate',
+    double? strength = 100,
+    String? unit = 'mg',
+    List<String> refs = const ['src.dailymed.sinemet.label'],
+  }) =>
+      DrugProductVariantMetadata(
+        drugProductVariantId: 'v1',
+        sourceSystem: 'DailyMed',
+        jurisdiction: 'US',
+        language: 'en',
+        genericName: 'carbidopa/levodopa',
+        brandName: null,
+        activeIngredients: ingredients,
+        strengthValue: strength,
+        strengthUnit: unit,
+        doseForm: 'tablet',
+        route: 'oral',
+        releaseType: releaseType,
+        productIdentifier: 'NDC-0000',
+        labelSection: 'dosage',
+        translationStatus: ReferenceTranslationStatus.notTranslation,
+        extractionConfidence: 0.9,
+        sourceRefs: refs,
+        limitationText: 'educational',
+      );
+
+  DrugLabelSectionRecord section() => const DrugLabelSectionRecord(
+        sectionId: 'sec-1',
+        drugProductVariantId: 'v1',
+        sourceDocId: 'spl:demo',
+        sectionKey: 'dosage_and_administration',
+        sectionTitle: 'Dosage and Administration',
+        sectionText: 'Synthetic demo section text.',
+      );
+
+  test('cdss drug metadata bridge preserves label section refs', () {
+    final m = adapter.fromCdssMetadata(
+        variant: variant(), sections: [section()], sourceDocVersion: 'v1.0');
+    expect(m.labelSectionRefs, hasLength(1));
+    expect(m.labelSectionRefs.single.sectionKey, 'dosage_and_administration');
+    expect(m.labelSectionRefs.single.sourceDocVersion, 'v1.0');
+    expect(m.hasLabelSectionProvenance, isTrue);
+  });
+
+  test('combination product preserves carbidopa and levodopa components', () {
+    final m = adapter.fromCdssMetadata(variant: variant());
+    expect(m.components.map((c) => c.ingredientName),
+        containsAll(['carbidopa', 'levodopa']));
+    expect(m.levodopaComponent, isNotNull);
+    expect(m.levodopaComponent!.role, 'active');
+    final carbidopa =
+        m.components.firstWhere((c) => c.ingredientName == 'carbidopa');
+    expect(carbidopa.role, 'decarboxylase_inhibitor');
+    expect(carbidopa.isLevodopa, isFalse); // preserved but not levodopa
+  });
+
+  test('combination per-component strength is missing, not fabricated', () {
+    final m = adapter.fromCdssMetadata(variant: variant());
+    // Single product strength only → no per-component split is invented.
+    for (final c in m.components) {
+      expect(c.strengthValue, isNull);
+      expect(c.hasMissingStrength, isTrue);
+    }
+    expect(m.missingFields, contains('component_strength_unit'));
+  });
+
+  test(
+      'single-ingredient product carries the product strength on its component',
+      () {
+    final m = adapter.fromCdssMetadata(
+        variant: variant(ingredients: ['levodopa'], strength: 100, unit: 'mg'));
+    expect(m.components.single.strengthValue, 100);
+    expect(m.components.single.strengthUnit, 'mg');
+  });
+
+  test('release type source is structured when known, unknown otherwise', () {
+    final known = adapter.fromCdssMetadata(variant: variant());
+    expect(known.releaseTypeSource, 'structured_variant_metadata');
+    final unknown =
+        adapter.fromCdssMetadata(variant: variant(releaseType: 'unknown'));
+    expect(unknown.releaseTypeSource, 'unknown');
+    expect(unknown.missingFields, contains('release_type'));
+  });
+
+  test('missing section provenance lowers completeness, not a fake trace', () {
+    final withSec =
+        adapter.fromCdssMetadata(variant: variant(), sections: [section()]);
+    final without = adapter.fromCdssMetadata(variant: variant());
+    expect(without.hasLabelSectionProvenance, isFalse);
+    expect(without.missingFields, contains('label_section_provenance'));
+    // No-section grade is not stronger than the with-section grade.
+    expect(withSec.metadataCompleteness == 'complete', isTrue);
+    expect(without.metadataCompleteness == 'complete', isFalse);
+  });
+
+  test('normalized context carries release type + components from metadata',
+      () {
+    final m =
+        adapter.fromCdssMetadata(variant: variant(), sections: [section()]);
+    final result = validator.validate(RawMedicationEntry(
+      activeIngredients: const ['carbidopa', 'levodopa'],
+      drugProductVariant: 'v1',
+      strength: 100,
+      unit: 'mg',
+      form: 'tablet',
+      route: 'oral',
+      releaseType: 'immediate',
+      jurisdiction: 'US',
+      sourceDocId: 'spl:demo',
+      medicationMetadata: m,
+    ));
+    expect(result.validity, MedicationContextValidity.valid);
+    expect(result.normalized!.metadata, isNotNull);
+    expect(result.normalized!.metadata!.releaseType, 'immediate');
+    expect(result.normalized!.metadata!.labelSectionRefs, isNotEmpty);
+  });
+
+  test('unitless user dosage stays insufficient despite product strength', () {
+    // The metadata carries a product strength (100 mg) but the user entered a
+    // unitless free-text dose. Product strength must NOT fill the intake dose.
+    final m = adapter.fromCdssMetadata(variant: variant());
+    final result = validator.validate(RawMedicationEntry(
+      freeText: 'levodopa 100', // unitless
+      activeIngredients: const ['carbidopa', 'levodopa'],
+      drugProductVariant: 'v1',
+      form: 'tablet',
+      route: 'oral',
+      releaseType: 'immediate',
+      jurisdiction: 'US',
+      sourceDocId: 'spl:demo',
+      medicationMetadata: m, // rich product strength attached
+    ));
+    expect(result.validity, isNot(MedicationContextValidity.valid));
+    expect(result.normalized, isNull); // no dose fabricated from metadata
+  });
+
+  group('absorption uses source-backed release type', () {
+    final absorption = LevodopaAbsorptionOpportunityModel();
+
+    MedicationTimelineEvent med(String releaseType, {required int minute}) {
+      final v = validator.validate(RawMedicationEntry(
+        activeIngredients: const ['carbidopa', 'levodopa'],
+        drugProductVariant: 'v1',
+        strength: 100,
+        unit: 'mg',
+        form: 'tablet',
+        route: 'oral',
+        releaseType: releaseType,
+        jurisdiction: 'US',
+        sourceDocId: 'spl:demo',
+      ));
+      return MedicationTimelineEvent(
+          id: 'm', minute: minute, context: v.normalized!);
+    }
+
+    test('ER release gives a wider window than IR', () {
+      final ir = absorption.build(medication: med('immediate', minute: 60));
+      final er = absorption.build(medication: med('extended', minute: 60));
+      expect(er.window.endMinute - er.window.startMinute,
+          greaterThan(ir.window.endMinute - ir.window.startMinute));
+    });
+
+    test('unknown release type widens uncertainty', () {
+      final known = absorption.build(medication: med('immediate', minute: 60));
+      final unknown = absorption.build(medication: med('unknown', minute: 60));
+      const order = [
+        UncertaintyBand.narrow,
+        UncertaintyBand.moderate,
+        UncertaintyBand.wide,
+        UncertaintyBand.veryWide,
+      ];
+      expect(order.indexOf(unknown.uncertaintyBand),
+          greaterThan(order.indexOf(known.uncertaintyBand)));
+      expect(
+        unknown.assumptions
+            .any((a) => a.contains('release_type_unknown_limited')),
+        isTrue,
+      );
+    });
+  });
+
+  test('per-event trace carries medication section provenance', () {
+    final normalizer = MealCompositionNormalizer();
+    final builder = TimeAxisBuilder();
+    final engine = MechanisticConflictEngine();
+    final m = adapter.fromCdssMetadata(
+        variant: variant(), sections: [section()], sourceDocVersion: 'v1.0');
+    final v = validator.validate(RawMedicationEntry(
+      activeIngredients: const ['carbidopa', 'levodopa'],
+      drugProductVariant: 'v1',
+      strength: 100,
+      unit: 'mg',
+      form: 'tablet',
+      route: 'oral',
+      releaseType: 'immediate',
+      jurisdiction: 'US',
+      sourceDocId: 'spl:demo',
+      medicationMetadata: m,
+    ));
+    final now = DateTime.utc(2026, 1, 1, 8);
+    final comp = normalizer.normalize(
+      mealId: 'c',
+      components: const [
+        FoodComponent(
+          id: 'p',
+          name: 'protein',
+          physicalForm: MealPhysicalForm.solid,
+          proteinGrams: 30,
+          fatGrams: 5,
+          fiberGrams: 0,
+          carbohydrateGrams: 0,
+          calories: 200,
+          portionGrams: 180,
+          sourceDocId: 'synthetic',
+        ),
+      ],
+    );
+    final ctx = builder.build(
+      now: now,
+      medicationInputs: [
+        MedicationTimelineInput(
+            id: 'm',
+            takenAt: now.add(const Duration(minutes: 30)),
+            medicationContext: v),
+      ],
+      mealInputs: [
+        MealTimelineInput(
+            id: 'meal',
+            startedAt: now,
+            compositionId: comp.id,
+            physicalForm: MealPhysicalForm.solid),
+      ],
+    );
+    final r =
+        engine.evaluate(context: ctx, mealCompositionsById: {comp.id: comp});
+    expect(r.perEventTraces, isNotEmpty);
+    final t = r.perEventTraces.first;
+    expect(t.levodopaComponentPresent, isTrue);
+    expect(t.combinationComponentCount, 2);
+    expect(t.labelSectionRefCount, 1);
+    expect(t.releaseTypeSource, 'structured_variant_metadata');
+    expect(t.medicationSourceSystem, 'DailyMed');
+    expect(t.doseForm, 'tablet');
+  });
+}


### PR DESCRIPTION
## Summary

Bridges existing **CDSS drug metadata into the mechanistic medication context**. The Task-1 audit confirmed the live importers already extract label sections, release type, dose form, route, and true combination components into the CDSS-record layer — the defect was the **seam**: the mechanistic path collapsed that rich metadata into a thin context, losing section provenance, component identity, release-type evidence, and source-doc trace before the absorption model and replay ever saw it.

This is a **mechanistic-context wiring PR, not an importer PR**: no new SPL/SmPC parser, no live fetch, no source-DB changes, no modification of the 7 live P0/P1 importers, no UI, no clinical copy, no dosage inference.

## What changed

- **New entities** (`medication_source_metadata.dart`): `MechanisticMedicationMetadata`, `LabelSectionRef`, `MedicationComponent`. Provenance-only; per-component strength is nullable so a single product strength on a combination product is **recorded missing, never fabricated**.
- **New bridge** (`medication_context_metadata_adapter.dart`): pure/deterministic `fromCdssMetadata({variant, sections, ...})` → `MechanisticMedicationMetadata`. Roles inferred (levodopa→active, carbidopa/benserazide→decarboxylase_inhibitor, COMT inhibitors, else adjunct); completeness via `MetadataCompletenessGate`.
- **Threaded through the contract**: optional `medicationMetadata` on `RawMedicationEntry` (input-facing passthrough) → `NormalizedMedicationContext.metadata` (engine-facing). **Dose path untouched.**
- **Absorption model**: unknown/empty release type now **widens uncertainty** and records `ldopa.absorption.release_type_unknown_limited` rather than silently assuming IR; `delayed` recognized; ER/CR stay wider.
- **Per-event trace + replay report**: additive fields surface release type + source, label-section-ref count, combination components, dose form/route, source system/doc/version, completeness, missing fields, and `dosage_source`.
- **Completeness gate**: factors section-provenance presence (additive; inert when metadata is null).

## P0 dose rule — preserved and proven

The analyzable intake dose still comes **solely** from the user-facing dosage field. Product/component strength may identify the variant but **never becomes an intake dose**. Test `unitless user dosage remains insufficient despite product strength metadata` locks this in. No default/fallback dose introduced.

## Scenarios & tests

- Replay scenarios **s39** (SPL IR carbidopa/levodopa with label-section refs) and **s40** (SPL ER) exercise the bridge end-to-end via synthetic CDSS-style fixtures (not live importer output).
- New `test/medication_context_metadata_bridge_test.dart` (11 tests) + extended replay-runner tests.

## Docs

`CONFLICT_ENGINE_MODEL.md` (§12 release behavior + §12b section provenance in the trace), `IMPORTER_METADATA_FLOW.md` (§14d CDSS→mechanistic bridge), `REPLAY_RUNNER.md` (new medication_* report fields + scenario count → 41), scorecard **S4 flipped 🟡→🟢** (SPL section identity now reaches the mechanistic context; discrete LOINC section-code field noted as residual future work).

## Verification

- `dart format .` clean · `flutter analyze` clean
- `flutter test --concurrency=1` → **399 passed**
- `npm run public:preflight` → **0 BLOCKER**
- `node tool/firestore_rules_contract_check.mjs` → **13/13**
- `dart run tool/run_mechanistic_replay.dart` → **41/41**

## Limitations

Bridge exercised via synthetic CDSS-style fixtures, not live importer output. `effectiveDate`/`sourceDocVersion` populate only when the source record carries them. Release-type handling is deterministic + conservative; unknown lowers confidence. Not clinically calibrated; section provenance improves traceability, not clinical validity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
