### PR TITLE
Add source-quality perturbation report

### DIFF
--- a/docs/BIOMEDICAL_STANDARDS_CONFORMANCE_SCORECARD.md
+++ b/docs/BIOMEDICAL_STANDARDS_CONFORMANCE_SCORECARD.md
@@ -253,6 +253,14 @@ boundary.
   the mechanism layer emits resolves in the registry (shipped this pass — see
   §6); (b) machine-readable license/access tags per source; (c) the
   clinical-calibration guardrail regression (backlog #12).
+- **Reusability artifact (shipped):** a deterministic **source-quality
+  perturbation report** (`SourceQualityPerturbationReportRunner`;
+  `tool/run_source_quality_perturbation_report.dart` / `npm run source:quality`;
+  see `docs/SOURCE_QUALITY_PERTURBATION_REPORT.md`) makes the engine's
+  provenance-sensitivity auditable: it shows how candidate scoring moves when
+  only source/provenance quality changes, and proves (test-backed) that conflict
+  overlap stays the dominant term while weaker amino-acid provenance widens
+  uncertainty. Educational analysis only; no advice, not clinically calibrated.
 - **Safety:** governance/provenance; gates live ingestion behind review.
 
 ## 5. Aggregate deltas, sequenced

--- a/docs/SOURCE_QUALITY_PERTURBATION_REPORT.md
+++ b/docs/SOURCE_QUALITY_PERTURBATION_REPORT.md
@@ -1,0 +1,76 @@
+# Source-Quality Perturbation Report
+
+Educational/research prototype only. Synthetic inputs only. **Not medical
+advice. Not clinically calibrated. Not a clinical dashboard.**
+
+## Purpose
+
+A deterministic, test-backed analysis artifact that shows **how candidate
+scoring moves when only source/provenance quality changes**, holding the
+meal / conflict / model input constant. It makes the engine's
+provenance-sensitivity auditable without any UI and without changing the
+scoring algorithm.
+
+## Run it
+
+```sh
+dart run tool/run_source_quality_perturbation_report.dart
+# or
+npm run source:quality
+```
+
+Outputs (deterministic):
+
+- `build/source_quality_perturbation/latest.json`
+- `build/source_quality_perturbation/latest.md`
+
+The runner reuses `MechanisticNextMealScorer` (it does **not** re-implement
+scoring): it fixes one synthetic base context + candidate composition and sweeps
+the source/provenance perturbation variables, recording the resulting scores.
+
+## Perturbation families
+
+1. **Provenance / source quality** (meal held constant): official
+   in-jurisdiction, official out-of-jurisdiction, synthetic/demo, missing
+   sourceRefs, complete vs partial metadata. Only the `CandidateMetadata`
+   (`authorityScore` / `jurisdictionMatchScore` / `provenanceQuality` /
+   `completeness`) changes.
+2. **Amino-acid confidence tier** (metadata held neutral): analytical /
+   calculated / imputed-or-assumed / unknown, plus a missing-nutrient-basis
+   case. Only the candidate's amino-acid provenance tier changes.
+
+## Row fields
+
+`case_id`, `input_changed`, `source_system`, `jurisdiction_match`,
+`source_authority_score`, `metadata_completeness`, `amino_acid_confidence_tier`,
+`nutrient_completeness`, `final_candidate_score`, `conflict_overlap_score`,
+`uncertainty_penalty`, `competition_uncertainty_band`,
+`lnaa_uncertainty_widened`, `ranker_used`, `explanation`, `safety_boundary`,
+`not_clinically_calibrated`.
+
+## Invariants (enforced by tests)
+
+- **Deterministic**: identical inputs → identical report.
+- **Authority ordering**: official in-jurisdiction scores ≥ a synthetic
+  equivalent when the meal/conflict input matches.
+- **Missing provenance is recorded, not fabricated**: missing sourceRefs lowers
+  provenance quality (and the final score), holding conflict overlap constant.
+- **Weaker amino-acid provenance widens uncertainty**: an imputed/assumed (or
+  calculated/unknown) tier widens the modeled competition uncertainty band
+  relative to analytical (`lnaa_uncertainty_widened = true`).
+- **Conflict overlap stays dominant**: the provenance-driven score swing (best
+  vs worst provenance on an identical composition) is bounded by the summed
+  provenance weights, which the scorer's `conflictRemainsDominant` invariant
+  keeps strictly below the conflict-overlap weight. Provenance can break a tie
+  when conflict scores are close, but can never overpower a substantial conflict
+  gap.
+- **No advice**: the report (JSON + markdown) is scanned for banned prescriptive
+  substrings; every row carries the shared safety boundary and
+  `not_clinically_calibrated = true`.
+
+## Boundary summary
+
+Deterministic educational analysis over synthetic inputs. No PHI, no
+patient/subject/encounter, no diagnosis/treatment/medication-timing/dose
+guidance, no live ingestion, no UI dashboard. The scoring algorithm is
+unchanged; this report only *observes* it.

--- a/lib/domain/usecases/source_quality_perturbation_report.dart
+++ b/lib/domain/usecases/source_quality_perturbation_report.dart
@@ -1,0 +1,454 @@
+import 'dart:convert';
+
+import '../entities/amino_acid_profile.dart';
+import '../entities/meal_composition.dart';
+import '../entities/rule_explanation.dart';
+import '../entities/time_axis_events.dart';
+import 'mechanistic_next_meal_scorer.dart';
+import 'medication_entry_validator.dart';
+import 'time_axis_builder.dart';
+
+/// One row of the source-quality perturbation report: the deterministic
+/// candidate-scoring outcome when **only** a source/provenance-quality input was
+/// changed, holding the meal / conflict / model input constant.
+///
+/// Educational/research prototype only. This is a transparency/analysis artifact;
+/// it carries no medical advice and is not clinically calibrated.
+class SourceQualityPerturbationRow {
+  final String caseId;
+  final String inputChanged;
+  final String sourceSystem;
+  final double jurisdictionMatch;
+  final double sourceAuthorityScore;
+  final double metadataCompleteness;
+  final String aminoAcidConfidenceTier;
+  final double nutrientCompleteness;
+  final double finalCandidateScore;
+  final double conflictOverlapScore;
+  final double uncertaintyPenalty;
+
+  /// Modeled amino-acid competition uncertainty band (genuinely widens with a
+  /// weaker-than-analytical provenance tier).
+  final String competitionUncertaintyBand;
+
+  /// True when the LNAA competition uncertainty was widened (non-analytical
+  /// provenance tier, partial fields, or missing source data).
+  final bool lnaaUncertaintyWidened;
+
+  final String rankerUsed;
+  final String explanation;
+  final String safetyBoundary;
+  final bool notClinicallyCalibrated;
+
+  const SourceQualityPerturbationRow({
+    required this.caseId,
+    required this.inputChanged,
+    required this.sourceSystem,
+    required this.jurisdictionMatch,
+    required this.sourceAuthorityScore,
+    required this.metadataCompleteness,
+    required this.aminoAcidConfidenceTier,
+    required this.nutrientCompleteness,
+    required this.finalCandidateScore,
+    required this.conflictOverlapScore,
+    required this.uncertaintyPenalty,
+    required this.competitionUncertaintyBand,
+    required this.lnaaUncertaintyWidened,
+    required this.rankerUsed,
+    required this.explanation,
+    required this.safetyBoundary,
+    required this.notClinicallyCalibrated,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'case_id': caseId,
+        'input_changed': inputChanged,
+        'source_system': sourceSystem,
+        'jurisdiction_match': jurisdictionMatch,
+        'source_authority_score': sourceAuthorityScore,
+        'metadata_completeness': metadataCompleteness,
+        'amino_acid_confidence_tier': aminoAcidConfidenceTier,
+        'nutrient_completeness': nutrientCompleteness,
+        'final_candidate_score': finalCandidateScore,
+        'conflict_overlap_score': conflictOverlapScore,
+        'uncertainty_penalty': uncertaintyPenalty,
+        'competition_uncertainty_band': competitionUncertaintyBand,
+        'lnaa_uncertainty_widened': lnaaUncertaintyWidened,
+        'ranker_used': rankerUsed,
+        'explanation': explanation,
+        'safety_boundary': safetyBoundary,
+        'not_clinically_calibrated': notClinicallyCalibrated,
+      };
+}
+
+/// The full deterministic report.
+class SourceQualityPerturbationReportResult {
+  final List<SourceQualityPerturbationRow> rows;
+
+  const SourceQualityPerturbationReportResult(this.rows);
+
+  SourceQualityPerturbationRow byCase(String caseId) =>
+      rows.firstWhere((r) => r.caseId == caseId);
+
+  Map<String, dynamic> toJson() => {
+        'report_type': 'source_quality_perturbation',
+        'not_clinically_calibrated': true,
+        'not_advice_text': RuleExplanation.defaultNotAdvice,
+        'safety_boundary': RuleExplanation.defaultSafetyBoundary,
+        'description':
+            'Deterministic educational analysis: how candidate scoring moves '
+                'when ONLY source/provenance quality changes, holding the '
+                'meal/conflict/model input constant. Conflict overlap remains '
+                'the dominant scoring term by construction. Not a clinical '
+                'dashboard; no user-facing advice.',
+        'rows': rows.map((r) => r.toJson()).toList(growable: false),
+      };
+
+  String toMarkdown() {
+    final b = StringBuffer()
+      ..writeln('# Source-Quality Perturbation Report')
+      ..writeln()
+      ..writeln('Educational simulation. Synthetic inputs only. Not medical '
+          'advice. Not clinically calibrated.')
+      ..writeln()
+      ..writeln('Shows how candidate scoring moves when **only** '
+          'source/provenance quality changes, holding the meal/conflict/model '
+          'input constant. Conflict overlap remains the dominant term by '
+          'construction.')
+      ..writeln()
+      ..writeln('| case | input changed | source | juris | authority | '
+          'meta cmpl | aa tier | nutrient cmpl | final | overlap | uncert | '
+          'comp band | widened |')
+      ..writeln('| --- | --- | --- | --- | --- | --- | --- | --- | --- | '
+          '--- | --- | --- | --- |');
+    for (final r in rows) {
+      b.writeln('| ${r.caseId} | ${r.inputChanged} | ${r.sourceSystem} | '
+          '${r.jurisdictionMatch.toStringAsFixed(2)} | '
+          '${r.sourceAuthorityScore.toStringAsFixed(2)} | '
+          '${r.metadataCompleteness.toStringAsFixed(2)} | '
+          '${r.aminoAcidConfidenceTier} | '
+          '${r.nutrientCompleteness.toStringAsFixed(2)} | '
+          '${r.finalCandidateScore.toStringAsFixed(4)} | '
+          '${r.conflictOverlapScore.toStringAsFixed(4)} | '
+          '${r.uncertaintyPenalty.toStringAsFixed(2)} | '
+          '${r.competitionUncertaintyBand} | ${r.lnaaUncertaintyWidened} |');
+    }
+    return b.toString();
+  }
+}
+
+/// Deterministic JSON encoder (stable key order via the model's `toJson`).
+String encodeSourceQualityReport(
+        SourceQualityPerturbationReportResult report) =>
+    const JsonEncoder.withIndent('  ').convert(report.toJson());
+
+/// Builds the report. Pure/deterministic: no I/O, no clock. Holds a fixed
+/// synthetic base context + candidate composition and sweeps source/provenance
+/// quality perturbations.
+class SourceQualityPerturbationReportRunner {
+  final MechanisticNextMealScorer scorer;
+  final MedicationEntryValidator validator;
+  final TimeAxisBuilder builder;
+
+  SourceQualityPerturbationReportRunner({
+    MechanisticNextMealScorer? scorer,
+    MedicationEntryValidator? validator,
+    TimeAxisBuilder? builder,
+  })  : scorer = scorer ?? MechanisticNextMealScorer(),
+        validator = validator ?? MedicationEntryValidator(),
+        builder = builder ?? TimeAxisBuilder();
+
+  // Fixed reference instant for deterministic timelines (UTC).
+  static final DateTime _now = DateTime.utc(2026, 1, 1, 8);
+
+  TimeAxisConflictContext _baseContext() {
+    final v = validator.validate(const RawMedicationEntry(
+      activeIngredients: ['carbidopa', 'levodopa'],
+      drugProductVariant: 'synthetic:demo',
+      strength: 100,
+      unit: 'mg',
+      form: 'tablet',
+      route: 'oral',
+      releaseType: 'immediate',
+      jurisdiction: 'US',
+      sourceDocId: 'synthetic:demo',
+    ));
+    return builder.build(
+      now: _now,
+      medicationInputs: [
+        MedicationTimelineInput(
+          id: 'm',
+          takenAt: _now.add(const Duration(minutes: 30)),
+          medicationContext: v,
+        ),
+      ],
+      mealInputs: const [],
+      userDefinedWindow: UserDefinedMealWindow(
+        window: TimelineWindow(
+          startMinute: dateTimeToMinute(_now) + 60,
+          endMinute: dateTimeToMinute(_now) + 120,
+        ),
+        source: 'report',
+      ),
+    );
+  }
+
+  /// FDC derivation code per amino-acid confidence tier (used to build the
+  /// candidate's amino-acid provenance for the tier sweep).
+  static String _codeForTier(NutrientConfidenceTier tier) => switch (tier) {
+        NutrientConfidenceTier.analytical => 'A',
+        NutrientConfidenceTier.calculated => 'CAL',
+        NutrientConfidenceTier.imputedOrAssumed => 'I',
+        NutrientConfidenceTier.unknown => 'X',
+      };
+
+  AminoAcidProfile _aaProfile(NutrientConfidenceTier tier) => AminoAcidProfile(
+        leucine: 1.8,
+        isoleucine: 1.0,
+        valine: 1.1,
+        phenylalanine: 0.9,
+        tyrosine: 0.7,
+        tryptophan: 0.3,
+        basis: 'per_serving',
+        nutrientIds: const ['504', '503', '510', '508', '509', '501'],
+        sourceRefs: const ['src.fdc.api.amino_acid_fields'],
+        derivations: {
+          'leucine': NutrientDerivation(derivationCode: _codeForTier(tier)),
+        },
+      );
+
+  CandidateFood _candidate(
+    String id, {
+    required double protein,
+    AminoAcidProfile? aa,
+    double? portionGrams = 150,
+    double? calories = 150,
+    String sourceSystem = 'synthetic',
+  }) =>
+      CandidateFood(
+        id: id,
+        name: id,
+        regionalFoodLibraryRef: sourceSystem,
+        declaredPhysicalForm: MealPhysicalForm.solid,
+        components: [
+          FoodComponent(
+            id: id,
+            name: id,
+            physicalForm: MealPhysicalForm.solid,
+            proteinGrams: protein,
+            fatGrams: 2,
+            fiberGrams: 1,
+            carbohydrateGrams: 20,
+            calories: calories,
+            portionGrams: portionGrams,
+            sourceDocId: sourceSystem,
+            aminoAcidProfile: aa,
+          ),
+        ],
+      );
+
+  CandidateMetadata _meta({
+    required double authority,
+    required double jurisdictionMatch,
+    required double provenance,
+    required double completeness,
+  }) =>
+      CandidateMetadata(
+        completeness: completeness,
+        authorityScore: authority,
+        jurisdictionMatchScore: jurisdictionMatch,
+        provenanceQuality: provenance,
+        jurisdiction: 'US',
+      );
+
+  SourceQualityPerturbationRow _row({
+    required String caseId,
+    required String inputChanged,
+    required CandidateFood candidate,
+    required CandidateMetadata metadata,
+    required NutrientConfidenceTier aaTier,
+  }) {
+    final scores = scorer.score(
+      baseContext: _baseContext(),
+      baseMealCompositionsById: const {},
+      candidates: [candidate],
+      candidateMetadata: {candidate.id: metadata},
+    );
+    final s = scores.firstWhere((e) => e.candidateFoodId == candidate.id);
+    final competition = s.upstreamResult?.competitionTimeline;
+    return SourceQualityPerturbationRow(
+      caseId: caseId,
+      inputChanged: inputChanged,
+      sourceSystem: candidate.regionalFoodLibraryRef,
+      jurisdictionMatch: s.jurisdictionMatchScore,
+      sourceAuthorityScore: s.sourceAuthorityScore,
+      metadataCompleteness: s.metadataCompletenessScore,
+      aminoAcidConfidenceTier: aaTier.name,
+      nutrientCompleteness: s.nutritionDataCompleteness,
+      finalCandidateScore: s.finalCandidateScore,
+      conflictOverlapScore: s.conflictOverlapScore,
+      uncertaintyPenalty: s.uncertaintyPenalty,
+      competitionUncertaintyBand: competition?.uncertaintyBand.name ?? 'none',
+      lnaaUncertaintyWidened:
+          competition?.lnaaSummary?.uncertaintyWidened ?? false,
+      rankerUsed: s.insufficientContext
+          ? 'legacy_fallback'
+          : 'mechanistic_primary_window_sampled',
+      explanation:
+          'Holding the meal/conflict/model input constant, only "$inputChanged" '
+          'changed. Conflict overlap remains the dominant scoring term; '
+          'provenance/metadata refine within a bounded weight.',
+      safetyBoundary: RuleExplanation.defaultSafetyBoundary,
+      notClinicallyCalibrated: true,
+    );
+  }
+
+  SourceQualityPerturbationReportResult run() {
+    final rows = <SourceQualityPerturbationRow>[];
+
+    // --- Family 1: provenance / source quality (meal held constant) ---------
+    // Same candidate composition (protein 8, analytical AA, portion known);
+    // only the CandidateMetadata changes.
+    final refAa = _aaProfile(NutrientConfidenceTier.analytical);
+    CandidateFood provCandidate(String src) =>
+        _candidate('prov_$src', protein: 8, aa: refAa, sourceSystem: src);
+
+    rows.add(_row(
+      caseId: 'prov_official_in_jurisdiction',
+      inputChanged: 'official_in_jurisdiction',
+      candidate: provCandidate('official_in_jurisdiction'),
+      metadata: _meta(
+          authority: 1.0,
+          jurisdictionMatch: 1.0,
+          provenance: 1.0,
+          completeness: 1.0),
+      aaTier: NutrientConfidenceTier.analytical,
+    ));
+    rows.add(_row(
+      caseId: 'prov_official_out_of_jurisdiction',
+      inputChanged: 'official_out_of_jurisdiction',
+      candidate: provCandidate('official_out_of_jurisdiction'),
+      metadata: _meta(
+          authority: 0.6,
+          jurisdictionMatch: 0.2,
+          provenance: 0.8,
+          completeness: 1.0),
+      aaTier: NutrientConfidenceTier.analytical,
+    ));
+    rows.add(_row(
+      caseId: 'prov_synthetic_demo',
+      inputChanged: 'synthetic_demo',
+      candidate: provCandidate('synthetic_demo'),
+      metadata: _meta(
+          authority: 0.1,
+          jurisdictionMatch: 0.1,
+          provenance: 0.1,
+          completeness: 0.3),
+      aaTier: NutrientConfidenceTier.analytical,
+    ));
+    rows.add(_row(
+      caseId: 'prov_missing_source_refs',
+      inputChanged: 'missing_source_refs',
+      candidate: provCandidate('official_in_jurisdiction'),
+      // Same authority/jurisdiction as official, but missing sourceRefs drops
+      // provenance quality + completeness (recorded missing, not fabricated).
+      metadata: _meta(
+          authority: 1.0,
+          jurisdictionMatch: 1.0,
+          provenance: 0.0,
+          completeness: 0.5),
+      aaTier: NutrientConfidenceTier.analytical,
+    ));
+    rows.add(_row(
+      caseId: 'prov_complete_metadata',
+      inputChanged: 'complete_metadata',
+      candidate: provCandidate('official_in_jurisdiction'),
+      metadata: _meta(
+          authority: 0.7,
+          jurisdictionMatch: 0.7,
+          provenance: 0.7,
+          completeness: 1.0),
+      aaTier: NutrientConfidenceTier.analytical,
+    ));
+    rows.add(_row(
+      caseId: 'prov_partial_metadata',
+      inputChanged: 'partial_metadata',
+      candidate: provCandidate('official_in_jurisdiction'),
+      metadata: _meta(
+          authority: 0.7,
+          jurisdictionMatch: 0.7,
+          provenance: 0.7,
+          completeness: 0.4),
+      aaTier: NutrientConfidenceTier.analytical,
+    ));
+
+    // --- Family 2: amino-acid confidence tier (metadata held neutral) -------
+    const neutralMeta = CandidateMetadata(
+      completeness: 0.6,
+      authorityScore: 0.5,
+      jurisdictionMatchScore: 0.5,
+      provenanceQuality: 0.5,
+      jurisdiction: 'US',
+    );
+    for (final tier in [
+      NutrientConfidenceTier.analytical,
+      NutrientConfidenceTier.calculated,
+      NutrientConfidenceTier.imputedOrAssumed,
+      NutrientConfidenceTier.unknown,
+    ]) {
+      rows.add(_row(
+        caseId: 'aa_${tier.name}',
+        inputChanged: 'amino_acid_tier_${tier.name}',
+        candidate:
+            _candidate('aa_${tier.name}', protein: 12, aa: _aaProfile(tier)),
+        metadata: neutralMeta,
+        aaTier: tier,
+      ));
+    }
+    // Missing nutrient basis: no amino-acid profile + missing portion/calories.
+    rows.add(_row(
+      caseId: 'aa_missing_nutrient_basis',
+      inputChanged: 'missing_nutrient_basis',
+      candidate: _candidate('aa_missing_nutrient_basis',
+          protein: 12, aa: null, portionGrams: null, calories: null),
+      metadata: neutralMeta,
+      aaTier: NutrientConfidenceTier.unknown,
+    ));
+
+    return SourceQualityPerturbationReportResult(List.unmodifiable(rows));
+  }
+
+  /// Scores two identical-composition candidates differing ONLY in provenance,
+  /// returning (betterProvenanceScore, worseProvenanceScore). Used to show
+  /// provenance breaks ties when conflict scores are equal.
+  ({double better, double worse}) tieBreakByProvenance() {
+    final aa = _aaProfile(NutrientConfidenceTier.analytical);
+    final best = _candidate('tie_best', protein: 8, aa: aa);
+    final worst = _candidate('tie_worst', protein: 8, aa: aa);
+    final scores = scorer.score(
+      baseContext: _baseContext(),
+      baseMealCompositionsById: const {},
+      candidates: [best, worst],
+      candidateMetadata: {
+        'tie_best': _meta(
+            authority: 1.0,
+            jurisdictionMatch: 1.0,
+            provenance: 1.0,
+            completeness: 1.0),
+        'tie_worst': _meta(
+            authority: 0.0,
+            jurisdictionMatch: 0.0,
+            provenance: 0.0,
+            completeness: 0.0),
+      },
+    );
+    return (
+      better: scores
+          .firstWhere((e) => e.candidateFoodId == 'tie_best')
+          .finalCandidateScore,
+      worse: scores
+          .firstWhere((e) => e.candidateFoodId == 'tie_worst')
+          .finalCandidateScore,
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "operator:clinical-review": "node tool/clinical_review_report.mjs",
     "operator:gate": "node tool/operator_gate.mjs",
     "mechanistic:replay": "node tool/run_mechanistic_replay.mjs",
+    "source:quality": "node tool/run_source_quality_perturbation_report.mjs",
     "live:smoke": "node tool/run_live_source_smoke.mjs"
   },
   "dependencies": {

--- a/test/source_quality_perturbation_report_test.dart
+++ b/test/source_quality_perturbation_report_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkinsum_companion/domain/entities/rule_explanation.dart';
+import 'package:parkinsum_companion/domain/usecases/next_meal_scoring_parameters.dart';
+import 'package:parkinsum_companion/domain/usecases/source_quality_perturbation_report.dart';
+
+/// P4 — source-quality perturbation report. Deterministic educational analysis
+/// of how candidate scoring moves when ONLY source/provenance quality changes,
+/// holding the meal/conflict/model input constant. Asserts the safety
+/// invariants: better provenance never hurts, conflict overlap stays dominant,
+/// weaker amino-acid provenance widens uncertainty, and no advice copy leaks.
+void main() {
+  final runner = SourceQualityPerturbationReportRunner();
+
+  test('report is generated deterministically', () {
+    final a = encodeSourceQualityReport(runner.run());
+    final b = encodeSourceQualityReport(runner.run());
+    expect(a, b);
+    expect(runner.run().rows, isNotEmpty);
+  });
+
+  test('official in-jurisdiction is not lower than synthetic equivalent', () {
+    final r = runner.run();
+    final official = r.byCase('prov_official_in_jurisdiction');
+    final synthetic = r.byCase('prov_synthetic_demo');
+    // Same meal/conflict input; only provenance differs.
+    expect(official.conflictOverlapScore,
+        closeTo(synthetic.conflictOverlapScore, 1e-9));
+    expect(official.finalCandidateScore,
+        greaterThanOrEqualTo(synthetic.finalCandidateScore));
+    expect(official.sourceAuthorityScore,
+        greaterThan(synthetic.sourceAuthorityScore));
+  });
+
+  test('missing sourceRefs lowers provenance quality (and the score)', () {
+    final r = runner.run();
+    final missing = r.byCase('prov_missing_source_refs');
+    final official = r.byCase('prov_official_in_jurisdiction');
+    // Identical authority/jurisdiction + identical conflict input; missing
+    // sourceRefs drops provenance quality + completeness, so the score is lower.
+    expect(missing.conflictOverlapScore,
+        closeTo(official.conflictOverlapScore, 1e-9));
+    expect(missing.finalCandidateScore, lessThan(official.finalCandidateScore));
+  });
+
+  test('imputed/assumed amino-acid tier widens uncertainty vs analytical', () {
+    final r = runner.run();
+    final analytical = r.byCase('aa_analytical');
+    final imputed = r.byCase('aa_imputedOrAssumed');
+    // Same composition + overlap; only the amino-acid provenance tier differs.
+    expect(analytical.lnaaUncertaintyWidened, isFalse);
+    expect(imputed.lnaaUncertaintyWidened, isTrue);
+    expect(analytical.competitionUncertaintyBand, 'narrow');
+    expect(imputed.competitionUncertaintyBand, isNot('narrow'));
+  });
+
+  test('conflict overlap stays dominant: provenance swing is bounded', () {
+    // Two identical-composition candidates (same conflict overlap) differing
+    // ONLY in provenance (best vs worst). The provenance-driven score swing is
+    // bounded by the summed provenance weights, which the conflict-dominant
+    // invariant keeps strictly below the conflict-overlap weight. So provenance
+    // can refine ranking but can never overpower a substantial conflict gap.
+    final t = runner.tieBreakByProvenance();
+    final swing = t.better - t.worse;
+    final params = NextMealScoringParameterSet.literatureInformedDefault();
+    expect(swing, greaterThanOrEqualTo(0.0));
+    expect(swing, lessThanOrEqualTo(params.provenanceWeightSum + 1e-9));
+    expect(params.provenanceWeightSum, lessThan(params.conflictOverlap.value));
+  });
+
+  test('provenance breaks ties when conflict scores are close', () {
+    // Identical-composition candidates differing ONLY in provenance: the better
+    // provenance ranks strictly higher than the worst (a bounded refinement).
+    final t = runner.tieBreakByProvenance();
+    expect(t.better, greaterThan(t.worse));
+  });
+
+  test('report contains no medical-advice phrasing', () {
+    final report = runner.run();
+    final json = encodeSourceQualityReport(report);
+    final md = report.toMarkdown();
+    expect(findBannedSubstrings(json), isEmpty);
+    expect(findBannedSubstrings(md), isEmpty);
+    // Every row carries the shared safety boundary + not-calibrated marker.
+    for (final row in report.rows) {
+      expect(row.safetyBoundary, RuleExplanation.defaultSafetyBoundary);
+      expect(row.notClinicallyCalibrated, isTrue);
+    }
+  });
+
+  test('every scored row uses the mechanistic-primary ranker', () {
+    for (final row in runner.run().rows) {
+      expect(row.rankerUsed, 'mechanistic_primary_window_sampled');
+    }
+  });
+}

--- a/tool/run_source_quality_perturbation_report.dart
+++ b/tool/run_source_quality_perturbation_report.dart
@@ -1,0 +1,42 @@
+// Runs the source-quality perturbation analysis and writes a machine-readable
+// report under build/source_quality_perturbation/.
+//
+// Usage:
+//   dart run tool/run_source_quality_perturbation_report.dart
+//
+// Deterministic educational analysis over synthetic inputs. Shows how candidate
+// scoring moves when ONLY source/provenance quality changes, holding the
+// meal/conflict/model input constant. Not a clinical dashboard; no medical
+// advice. Exits non-zero only if a banned prescriptive substring leaks.
+
+import 'dart:io';
+
+import 'package:parkinsum_companion/domain/entities/rule_explanation.dart';
+import 'package:parkinsum_companion/domain/usecases/source_quality_perturbation_report.dart';
+
+Future<void> main(List<String> args) async {
+  final runner = SourceQualityPerturbationReportRunner();
+  final report = runner.run();
+
+  final outDir = Directory('build/source_quality_perturbation');
+  if (!outDir.existsSync()) {
+    outDir.createSync(recursive: true);
+  }
+  final jsonStr = encodeSourceQualityReport(report);
+  final mdStr = report.toMarkdown();
+  File('${outDir.path}/latest.json').writeAsStringSync(jsonStr);
+  File('${outDir.path}/latest.md').writeAsStringSync(mdStr);
+
+  // Safety gate: the report's copy must stay non-prescriptive.
+  final banned = findBannedSubstrings('$jsonStr\n$mdStr');
+
+  stdout
+    ..writeln('Source-quality perturbation report: ${report.rows.length} rows.')
+    ..writeln('Report: ${outDir.path}/latest.json')
+    ..writeln('Report: ${outDir.path}/latest.md');
+  if (banned.isNotEmpty) {
+    stderr.writeln('Banned prescriptive substrings leaked: $banned');
+    exit(1);
+  }
+  exit(0);
+}

--- a/tool/run_source_quality_perturbation_report.mjs
+++ b/tool/run_source_quality_perturbation_report.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+// Thin wrapper so `npm run source:quality` invokes the Dart report runner.
+// Synthetic inputs only. Deterministic educational analysis; not medical advice.
+
+import { spawnSync } from 'node:child_process';
+
+const result = spawnSync(
+  'dart',
+  ['run', 'tool/run_source_quality_perturbation_report.dart'],
+  { stdio: 'inherit' },
+);
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary

Adds a deterministic, test-backed CLI artifact that makes the engine's
**source/provenance sensitivity auditable**: it shows how next-meal candidate
scoring moves when **only** source/provenance quality changes, holding the
meal / conflict / model input constant. Independent of #36 / #37 (branches off
base).

It **reuses** `MechanisticNextMealScorer` — no scoring-algorithm change — and is
**not a clinical dashboard** and **not** UI.

## What it does

- New `SourceQualityPerturbationReportRunner` fixes one synthetic base context +
  candidate composition and sweeps two perturbation families:
  1. **Provenance / source quality** (meal held constant): official
     in-jurisdiction, official out-of-jurisdiction, synthetic/demo, missing
     sourceRefs, complete vs partial metadata.
  2. **Amino-acid confidence tier** (metadata neutral): analytical / calculated
     / imputed-or-assumed / unknown / missing nutrient basis.
- New `tool/run_source_quality_perturbation_report.dart` (+ `.mjs` wrapper, npm
  `source:quality`) writes `build/source_quality_perturbation/latest.{json,md}`,
  mirroring the replay runner.
- Each row: `case_id`, `input_changed`, `source_system`, `jurisdiction_match`,
  `source_authority_score`, `metadata_completeness`, `amino_acid_confidence_tier`,
  `nutrient_completeness`, `final_candidate_score`, `conflict_overlap_score`,
  `uncertainty_penalty`, `competition_uncertainty_band`,
  `lnaa_uncertainty_widened`, `ranker_used`, `explanation`, `safety_boundary`,
  `not_clinically_calibrated`.

## Invariants (test-backed)

- Deterministic generation.
- Official in-jurisdiction ≥ synthetic equivalent when other inputs match.
- Missing sourceRefs lowers provenance quality (and the score), conflict overlap
  held constant.
- Imputed/assumed amino-acid tier **widens the competition uncertainty band** vs
  analytical (`lnaa_uncertainty_widened = true`).
- **Conflict overlap stays dominant**: the provenance-driven score swing (best vs
  worst provenance on an identical composition) is bounded by the summed
  provenance weights, which the scorer's `conflictRemainsDominant` invariant keeps
  strictly below the conflict-overlap weight — provenance can break a tie but can
  never overpower a substantial conflict gap.
- No medical-advice phrasing; every row carries the shared safety boundary and
  `not_clinically_calibrated = true`.

## Docs
New `docs/SOURCE_QUALITY_PERTURBATION_REPORT.md` + scorecard S9 reusability note.

## Verification
- `dart format .` clean · `flutter analyze` clean
- `flutter test --concurrency=1` → **424 passed**
- `npm run public:preflight` → **0 BLOCKER**
- `node tool/firestore_rules_contract_check.mjs` → **13/13**
- `dart run tool/run_mechanistic_replay.dart` → **41/41** (unchanged)
- `dart run tool/run_source_quality_perturbation_report.dart` & `npm run
  source:quality` → 11 rows written

## Known limitations
Deterministic educational analysis over synthetic inputs; not a clinical
dashboard; no user-facing advice; no PHI; not clinically calibrated. The scoring
algorithm is unchanged — the report only observes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
