### PR TITLE
Consolidate public showcase and verification docs

### DIFF
--- a/PUBLIC_SHOWCASE_READINESS.md
+++ b/PUBLIC_SHOWCASE_READINESS.md
@@ -31,6 +31,17 @@ the public repository preflight reports zero blockers.
   personal health information or credentials.
 - `npm run public:preflight` passes with zero `BLOCKER` findings.
 
+## Evidence & Traceability Showcase Entry Points
+
+The evidence/traceability layer is the primary review surface. It is a set of
+deterministic, synthetic-data artifacts — not clinical calibration and not
+medical advice:
+
+- Guided walkthrough: `docs/EVIDENCE_AND_TRACEABILITY_DEMO_GUIDE.md`
+- Implemented vs future work: `docs/CAPABILITY_MATRIX.md`
+- Exact reviewer commands: `docs/PUBLIC_VERIFICATION.md`
+- Documentation index: `docs/README.md`
+
 ## Future Real-World Use Gate
 
 If this project is ever repositioned as a real health, clinical, or personal

--- a/README.md
+++ b/README.md
@@ -168,6 +168,42 @@ preference to the protein-source proxy. The legacy heuristic can only order
 results when `rankerEligibility.mechanisticPrimaryEligible == false`, with the
 reason surfaced in UI + replay.
 
+## Evidence & Traceability Architecture
+
+ParkinSUM's most reviewable surface is its **evidence and provenance layer**.
+Every educational output is deterministic, source-linked, and serializable for
+review — without any patient data.
+
+- **Deterministic mechanistic replay** — 41 synthetic scenarios, banned-phrase
+  scanned (`docs/REPLAY_RUNNER.md`).
+- **CDSS-style source/provenance metadata** with **source-authority** and
+  **metadata-completeness** gates (`docs/IMPORTER_METADATA_FLOW.md`).
+- **FDC nutrient provenance tiers** (analytical / calculated / imputed / unknown)
+  as **source-quality signals** that affect modeled confidence, not advice.
+- **Multi-dose medication traces** with per-dose modeled overlap.
+- **Local EvidenceTraceBundle** — a ParkinSUM-local artifact (explicitly **not** a
+  FHIR Bundle) pairing the two inspired views (`docs/EVIDENCE_TRACE_BUNDLE.md`).
+- **FHIR-inspired, non-conformant** NutritionIntake / MedicationKnowledge views
+  (PHI-free; `inspired_not_conformant`) with a conservative **LOINC section-code**
+  trace.
+- **Source-quality perturbation report** — shows how scoring moves when only
+  source/provenance quality changes (`docs/SOURCE_QUALITY_PERTURBATION_REPORT.md`).
+- **Public preflight + Firestore rules contract** release guardrails.
+
+```text
+source/importer metadata → normalized facts (missing ≠ zero)
+  → metadata completeness + source authority
+  → mechanistic engine (per-dose) → replay / source-quality report
+  → FHIR-inspired views + local EvidenceTraceBundle
+```
+
+Reviewer entry points: **[docs/EVIDENCE_AND_TRACEABILITY_DEMO_GUIDE.md](docs/EVIDENCE_AND_TRACEABILITY_DEMO_GUIDE.md)**
+(guided walkthrough), **[docs/CAPABILITY_MATRIX.md](docs/CAPABILITY_MATRIX.md)**
+(implemented vs future work), **[docs/PUBLIC_VERIFICATION.md](docs/PUBLIC_VERIFICATION.md)**
+(exact commands), and the **[docs index](docs/README.md)**. These artifacts are
+deterministic synthetic-data demonstrations — they are **not** clinical
+validation, and the source-quality report is **not** a clinical dashboard.
+
 ## Demo Media
 
 The screenshots and GIF below use synthetic local demo data only. They show the current public prototype flow and are not medical advice, clinical validation, or patient data.
@@ -203,6 +239,17 @@ npm ci
 npm run public:preflight
 npm run rules:contract
 ```
+
+Run the deterministic evidence artifacts (synthetic data; not clinical
+validation):
+
+```sh
+dart run tool/run_mechanistic_replay.dart            # or: npm run mechanistic:replay
+dart run tool/run_source_quality_perturbation_report.dart  # or: npm run source:quality
+```
+
+See [docs/PUBLIC_VERIFICATION.md](docs/PUBLIC_VERIFICATION.md) for what each
+command checks, its expected output, and what failure means.
 
 The default public-demo path is local mode. Firebase-backed commands are retained for internal operator validation and require project access.
 
@@ -306,6 +353,18 @@ If you discuss the project academically, include the safety boundary: educationa
 
 ## Documentation
 
+- [Documentation index](docs/README.md)
+- [Evidence & traceability demo guide](docs/EVIDENCE_AND_TRACEABILITY_DEMO_GUIDE.md)
+- [Capability matrix](docs/CAPABILITY_MATRIX.md)
+- [Public verification guide](docs/PUBLIC_VERIFICATION.md)
+- [Evidence trace bundle](docs/EVIDENCE_TRACE_BUNDLE.md)
+- [Source-quality perturbation report](docs/SOURCE_QUALITY_PERTURBATION_REPORT.md)
+- [Conflict engine model](docs/CONFLICT_ENGINE_MODEL.md)
+- [Importer & metadata flow](docs/IMPORTER_METADATA_FLOW.md)
+- [Replay runner](docs/REPLAY_RUNNER.md)
+- [Biomedical standards conformance scorecard](docs/BIOMEDICAL_STANDARDS_CONFORMANCE_SCORECARD.md)
+- [Source access & licenses](docs/SOURCE_ACCESS_AND_LICENSES.md)
+- [Manual validation](docs/MANUAL_VALIDATION.md)
 - [Disclaimer](DISCLAIMER.md)
 - [Security policy](SECURITY.md)
 - [Roadmap](ROADMAP.md)

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -1,0 +1,43 @@
+# Capability Matrix
+
+Educational/research prototype. Synthetic/demo data only. Not medical advice,
+not clinically calibrated, and carries no clinical-validation claim.
+
+This matrix summarizes what ParkinSUM Companion's evidence/traceability layer
+actually implements, how it is exercised, and where its boundaries are. Status
+values:
+
+- **implemented** — runtime code, exercised by unit tests.
+- **fixture-tested** — implemented and validated against synthetic fixtures only
+  (no live ingestion).
+- **deterministic-report** — a deterministic CLI/report artifact for review.
+- **documentation-only** — described in docs; not a code capability.
+- **future-work** — not implemented; recorded for transparency.
+
+| Capability | Status | Files / docs | Test coverage | Safety boundary | Limitations |
+| --- | --- | --- | --- | --- | --- |
+| Mechanistic replay runner | deterministic-report + fixture-tested | `lib/domain/usecases/mechanistic_replay_runner.dart`, `tool/run_mechanistic_replay.dart`, `docs/REPLAY_RUNNER.md` | `test/mechanistic_replay_runner_test.dart` (41 scenarios) | Deterministic synthetic regression; exits non-zero on banned-phrase hit | Not clinical validation; synthetic scenarios only |
+| Source-quality perturbation report | deterministic-report | `lib/domain/usecases/source_quality_perturbation_report.dart`, `tool/run_source_quality_perturbation_report.dart`, `docs/SOURCE_QUALITY_PERTURBATION_REPORT.md` | `test/source_quality_perturbation_report_test.dart` | Shows how scoring moves with source quality only; conflict overlap stays dominant | Not a clinical dashboard; no user-facing advice |
+| EvidenceTraceBundle (local) | implemented | `lib/domain/entities/evidence_trace_bundle.dart`, `lib/domain/usecases/evidence_trace_bundle_builder.dart`, `docs/EVIDENCE_TRACE_BUNDLE.md` | `test/evidence_trace_bundle_test.dart` | Local artifact; **not** a FHIR Bundle; no patient/subject/encounter | Synthetic fixtures; pairs two views for review |
+| FHIR-inspired NutritionIntake view | implemented | `lib/domain/entities/fhir_inspired_nutrition_intake_view.dart`, mapper | `test/fhir_inspired_nutrition_intake_view_test.dart` | `inspired_not_conformant`; PHI-free key-level scan | Not FHIR conformant; no clinical interoperability |
+| FHIR-inspired MedicationKnowledge view | implemented | `lib/domain/entities/fhir_inspired_medication_knowledge_view.dart`, mapper | `test/fhir_inspired_medication_knowledge_view_test.dart` | `inspired_not_conformant`; product strength is product metadata, not an intake dose | Not FHIR conformant; no coded RxCUI/ATC |
+| LOINC section-code trace | implemented | `lib/domain/entities/label_section_code.dart`, `lib/domain/usecases/label_section_code_mapper.dart` | `test/label_section_code_mapper_test.dart` | Conservative map of known FDA SPL headings; unknown stays unknown | Partial map; missing LOINC ≠ invalid provenance |
+| FDC nutrient provenance tier | implemented | `lib/domain/entities/nutrient_derivation.dart`, `source_metadata.dart`, `metadata_completeness_gate.dart` | `test/fdc_provenance_metadata_completeness_test.dart` | Source-quality signal, **not** clinical/biological accuracy | Missing derivation → null tier (never raises confidence) |
+| Metadata completeness gate | implemented | `lib/domain/usecases/metadata_completeness_gate.dart` | `test/multi_jurisdiction_metadata_test.dart`, FDC tests | Grades completeness; widens uncertainty, never fakes precision | Educational grading only |
+| Source authority scoring | implemented | `lib/domain/usecases/source_authority_scorer.dart` | `test/candidate_metadata_authority_test.dart`, multi-jurisdiction tests | Official-in-jurisdiction outranks synthetic/seed; seed never overrides official | Deterministic heuristic; not a trust certification |
+| Multi-dose medication trace | implemented | `lib/domain/usecases/mechanistic_conflict_engine.dart` (per-event traces) | replay multi-dose scenarios, engine tests | Per-dose modeled overlap; deterministic max-overlap aggregate | Educational simulation; no PK/PD prediction |
+| Missing nutrients ≠ true zero | implemented | `meal_composition_normalizer.dart`, `cdss_catalog_projection_service.dart` | `test/missing_not_zero_test.dart` | Missing recorded as missing; lowers completeness/widens uncertainty | A real measured 0 is preserved as a true zero |
+| Dose passthrough / no hidden dosage | implemented | `lib/domain/usecases/medication_entry_validator.dart` | `test/medication_entry_validator_test.dart` | Intake dose comes only from the user's explicit value+unit; no default | Ambiguous/unitless dose → insufficient context |
+| Live source smoke | fixture-tested (opt-in) | `tool/run_live_source_smoke.dart`, `npm run live:smoke` | excluded from normal test runs | Opt-in; fetches official metadata only; not used for advice | Not production ingestion; network-dependent when run |
+| Source access / license docs | documentation-only | `docs/SOURCE_ACCESS_AND_LICENSES.md`, `Bibliographies.md` | n/a | Records access + license-review status | Source-specific legal/license review remains future work |
+| Firestore rules contract | implemented | `tool/firestore_rules_contract_check.mjs`, `npm run rules:contract` | 13 contract checks | Enforces owner-scoped, deny-by-default rules | Static contract check, not a live pen-test |
+| Public preflight | implemented | `tool/public_repo_preflight.mjs`, `npm run public:preflight` | BLOCKER/WARN/INFO findings | Gates public positioning + banned-phrase claims | Heuristic doc/scan gate, not a security audit |
+
+## Cross-cutting boundaries
+
+All capabilities are **educational and non-prescriptive**, use **synthetic/demo
+data only**, emit **no PHI / patient / subject / encounter** fields, and make
+**no FHIR conformance** or clinical-validation claim. The model is **not
+clinically calibrated**. Source-quality and provenance signals affect modeled
+confidence and tie-breaking only — never medical advice — and never override
+conflict-overlap dominance, source-authority, or jurisdiction policy.

--- a/docs/PUBLIC_VERIFICATION.md
+++ b/docs/PUBLIC_VERIFICATION.md
@@ -1,0 +1,81 @@
+# Public Verification Guide
+
+Educational/research prototype. Synthetic/demo data only. **Not medical advice,
+not clinically calibrated, and carries no clinical-validation claim.**
+
+These are the exact commands a reviewer can run to verify ParkinSUM Companion
+locally. They are **deterministic, synthetic-data regression and governance
+checks** — they are **not** clinical validation, and the source-quality report
+is **not** a clinical dashboard.
+
+## Prerequisites
+
+Install Flutter, Dart, Node.js, and npm. From the repository root run
+`flutter pub get` and `npm ci` once. All checks below run on **synthetic/demo
+data** and, except where noted, require **no network**.
+
+## Core checks
+
+### `flutter analyze`
+- **Checks:** static analysis of the Dart/Flutter codebase.
+- **Expected:** `No issues found!`
+- **Failure means:** a static error/warning was introduced.
+- **Network:** no. **Data:** n/a.
+
+### `flutter test --concurrency=1`
+- **Checks:** the full unit/widget test suite (rules, importers, mechanistic
+  engine, metadata, evidence views, safety-copy guards).
+- **Expected:** `All tests passed!`
+- **Failure means:** a regression in deterministic behavior or a safety guard.
+- **Network:** no. **Data:** synthetic only.
+
+### `dart run tool/run_mechanistic_replay.dart`  (or `npm run mechanistic:replay`)
+- **Checks:** the deterministic mechanistic replay suite (41 synthetic
+  scenarios) and a banned-prescriptive-phrase scan over every emission.
+- **Expected:** `Mechanistic replay: 41/41 scenarios passed.` and report files
+  under `build/mechanistic_replay/latest.{json,md}`.
+- **Failure means:** a scenario's modeled output changed unexpectedly, or banned
+  copy leaked. **This is synthetic regression testing, not clinical validation.**
+- **Network:** no. **Data:** synthetic only.
+
+### `npm run public:preflight`
+- **Checks:** public-positioning + banned-claim + boundary guardrails across
+  README and public docs.
+- **Expected:** `"pass": true` with `BLOCKER: 0`.
+- **Failure means:** a public doc drifted into an unsafe claim or dropped a
+  required boundary phrase.
+- **Network:** no. **Data:** n/a.
+
+### `node tool/firestore_rules_contract_check.mjs`  (or `npm run rules:contract`)
+- **Checks:** Firestore security-rules contract (owner-scoped, deny-by-default,
+  admin/importer write gates).
+- **Expected:** `Firestore rules contract passed: 13/13`.
+- **Failure means:** a rule regressed against the contract.
+- **Network:** no. **Data:** n/a.
+
+## Source-quality report (optional)
+
+### `dart run tool/run_source_quality_perturbation_report.dart`  (or `npm run source:quality`)
+- **Checks:** how candidate scoring moves when **only** source/provenance
+  quality changes, holding the meal/conflict/model input constant.
+- **Expected:** `Source-quality perturbation report: 13 rows.` and report files
+  under `build/source_quality_perturbation/latest.{json,md}`.
+- **Failure means:** a provenance/source-quality invariant changed (e.g.
+  official-in-jurisdiction no longer ≥ synthetic equivalent, or conflict overlap
+  no longer dominant).
+- **Network:** no. **Data:** synthetic only.
+- **Note:** this is a deterministic educational analysis artifact, **not a
+  clinical dashboard** and not user-facing advice.
+
+## What these checks do and do not establish
+
+- **They establish:** deterministic behavior, preserved provenance/missingness,
+  intact safety boundaries, and that public docs stay within the educational
+  positioning.
+- **They do not establish:** any clinical accuracy, patient-outcome validity, or
+  regulatory approval. The model is **not clinically calibrated**, importer
+  adapters are fixture-validated (not live production ingestion), and all data is
+  synthetic/demo.
+
+See `docs/EVIDENCE_AND_TRACEABILITY_DEMO_GUIDE.md` for a guided walkthrough and
+`docs/CAPABILITY_MATRIX.md` for the implemented-vs-future-work summary.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,59 @@
+# ParkinSUM Companion — Documentation Index
+
+Educational/research prototype. Synthetic/demo data only. Not medical advice,
+not clinically calibrated, and carries no clinical-validation claim.
+
+This index groups the documentation by purpose so reviewers can find the right
+file quickly. For a guided end-to-end walkthrough start with the demo guide; for
+exact commands use the public verification guide.
+
+## Start here
+
+- [Evidence & Traceability Demo Guide](EVIDENCE_AND_TRACEABILITY_DEMO_GUIDE.md) — end-to-end reviewer walkthrough of the evidence artifacts.
+- [Capability Matrix](CAPABILITY_MATRIX.md) — what is implemented, fixture-tested, report-only, or future work.
+- [Public Verification Guide](PUBLIC_VERIFICATION.md) — exact commands, expected output, and what each check does (and does not) establish.
+- [Public Demo Boundary](PUBLIC_DEMO_BOUNDARY.md) — what the public prototype may and may not be used for.
+
+## Architecture
+
+- [Architecture Overview](ARCHITECTURE.md) — app layering (UI, state, data, rules, evidence).
+- [Rule Engine](RULE_ENGINE.md) — medication-context gate + structured rule-explanation template.
+
+## Evidence and traceability
+
+- [Evidence Trace Bundle](EVIDENCE_TRACE_BUNDLE.md) — the local (non-FHIR) artifact pairing the two inspired views.
+- [Source-Quality Perturbation Report](SOURCE_QUALITY_PERTURBATION_REPORT.md) — deterministic report of how source quality moves scoring.
+- [Replay Runner](REPLAY_RUNNER.md) — the deterministic synthetic replay suite + CLI.
+
+## Algorithm / mechanistic model
+
+- [Conflict Engine Model](CONFLICT_ENGINE_MODEL.md) — the layered, literature-informed educational simulation (not clinically calibrated).
+
+## Source / importer metadata
+
+- [Importer & Metadata Flow](IMPORTER_METADATA_FLOW.md) — canonical metadata, source-authority policy, completeness gate, FDC provenance tier, FHIR-inspired views.
+
+## Safety and release guardrails
+
+- [Public Showcase Readiness](../PUBLIC_SHOWCASE_READINESS.md) — public-repository readiness controls.
+- [Known Risks](known_risks.md) — recorded risk register.
+- [Release Evidence Index](RELEASE_EVIDENCE_INDEX.md) — release-evidence pointers.
+
+## Biomedical standards / roadmap
+
+- [Biomedical Standards Conformance Scorecard](BIOMEDICAL_STANDARDS_CONFORMANCE_SCORECARD.md) — code-grounded posture vs FHIR/LOINC/FDC/FAIR (inspired, never conformant).
+- [Biomedical Traceability Matrix](BIOMEDICAL_TRACEABILITY_MATRIX.md) — opportunity → source → implementation → test traceability.
+- [Biomedical Engineering Opportunity Map](BIOMEDICAL_ENGINEERING_OPPORTUNITY_MAP.md) / [Backlog](BIOMEDICAL_ENGINEERING_BACKLOG.md) — roadmap.
+
+## Manual validation
+
+- [Manual Validation](MANUAL_VALIDATION.md) — hands-on synthetic-data walkthrough.
+
+## Source access and licenses
+
+- [Source Access & Licenses](SOURCE_ACCESS_AND_LICENSES.md) — per-source access method + license-review status (review remains future work).
+- [Bibliographies](../Bibliographies.md) — MLA citations behind the educational model.
+
+> Operator/release runbooks (Firebase operations, production acceptance, IAM
+> governance, rollback) live alongside these files in `docs/` but are internal
+> validation material, not part of the public showcase surface.

--- a/docs/RELEASE_EVIDENCE_INDEX.md
+++ b/docs/RELEASE_EVIDENCE_INDEX.md
@@ -13,6 +13,17 @@ or professional approval.
 - Contribution policy: `CONTRIBUTING.md`
 - Public preflight report: `build/public_release_preflight/latest.md`
 
+## Evidence & Traceability (synthetic; not clinical validation)
+
+- Documentation index: `docs/README.md`
+- Demo guide: `docs/EVIDENCE_AND_TRACEABILITY_DEMO_GUIDE.md`
+- Capability matrix: `docs/CAPABILITY_MATRIX.md`
+- Public verification guide: `docs/PUBLIC_VERIFICATION.md`
+- Mechanistic replay: `docs/REPLAY_RUNNER.md`, `build/mechanistic_replay/latest.md`
+- Source-quality perturbation report: `docs/SOURCE_QUALITY_PERTURBATION_REPORT.md`, `build/source_quality_perturbation/latest.md`
+- Evidence trace bundle: `docs/EVIDENCE_TRACE_BUNDLE.md`
+- Standards posture: `docs/BIOMEDICAL_STANDARDS_CONFORMANCE_SCORECARD.md`
+
 ## Architecture Evidence
 
 - Architecture overview: `docs/ARCHITECTURE.md`


### PR DESCRIPTION
## Summary

Consolidates ParkinSUM Companion's public-facing documentation after the
evidence, traceability, replay, source-quality, and FHIR-inspired view upgrades.
**Documentation-only** — no algorithm, importer, Firebase rules, model constants,
or clinical behavior is changed.

## What changed

- **README** — new **Evidence & Traceability Architecture** section surfacing the
  capabilities that were previously buried in docs (deterministic replay,
  CDSS-style source/provenance metadata + source-authority / metadata-completeness
  gates, FDC nutrient provenance tiers, multi-dose medication traces, local
  EvidenceTraceBundle, FHIR-inspired non-conformant NutritionIntake /
  MedicationKnowledge views + conservative LOINC section-code trace,
  source-quality perturbation report, preflight + Firestore rules guardrails),
  with a simple data-flow sketch and reviewer entry points. The local-evaluation
  block now lists the replay + source-quality commands, and the Documentation
  list links the new docs.
- **`docs/README.md`** (new) — grouped documentation index (start here /
  architecture / evidence & traceability / algorithm / source metadata / safety &
  release / biomedical standards / manual validation / source access), one line
  per entry.
- **`docs/PUBLIC_VERIFICATION.md`** (new) — exact reviewer commands with what each
  checks, expected output pattern, failure meaning, network + synthetic-data
  notes, and an explicit "not clinical validation / source-quality report is not a
  clinical dashboard" framing.
- **`docs/CAPABILITY_MATRIX.md`** (new) — implemented / fixture-tested /
  deterministic-report / documentation-only / future-work status per capability,
  with files, test coverage, safety boundary, and limitations.
- **`PUBLIC_SHOWCASE_READINESS.md`** + **`docs/RELEASE_EVIDENCE_INDEX.md`** — added
  evidence & traceability entry-point pointers.

## Safety wording

All wording is kept **scanner-safe** (avoids the preflight banned phrases such as
"clinically validated", "adjust your dose", "recommended dose"; the `docs/` files
are scanned). The educational-only, non-prescriptive, synthetic-data-only,
not-clinically-calibrated, not-FHIR-conformant, no-PHI boundary is preserved
throughout.

## Verification
- `dart format .` clean · `flutter analyze` clean
- `flutter test --concurrency=1` → **460 passed**
- `npm run public:preflight` → **0 BLOCKER**
- `node tool/firestore_rules_contract_check.mjs` → **13/13**
- `dart run tool/run_mechanistic_replay.dart` → **41/41**
- `dart run tool/run_source_quality_perturbation_report.dart` → 13 rows

## Known limitations
Docs-only; no behavior change. The artifacts described remain educational,
synthetic-data demonstrations and are not clinical validation. Internal
operator/release runbooks remain in `docs/` but are intentionally kept out of the
public-showcase index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
