### PR TITLE
Wire FDC provenance into metadata completeness

### DIFF
--- a/docs/BIOMEDICAL_STANDARDS_CONFORMANCE_SCORECARD.md
+++ b/docs/BIOMEDICAL_STANDARDS_CONFORMANCE_SCORECARD.md
@@ -211,8 +211,21 @@ boundary.
   `complete` grade), and the FDC amino-acid block is captured more fully
   (lysine/cystine/arginine added for representation completeness; competing-LNAA
   math unchanged).
-- **Safety:** provenance only; never fabricate a sample count or method; missing
-  → never higher confidence.
+- **P5 shipped (full metadata integration):** the tier is now stored explicitly
+  on `FoodVariantMetadata` (`nutrientConfidenceTier`, `aminoAcidConfidenceTier`,
+  `nutrientDataType`, `nutrientDataPoints`, `nutrientDerivationSource`,
+  `nutrientProvenanceQuality`, `usesAnalytical/Calculated/ImputedOrAssumedNutrientValues`,
+  `nutrientProvenanceLimitationText`) and populated by
+  `NextMealRecommendationOrchestrator._buildCandidateMetadata`, so it is
+  serializable and flows through `CandidateMetadata.completeness` →
+  `MechanisticCandidateScore` (was previously LNAA-uncertainty-only). The
+  source-quality perturbation report surfaces `nutrient_confidence_tier` /
+  `nutrient_provenance_quality` / `provenance_quality_score` / `confidence_band`
+  and a case showing authority and provenance tier move **independently**.
+- **Safety:** provenance/**source-quality** signals only — not clinical/biological
+  accuracy; never fabricate a sample count or method; missing → never higher
+  confidence; tier never overrides source-authority/jurisdiction policy or
+  conflict-overlap dominance.
 
 ### S6 — FAO/INFOODS component identifiers (tagnames) — ⬜ Absent
 

--- a/docs/CONFLICT_ENGINE_MODEL.md
+++ b/docs/CONFLICT_ENGINE_MODEL.md
@@ -324,7 +324,14 @@ proxy and additionally exposes, in `CompetitionLnaaSummary`:
   like partial handling. This is a provenance signal, **not** a
   measurement-uncertainty or clinical-accuracy estimate; a missing derivation
   stays missing and never raises confidence
-  (`src.usda.fdc.foundation_docs`).
+  (`src.usda.fdc.foundation_docs`). Beyond LNAA uncertainty, the tier now also
+  feeds **candidate metadata completeness** (`MetadataCompletenessGate
+  .scoreCandidateFood` → `CandidateMetadata.completeness` →
+  `MechanisticCandidateScore`) and is stored explicitly on `FoodVariantMetadata`,
+  so source quality affects ranking confidence/tie-breaking — never advice, and
+  never overriding source-authority/jurisdiction policy or conflict dominance
+  (see `docs/IMPORTER_METADATA_FLOW.md` §9 and
+  `docs/SOURCE_QUALITY_PERTURBATION_REPORT.md`).
 
 The modeled overlap represents **intestinal-absorption** competition; broader
 blood–brain-barrier LNAA transport competition is named as a cited mechanism in

--- a/docs/IMPORTER_METADATA_FLOW.md
+++ b/docs/IMPORTER_METADATA_FLOW.md
@@ -119,6 +119,24 @@ fallback). Provenance metadata is carried alongside as
 food, and rule explanation. Composes with the hard `MedicationEntryValidator`
 gate; adds the softer downgrade/uncertainty layer.
 
+**FDC nutrient provenance tier (P5).** `scoreCandidateFood(...,
+nutrientConfidenceTier:)` factors the USDA FDC amino-acid derivation tier
+(analytical > calculated > imputed/assumed > unknown) into the candidate-food
+grade: a weaker-than-analytical tier counts as one missing-equivalent, and an
+imputed/unknown tier blocks the top `complete` grade. This tier is now also
+**stored explicitly on `FoodVariantMetadata`** (`nutrientConfidenceTier`,
+`aminoAcidConfidenceTier`, `nutrientDataType`, `nutrientDataPoints`,
+`nutrientDerivationSource`, `nutrientProvenanceQuality`,
+`usesAnalytical/Calculated/ImputedOrAssumedNutrientValues`,
+`nutrientProvenanceLimitationText`) so it is serializable and visible, not just a
+transient gate argument. It was previously wired only into LNAA uncertainty.
+The graded completeness flows into `CandidateMetadata.completeness` →
+`MechanisticCandidateScore`, so source quality affects ranking **confidence and
+tie-breaking** — never advice. These tiers are **source-quality signals, not
+clinical/biological accuracy**; a missing derivation yields a null tier and never
+raises confidence; the tier never overrides source-authority or jurisdiction
+policy, and conflict overlap stays dominant.
+
 ### 9a. Componentized meal-history join
 
 Historical meals are modeled as one `FoodComponent` per logged `MealItem`

--- a/docs/SOURCE_QUALITY_PERTURBATION_REPORT.md
+++ b/docs/SOURCE_QUALITY_PERTURBATION_REPORT.md
@@ -38,15 +38,27 @@ the source/provenance perturbation variables, recording the resulting scores.
 2. **Amino-acid confidence tier** (metadata held neutral): analytical /
    calculated / imputed-or-assumed / unknown, plus a missing-nutrient-basis
    case. Only the candidate's amino-acid provenance tier changes.
+3. **Source authority × nutrient provenance tier** (P5): a synthetic source with
+   analytical nutrient provenance vs an official source with imputed provenance —
+   demonstrating that *who published the value* (authority) and *how the value
+   was derived* (FDC tier) are distinct axes that do not collapse into each
+   other.
 
 ## Row fields
 
 `case_id`, `input_changed`, `source_system`, `jurisdiction_match`,
-`source_authority_score`, `metadata_completeness`, `amino_acid_confidence_tier`,
-`nutrient_completeness`, `final_candidate_score`, `conflict_overlap_score`,
-`uncertainty_penalty`, `competition_uncertainty_band`,
+`source_authority_score`, `metadata_completeness` (+ `metadata_completeness_score`),
+`amino_acid_confidence_tier`, `nutrient_confidence_tier` (P5),
+`nutrient_provenance_quality` (P5), `provenance_quality_score` (P5),
+`confidence_band` (P5), `nutrient_completeness`, `final_candidate_score`,
+`conflict_overlap_score`, `uncertainty_penalty`, `competition_uncertainty_band`,
 `lnaa_uncertainty_widened`, `ranker_used`, `explanation`, `safety_boundary`,
 `not_clinically_calibrated`.
+
+`nutrient_provenance_quality` is a deterministic 0..1 **source-quality** signal
+mapped from the FDC tier (analytical 1.0 / calculated 0.7 / imputed 0.4 /
+unknown 0.2) — it describes how the value was derived, **not** clinical or
+biological accuracy.
 
 ## Invariants (enforced by tests)
 

--- a/lib/domain/entities/nutrient_derivation.dart
+++ b/lib/domain/entities/nutrient_derivation.dart
@@ -54,6 +54,32 @@ int nutrientConfidenceRank(NutrientConfidenceTier t) {
 bool tierWidensUncertainty(NutrientConfidenceTier t) =>
     t != NutrientConfidenceTier.analytical;
 
+/// Deterministic 0..1 **source-quality** signal for a nutrient confidence tier.
+/// This describes how the value was *derived*, NOT clinical/biological accuracy.
+/// Used for reporting/visibility (e.g. `FoodVariantMetadata.nutrientProvenanceQuality`);
+/// it does not, by itself, change candidate ranking.
+double nutrientProvenanceQualityFor(NutrientConfidenceTier t) {
+  switch (t) {
+    case NutrientConfidenceTier.analytical:
+      return 1.0;
+    case NutrientConfidenceTier.calculated:
+      return 0.7;
+    case NutrientConfidenceTier.imputedOrAssumed:
+      return 0.4;
+    case NutrientConfidenceTier.unknown:
+      return 0.2;
+  }
+}
+
+/// Non-prescriptive source-quality caution for a weaker-than-analytical tier, or
+/// null for analytical (no caution needed). Never a clinical claim.
+String? nutrientProvenanceLimitationFor(NutrientConfidenceTier t) {
+  if (t == NutrientConfidenceTier.analytical) return null;
+  return 'Amino-acid/nutrient values are ${t.name}-derived (a source-quality '
+      'signal, not clinical accuracy); modeled confidence is lowered, not the '
+      'value itself.';
+}
+
 class NutrientDerivation {
   /// FDC `foodNutrientDerivation.code` (e.g. analytical / calculated codes).
   final String? derivationCode;

--- a/lib/domain/entities/source_metadata.dart
+++ b/lib/domain/entities/source_metadata.dart
@@ -184,6 +184,43 @@ class FoodVariantMetadata {
   final List<String> sourceRefs;
   final String limitationText;
 
+  // --- FDC nutrient provenance (P5) -----------------------------------------
+  // All optional/additive: null/false when no derivation provenance is carried
+  // (missing never raises confidence). These are **source-quality signals**,
+  // not clinical/biological accuracy estimates.
+
+  /// Aggregate FDC nutrient confidence tier name (analytical / calculated /
+  /// imputedOrAssumed / unknown), or null when no derivation provenance.
+  final String? nutrientConfidenceTier;
+
+  /// Amino-acid-specific confidence tier name (usually equal to
+  /// `nutrientConfidenceTier` in this prototype), or null.
+  final String? aminoAcidConfidenceTier;
+
+  /// FDC `dataType` (e.g. Foundation / SR Legacy / Branded), when known.
+  final String? nutrientDataType;
+
+  /// A representative FDC `dataPoints` count (number of observations), or null
+  /// (unknown never raises confidence — it is not treated as zero).
+  final int? nutrientDataPoints;
+
+  /// A representative FDC derivation source/code, when known.
+  final String? nutrientDerivationSource;
+
+  /// Deterministic 0..1 source-quality signal derived from the tier
+  /// (analytical 1.0 / calculated 0.7 / imputed 0.4 / unknown 0.2). Null when no
+  /// tier. **Reporting/visibility only** — not a clinical accuracy estimate.
+  final double? nutrientProvenanceQuality;
+
+  final bool usesAnalyticalNutrientValues;
+  final bool usesCalculatedNutrientValues;
+  final bool usesImputedOrAssumedNutrientValues;
+
+  /// Human-readable note when nutrient values are weaker-than-analytical
+  /// (source-quality caution, never a clinical claim). Null when analytical or
+  /// no provenance.
+  final String? nutrientProvenanceLimitationText;
+
   const FoodVariantMetadata({
     required this.foodVariantId,
     required this.sourceSystem,
@@ -197,6 +234,16 @@ class FoodVariantMetadata {
     required this.extractionConfidence,
     required this.sourceRefs,
     required this.limitationText,
+    this.nutrientConfidenceTier,
+    this.aminoAcidConfidenceTier,
+    this.nutrientDataType,
+    this.nutrientDataPoints,
+    this.nutrientDerivationSource,
+    this.nutrientProvenanceQuality,
+    this.usesAnalyticalNutrientValues = false,
+    this.usesCalculatedNutrientValues = false,
+    this.usesImputedOrAssumedNutrientValues = false,
+    this.nutrientProvenanceLimitationText,
   });
 
   Map<String, dynamic> toJson() => {
@@ -212,5 +259,16 @@ class FoodVariantMetadata {
         'extraction_confidence': extractionConfidence,
         'source_refs': sourceRefs,
         'limitation_text': limitationText,
+        'nutrient_confidence_tier': nutrientConfidenceTier,
+        'amino_acid_confidence_tier': aminoAcidConfidenceTier,
+        'nutrient_data_type': nutrientDataType,
+        'nutrient_data_points': nutrientDataPoints,
+        'nutrient_derivation_source': nutrientDerivationSource,
+        'nutrient_provenance_quality': nutrientProvenanceQuality,
+        'uses_analytical_nutrient_values': usesAnalyticalNutrientValues,
+        'uses_calculated_nutrient_values': usesCalculatedNutrientValues,
+        'uses_imputed_or_assumed_nutrient_values':
+            usesImputedOrAssumedNutrientValues,
+        'nutrient_provenance_limitation_text': nutrientProvenanceLimitationText,
       };
 }

--- a/lib/domain/usecases/next_meal_recommendation_orchestrator.dart
+++ b/lib/domain/usecases/next_meal_recommendation_orchestrator.dart
@@ -14,6 +14,8 @@ import 'dosage_note_parser.dart';
 import '../entities/meal_composition.dart';
 import '../entities/next_meal_recommendation_models.dart';
 import '../entities/cdss_records.dart';
+import '../entities/amino_acid_profile.dart';
+import '../entities/nutrient_derivation.dart';
 import '../entities/source_metadata.dart';
 import '../entities/time_axis_events.dart';
 import 'catalog_food_to_candidate.dart';
@@ -852,6 +854,13 @@ class NextMealRecommendationOrchestrator {
           coreFields.where((f) => !item.isNutrientMissing(f)).length;
       final nutrientCompleteness = presentCount / coreFields.length;
 
+      // FDC nutrient provenance (P5): make the amino-acid derivation tier
+      // explicit + serializable on the food metadata (it was previously only a
+      // transient argument to the gate). These are source-quality signals, not
+      // clinical/biological accuracy; a null tier (no derivation) stays inert.
+      final aaProfile = item.aminoAcidProfile;
+      final nutrientTier = aaProfile?.aggregateConfidenceTier;
+      final representativeDerivation = _representativeDerivation(aaProfile);
       final foodMeta = FoodVariantMetadata(
         foodVariantId: item.id,
         sourceSystem: item.sourceSystem,
@@ -861,18 +870,36 @@ class NextMealRecommendationOrchestrator {
         basisType: item.basisType,
         servingUnit: null,
         preparationState: item.preparationState ?? 'unknown',
-        aminoAcidFieldsPresent: item.aminoAcidProfile != null,
+        aminoAcidFieldsPresent: aaProfile != null,
         extractionConfidence: null,
         sourceRefs: source.sourceRefs,
         limitationText: source.limitationText,
+        nutrientConfidenceTier: nutrientTier?.name,
+        aminoAcidConfidenceTier: nutrientTier?.name,
+        nutrientDataType: aaProfile?.fdcDataType,
+        nutrientDataPoints: representativeDerivation?.dataPoints,
+        nutrientDerivationSource: representativeDerivation?.sourceCode ??
+            representativeDerivation?.derivationCode,
+        nutrientProvenanceQuality: nutrientTier == null
+            ? null
+            : nutrientProvenanceQualityFor(nutrientTier),
+        usesAnalyticalNutrientValues:
+            nutrientTier == NutrientConfidenceTier.analytical,
+        usesCalculatedNutrientValues:
+            nutrientTier == NutrientConfidenceTier.calculated,
+        usesImputedOrAssumedNutrientValues:
+            nutrientTier == NutrientConfidenceTier.imputedOrAssumed,
+        nutrientProvenanceLimitationText: nutrientTier == null
+            ? null
+            : nutrientProvenanceLimitationFor(nutrientTier),
       );
       final completenessScore = _completenessGate.scoreCandidateFood(
         foodMeta,
         nutrientCompleteness: nutrientCompleteness,
-        // FDC nutrient provenance (B1 follow-up): a calculated/imputed/unknown
-        // amino-acid derivation tier downgrades the candidate-food completeness
-        // grade, not just the LNAA-layer uncertainty.
-        nutrientConfidenceTier: item.aminoAcidProfile?.aggregateConfidenceTier,
+        // FDC nutrient provenance: a calculated/imputed/unknown amino-acid
+        // derivation tier downgrades the candidate-food completeness grade, not
+        // just the LNAA-layer uncertainty.
+        nutrientConfidenceTier: nutrientTier,
       );
       final completeness = _completenessGate.toWeight(completenessScore);
 
@@ -899,6 +926,19 @@ class NextMealRecommendationOrchestrator {
       );
     }
     return result;
+  }
+
+  /// Picks a representative FDC derivation for provenance display: the one whose
+  /// tier matches the profile's weakest-wins aggregate tier (so the surfaced
+  /// dataPoints/source align with the reported tier), else the first available.
+  /// Returns null when no derivation provenance is carried.
+  NutrientDerivation? _representativeDerivation(AminoAcidProfile? profile) {
+    if (profile == null || profile.derivations.isEmpty) return null;
+    final aggregate = profile.aggregateConfidenceTier;
+    for (final d in profile.derivations.values) {
+      if (d.tier == aggregate) return d;
+    }
+    return profile.derivations.values.first;
   }
 
   List<String> _userJurisdictionChain(UserProfile profile) {

--- a/lib/domain/usecases/source_quality_perturbation_report.dart
+++ b/lib/domain/usecases/source_quality_perturbation_report.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import '../entities/amino_acid_profile.dart';
 import '../entities/meal_composition.dart';
+import '../entities/nutrient_derivation.dart';
 import '../entities/rule_explanation.dart';
 import '../entities/time_axis_events.dart';
 import 'mechanistic_next_meal_scorer.dart';
@@ -22,6 +23,22 @@ class SourceQualityPerturbationRow {
   final double sourceAuthorityScore;
   final double metadataCompleteness;
   final String aminoAcidConfidenceTier;
+
+  /// FDC nutrient confidence tier name (in this prototype usually equal to the
+  /// amino-acid tier). Surfaced explicitly per P5.
+  final String nutrientConfidenceTier;
+
+  /// Deterministic 0..1 source-quality signal for the nutrient tier (analytical
+  /// 1.0 / calculated 0.7 / imputed 0.4 / unknown 0.2). Source-quality only, not
+  /// clinical accuracy.
+  final double nutrientProvenanceQuality;
+
+  /// Candidate provenance-quality ranking term (`score.provenanceQualityScore`).
+  final double provenanceQualityScore;
+
+  /// Modeled confidence band name for the candidate.
+  final String confidenceBand;
+
   final double nutrientCompleteness;
   final double finalCandidateScore;
   final double conflictOverlapScore;
@@ -48,6 +65,10 @@ class SourceQualityPerturbationRow {
     required this.sourceAuthorityScore,
     required this.metadataCompleteness,
     required this.aminoAcidConfidenceTier,
+    required this.nutrientConfidenceTier,
+    required this.nutrientProvenanceQuality,
+    required this.provenanceQualityScore,
+    required this.confidenceBand,
     required this.nutrientCompleteness,
     required this.finalCandidateScore,
     required this.conflictOverlapScore,
@@ -67,7 +88,12 @@ class SourceQualityPerturbationRow {
         'jurisdiction_match': jurisdictionMatch,
         'source_authority_score': sourceAuthorityScore,
         'metadata_completeness': metadataCompleteness,
+        'metadata_completeness_score': metadataCompleteness,
         'amino_acid_confidence_tier': aminoAcidConfidenceTier,
+        'nutrient_confidence_tier': nutrientConfidenceTier,
+        'nutrient_provenance_quality': nutrientProvenanceQuality,
+        'provenance_quality_score': provenanceQualityScore,
+        'confidence_band': confidenceBand,
         'nutrient_completeness': nutrientCompleteness,
         'final_candidate_score': finalCandidateScore,
         'conflict_overlap_score': conflictOverlapScore,
@@ -117,16 +143,19 @@ class SourceQualityPerturbationReportResult {
           'construction.')
       ..writeln()
       ..writeln('| case | input changed | source | juris | authority | '
-          'meta cmpl | aa tier | nutrient cmpl | final | overlap | uncert | '
-          'comp band | widened |')
-      ..writeln('| --- | --- | --- | --- | --- | --- | --- | --- | --- | '
-          '--- | --- | --- | --- |');
+          'meta cmpl | aa tier | nutrient prov q | prov q | conf band | '
+          'nutrient cmpl | final | overlap | uncert | comp band | widened |')
+      ..writeln('| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | '
+          '--- | --- | --- | --- | --- | --- |');
     for (final r in rows) {
       b.writeln('| ${r.caseId} | ${r.inputChanged} | ${r.sourceSystem} | '
           '${r.jurisdictionMatch.toStringAsFixed(2)} | '
           '${r.sourceAuthorityScore.toStringAsFixed(2)} | '
           '${r.metadataCompleteness.toStringAsFixed(2)} | '
           '${r.aminoAcidConfidenceTier} | '
+          '${r.nutrientProvenanceQuality.toStringAsFixed(2)} | '
+          '${r.provenanceQualityScore.toStringAsFixed(2)} | '
+          '${r.confidenceBand} | '
           '${r.nutrientCompleteness.toStringAsFixed(2)} | '
           '${r.finalCandidateScore.toStringAsFixed(4)} | '
           '${r.conflictOverlapScore.toStringAsFixed(4)} | '
@@ -284,6 +313,10 @@ class SourceQualityPerturbationReportRunner {
       sourceAuthorityScore: s.sourceAuthorityScore,
       metadataCompleteness: s.metadataCompletenessScore,
       aminoAcidConfidenceTier: aaTier.name,
+      nutrientConfidenceTier: aaTier.name,
+      nutrientProvenanceQuality: nutrientProvenanceQualityFor(aaTier),
+      provenanceQualityScore: s.provenanceQualityScore,
+      confidenceBand: s.confidenceBand.name,
       nutrientCompleteness: s.nutritionDataCompleteness,
       finalCandidateScore: s.finalCandidateScore,
       conflictOverlapScore: s.conflictOverlapScore,
@@ -413,6 +446,40 @@ class SourceQualityPerturbationReportRunner {
           protein: 12, aa: null, portionGrams: null, calories: null),
       metadata: neutralMeta,
       aaTier: NutrientConfidenceTier.unknown,
+    ));
+
+    // --- Family 3: source authority × provenance tier move independently -----
+    // A synthetic source with analytical nutrient provenance vs an official
+    // source with imputed provenance: authority and nutrient-provenance tier are
+    // distinct axes (one is who published it; the other is how the value was
+    // derived). Neither collapses into the other.
+    rows.add(_row(
+      caseId: 'mix_synthetic_source_analytical_provenance',
+      inputChanged: 'synthetic_source_analytical_provenance',
+      candidate: _candidate('mix_synth_analytical',
+          protein: 8,
+          aa: _aaProfile(NutrientConfidenceTier.analytical),
+          sourceSystem: 'synthetic_demo'),
+      metadata: _meta(
+          authority: 0.1,
+          jurisdictionMatch: 0.1,
+          provenance: 0.1,
+          completeness: 0.3),
+      aaTier: NutrientConfidenceTier.analytical,
+    ));
+    rows.add(_row(
+      caseId: 'mix_official_source_imputed_provenance',
+      inputChanged: 'official_source_imputed_provenance',
+      candidate: _candidate('mix_official_imputed',
+          protein: 8,
+          aa: _aaProfile(NutrientConfidenceTier.imputedOrAssumed),
+          sourceSystem: 'official_in_jurisdiction'),
+      metadata: _meta(
+          authority: 1.0,
+          jurisdictionMatch: 1.0,
+          provenance: 1.0,
+          completeness: 1.0),
+      aaTier: NutrientConfidenceTier.imputedOrAssumed,
     ));
 
     return SourceQualityPerturbationReportResult(List.unmodifiable(rows));

--- a/test/fdc_provenance_metadata_completeness_test.dart
+++ b/test/fdc_provenance_metadata_completeness_test.dart
@@ -1,0 +1,267 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkinsum_companion/domain/entities/meal_composition.dart';
+import 'package:parkinsum_companion/domain/entities/nutrient_derivation.dart';
+import 'package:parkinsum_companion/domain/entities/rule_explanation.dart';
+import 'package:parkinsum_companion/domain/entities/source_metadata.dart';
+import 'package:parkinsum_companion/domain/entities/time_axis_events.dart';
+import 'package:parkinsum_companion/domain/entities/mechanistic_candidate_score.dart';
+import 'package:parkinsum_companion/domain/usecases/mechanistic_next_meal_scorer.dart';
+import 'package:parkinsum_companion/domain/usecases/medication_entry_validator.dart';
+import 'package:parkinsum_companion/domain/usecases/metadata_completeness_gate.dart';
+import 'package:parkinsum_companion/domain/usecases/time_axis_builder.dart';
+
+/// P5 — FDC nutrient provenance tier → FoodVariantMetadata + completeness +
+/// ranking. Verifies the tier is explicit/serializable on the metadata, that the
+/// completeness gate orders analytical > calculated > imputed > unknown, that
+/// missing nutrient is worse than weak-but-present provenance, that true 0 g is
+/// not missing, and that the tier flows through the gate → weight →
+/// CandidateMetadata.completeness → scorer (analytical ranks >= imputed), while
+/// conflict overlap stays dominant. Source-quality only; no clinical claim.
+void main() {
+  final gate = MetadataCompletenessGate();
+
+  FoodVariantMetadata foodMeta({
+    String? tier,
+    double? provenanceQuality,
+    String? limitation,
+  }) =>
+      FoodVariantMetadata(
+        foodVariantId: 'f1',
+        sourceSystem: 'usda_fdc',
+        jurisdiction: 'US',
+        language: 'und',
+        foodName: 'demo food (synthetic)',
+        basisType: 'per_100g',
+        servingUnit: 'g',
+        preparationState: 'raw',
+        aminoAcidFieldsPresent: true,
+        extractionConfidence: null,
+        sourceRefs: const ['src.usda.fdc.foundation_docs'],
+        limitationText: 'educational',
+        nutrientConfidenceTier: tier,
+        aminoAcidConfidenceTier: tier,
+        nutrientProvenanceQuality: provenanceQuality,
+        nutrientProvenanceLimitationText: limitation,
+      );
+
+  group('FoodVariantMetadata provenance fields', () {
+    test('new fields serialize deterministically; null stays null', () {
+      final meta = foodMeta(
+        tier: 'analytical',
+        provenanceQuality: 1.0,
+      );
+      final json = meta.toJson();
+      expect(json['nutrient_confidence_tier'], 'analytical');
+      expect(json['amino_acid_confidence_tier'], 'analytical');
+      expect(json['nutrient_provenance_quality'], 1.0);
+      expect(
+          json['uses_analytical_nutrient_values'], false); // default unless set
+      expect(json['nutrient_provenance_limitation_text'], isNull);
+      expect(jsonEncode(meta.toJson()), jsonEncode(meta.toJson()));
+      // A metadata with no provenance keeps the fields null/false (inert).
+      final bare = foodMeta();
+      expect(bare.toJson()['nutrient_confidence_tier'], isNull);
+      expect(bare.toJson()['nutrient_provenance_quality'], isNull);
+    });
+  });
+
+  group('tier → source-quality helpers', () {
+    test('quality is ordered analytical > calculated > imputed > unknown', () {
+      final a = nutrientProvenanceQualityFor(NutrientConfidenceTier.analytical);
+      final c = nutrientProvenanceQualityFor(NutrientConfidenceTier.calculated);
+      final i =
+          nutrientProvenanceQualityFor(NutrientConfidenceTier.imputedOrAssumed);
+      final u = nutrientProvenanceQualityFor(NutrientConfidenceTier.unknown);
+      expect(a, greaterThan(c));
+      expect(c, greaterThan(i));
+      expect(i, greaterThan(u));
+    });
+
+    test('limitation is null for analytical, mentions the tier otherwise', () {
+      expect(nutrientProvenanceLimitationFor(NutrientConfidenceTier.analytical),
+          isNull);
+      final imputed = nutrientProvenanceLimitationFor(
+          NutrientConfidenceTier.imputedOrAssumed);
+      expect(imputed, isNotNull);
+      expect(imputed, contains('imputedOrAssumed'));
+      // Source-quality framing, not a clinical claim.
+      expect(imputed!.toLowerCase(), contains('source-quality'));
+      expect(findBannedSubstrings(imputed), isEmpty);
+    });
+  });
+
+  group('completeness gate ordering', () {
+    double w(NutrientConfidenceTier? t) =>
+        gate.toWeight(gate.scoreCandidateFood(
+          foodMeta(),
+          nutrientCompleteness: 1.0,
+          nutrientConfidenceTier: t,
+        ));
+
+    test('analytical >= calculated >= imputed/assumed >= unknown', () {
+      final a = w(NutrientConfidenceTier.analytical);
+      final c = w(NutrientConfidenceTier.calculated);
+      final i = w(NutrientConfidenceTier.imputedOrAssumed);
+      final u = w(NutrientConfidenceTier.unknown);
+      expect(a, greaterThanOrEqualTo(c));
+      expect(c, greaterThanOrEqualTo(i));
+      expect(i, greaterThanOrEqualTo(u));
+      expect(a, greaterThan(u)); // strict end-to-end separation
+    });
+
+    test('missing nutrient is worse than weak-but-present provenance', () {
+      // Hold the provenance tier equal (imputed) and vary ONLY nutrient
+      // completeness: a candidate missing most nutrients scores below one whose
+      // nutrients are fully present, even though both have weak provenance.
+      final weakButPresent = gate.toWeight(gate.scoreCandidateFood(
+        foodMeta(),
+        nutrientCompleteness: 1.0,
+        nutrientConfidenceTier: NutrientConfidenceTier.imputedOrAssumed,
+      ));
+      final missingNutrients = gate.toWeight(gate.scoreCandidateFood(
+        foodMeta(),
+        nutrientCompleteness: 0.2,
+        nutrientConfidenceTier: NutrientConfidenceTier.imputedOrAssumed,
+      ));
+      expect(missingNutrients, lessThan(weakButPresent));
+    });
+
+    test('present nutrients (incl. true 0 g) outrank missing nutrients', () {
+      // The normalizer encodes "missing ≠ true 0 g" as nutrientCompleteness
+      // (see missing_not_zero_test.dart). At the gate, full completeness (all
+      // fields present, which may include legitimate zeros) grades strictly
+      // above low completeness (fields actually missing), holding tier equal.
+      final present = gate.toWeight(gate.scoreCandidateFood(foodMeta(),
+          nutrientCompleteness: 1.0,
+          nutrientConfidenceTier: NutrientConfidenceTier.analytical));
+      final missing = gate.toWeight(gate.scoreCandidateFood(foodMeta(),
+          nutrientCompleteness: 0.2,
+          nutrientConfidenceTier: NutrientConfidenceTier.analytical));
+      expect(present, greaterThan(missing));
+    });
+
+    test('missing derivation (null tier) does not raise confidence', () {
+      final nullTier = gate.scoreCandidateFood(foodMeta(),
+          nutrientCompleteness: 1.0, nutrientConfidenceTier: null);
+      final analytical = gate.scoreCandidateFood(foodMeta(),
+          nutrientCompleteness: 1.0,
+          nutrientConfidenceTier: NutrientConfidenceTier.analytical);
+      // A null tier is inert (never better than analytical).
+      expect(gate.toWeight(nullTier),
+          lessThanOrEqualTo(gate.toWeight(analytical)));
+    });
+  });
+
+  // End-to-end: tier → gate → weight → CandidateMetadata.completeness → scorer.
+  group('tier flows into candidate ranking', () {
+    final scorer = MechanisticNextMealScorer();
+    final validator = MedicationEntryValidator();
+    final builder = TimeAxisBuilder();
+    final now = DateTime.utc(2026, 1, 1, 8);
+
+    TimeAxisConflictContext ctx() {
+      final v = validator.validate(const RawMedicationEntry(
+        activeIngredients: ['carbidopa', 'levodopa'],
+        drugProductVariant: 's',
+        strength: 100,
+        unit: 'mg',
+        form: 'tablet',
+        route: 'oral',
+        releaseType: 'immediate',
+        jurisdiction: 'US',
+        sourceDocId: 's',
+      ));
+      return builder.build(
+        now: now,
+        medicationInputs: [
+          MedicationTimelineInput(
+              id: 'm',
+              takenAt: now.add(const Duration(minutes: 30)),
+              medicationContext: v),
+        ],
+        mealInputs: const [],
+        userDefinedWindow: UserDefinedMealWindow(
+          window: TimelineWindow(
+              startMinute: dateTimeToMinute(now) + 60,
+              endMinute: dateTimeToMinute(now) + 120),
+          source: 'test',
+        ),
+      );
+    }
+
+    CandidateFood food(String id) => CandidateFood(
+          id: id,
+          name: id,
+          regionalFoodLibraryRef: 'usda_fdc',
+          declaredPhysicalForm: MealPhysicalForm.solid,
+          components: [
+            FoodComponent(
+              id: id,
+              name: id,
+              physicalForm: MealPhysicalForm.solid,
+              proteinGrams: 8,
+              fatGrams: 2,
+              fiberGrams: 1,
+              carbohydrateGrams: 20,
+              calories: 150,
+              portionGrams: 150,
+              sourceDocId: 'usda_fdc',
+            ),
+          ],
+        );
+
+    // Completeness derived through the real gate from the nutrient tier.
+    CandidateMetadata metaForTier(NutrientConfidenceTier tier) {
+      final completeness = gate.toWeight(gate.scoreCandidateFood(
+        foodMeta(),
+        nutrientCompleteness: 1.0,
+        nutrientConfidenceTier: tier,
+      ));
+      return CandidateMetadata(
+        completeness: completeness,
+        authorityScore: 0.6,
+        jurisdictionMatchScore: 0.6,
+        provenanceQuality: 0.6,
+        jurisdiction: 'US',
+      );
+    }
+
+    double scoreOf(List<MechanisticCandidateScore> s, String id) =>
+        s.firstWhere((e) => e.candidateFoodId == id).finalCandidateScore;
+
+    test('identical candidates: analytical ranks >= imputed/assumed', () {
+      final scores = scorer.score(
+        baseContext: ctx(),
+        baseMealCompositionsById: const {},
+        candidates: [food('analytical'), food('imputed')],
+        candidateMetadata: {
+          'analytical': metaForTier(NutrientConfidenceTier.analytical),
+          'imputed': metaForTier(NutrientConfidenceTier.imputedOrAssumed),
+        },
+      );
+      expect(scoreOf(scores, 'analytical'),
+          greaterThanOrEqualTo(scoreOf(scores, 'imputed')));
+    });
+
+    test('tier difference cannot break conflict-overlap dominance', () {
+      // The provenance/completeness swing from the tier is bounded and cannot
+      // overpower the dominant conflict-overlap term (same invariant as PR #38).
+      final scores = scorer.score(
+        baseContext: ctx(),
+        baseMealCompositionsById: const {},
+        candidates: [food('analytical'), food('imputed')],
+        candidateMetadata: {
+          'analytical': metaForTier(NutrientConfidenceTier.analytical),
+          'imputed': metaForTier(NutrientConfidenceTier.imputedOrAssumed),
+        },
+      );
+      final gap = scoreOf(scores, 'analytical') - scoreOf(scores, 'imputed');
+      // Identical composition ⇒ identical conflict overlap ⇒ the tier-driven
+      // gap is small (a refinement), never a dominant swing.
+      expect(gap, lessThan(0.2));
+      expect(gap, greaterThanOrEqualTo(0.0));
+    });
+  });
+}

--- a/test/source_quality_perturbation_report_test.dart
+++ b/test/source_quality_perturbation_report_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:parkinsum_companion/domain/entities/rule_explanation.dart';
 import 'package:parkinsum_companion/domain/usecases/next_meal_scoring_parameters.dart';
@@ -91,5 +93,45 @@ void main() {
     for (final row in runner.run().rows) {
       expect(row.rankerUsed, 'mechanistic_primary_window_sampled');
     }
+  });
+
+  // P5 — FDC provenance tier fields exposed in the report rows + JSON.
+  test('rows expose nutrient-provenance + confidence fields (P5)', () {
+    final report = runner.run();
+    final json = jsonDecode(encodeSourceQualityReport(report)) as Map;
+    final firstRow = (json['rows'] as List).first as Map;
+    for (final key in const [
+      'nutrient_confidence_tier',
+      'nutrient_provenance_quality',
+      'provenance_quality_score',
+      'confidence_band',
+      'metadata_completeness_score',
+    ]) {
+      expect(firstRow.containsKey(key), isTrue, reason: 'missing $key');
+    }
+    // Nutrient provenance quality is ordered by tier (analytical > imputed).
+    final analytical = report.byCase('aa_analytical').nutrientProvenanceQuality;
+    final imputed =
+        report.byCase('aa_imputedOrAssumed').nutrientProvenanceQuality;
+    final unknown = report.byCase('aa_unknown').nutrientProvenanceQuality;
+    expect(analytical, greaterThan(imputed));
+    expect(imputed, greaterThan(unknown));
+  });
+
+  test('source authority and nutrient-provenance tier move independently (P5)',
+      () {
+    final report = runner.run();
+    final synthAnalytical =
+        report.byCase('mix_synthetic_source_analytical_provenance');
+    final officialImputed =
+        report.byCase('mix_official_source_imputed_provenance');
+    // Synthetic source but analytical nutrient provenance: low authority, high
+    // nutrient provenance quality.
+    expect(synthAnalytical.sourceAuthorityScore, lessThan(0.5));
+    expect(synthAnalytical.nutrientProvenanceQuality, 1.0);
+    // Official source but imputed nutrient provenance: high authority, low
+    // nutrient provenance quality. The two axes do not collapse into each other.
+    expect(officialImputed.sourceAuthorityScore, greaterThan(0.5));
+    expect(officialImputed.nutrientProvenanceQuality, lessThan(0.5));
   });
 }


### PR DESCRIPTION
## Summary

Completes the deferred **P5** integration: the USDA FDC nutrient confidence tier
now flows **beyond LNAA uncertainty** into food metadata and candidate
completeness, so source quality is explicit, serializable, and visible —
**without changing the ranking algorithm**.

> Audit note: the tier → completeness → ranking *core* already existed (the
> orchestrator already passed `nutrientConfidenceTier` into `scoreCandidateFood`,
> whose grade feeds `CandidateMetadata.completeness`). This PR makes the tier
> **explicit/serializable** and surfaces it in reports.

## Changes

- **`FoodVariantMetadata`** gains additive, nullable nutrient-provenance fields
  (`nutrientConfidenceTier`, `aminoAcidConfidenceTier`, `nutrientDataType`,
  `nutrientDataPoints`, `nutrientDerivationSource`, `nutrientProvenanceQuality`,
  `usesAnalytical/Calculated/ImputedOrAssumedNutrientValues`,
  `nutrientProvenanceLimitationText`) + `toJson`. Null/false when no derivation
  (missing never raises confidence).
- **`nutrient_derivation.dart`** helpers: `nutrientProvenanceQualityFor`
  (analytical 1.0 / calculated 0.7 / imputed 0.4 / unknown 0.2) and
  `nutrientProvenanceLimitationFor` (null for analytical; source-quality caution,
  never a clinical claim, otherwise).
- **Orchestrator** populates those fields per candidate from the amino-acid
  profile. The tier is still passed to `scoreCandidateFood` exactly as before;
  `nutrientProvenanceQuality` is **reporting-only** and is **not** folded into the
  ranking `provenanceQuality` term (no ranking-behavior change).
- **Source-quality perturbation report** rows gain `nutrient_confidence_tier`,
  `nutrient_provenance_quality`, `provenance_quality_score`, `confidence_band`,
  `metadata_completeness_score`, plus a case showing **source authority and
  nutrient-provenance tier move independently** (synthetic+analytical vs
  official+imputed). 11 → 13 rows.

## How provenance now affects ranking
Tier → `MetadataCompletenessGate.scoreCandidateFood` grade → `toWeight` →
`CandidateMetadata.completeness` → `metadataCompletenessScore` →
`finalCandidateScore`. So analytical ≥ calculated ≥ imputed/assumed ≥ unknown for
metadata completeness, and analytical candidates rank ≥ imputed when otherwise
identical — but the swing is bounded and **conflict overlap stays dominant**.

## Tests
New `test/fdc_provenance_metadata_completeness_test.dart` (metadata serialization;
tier→quality/limitation helpers; gate ordering; missing-nutrient worse than
weak-but-present; present-incl-true-0g outranks missing; null tier inert;
end-to-end tier→scorer ranking; dominance preserved). Extended the source-quality
report test for the new fields + the authority/tier-independence case.

## Safety
FDC tiers are **source-quality signals, not biological/clinical accuracy**;
missing ≠ true zero; tier never overrides source-authority/jurisdiction policy or
conflict-overlap dominance; affects confidence/tie-breaking, never advice; **not
clinically calibrated**. (The evidence demo guide that describes this lives in
the companion PR.)

## Verification
- `dart format .` clean · `flutter analyze` clean
- `flutter test --concurrency=1` → **460 passed**
- `npm run public:preflight` → **0 BLOCKER**
- `node tool/firestore_rules_contract_check.mjs` → **13/13**
- `dart run tool/run_mechanistic_replay.dart` → **41/41** (unchanged)
- `dart run tool/run_source_quality_perturbation_report.dart` / `npm run
  source:quality` → 13 rows

## Known limitations
Replay was intentionally left unchanged (it already surfaces
`amino_acid_confidence_tier`; adding food-completeness there would require
candidate scoring inside the runner). The tier is a source-quality signal only,
exercised via synthetic fixtures; not clinically calibrated; no PHI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
