### PR TITLE
[codex] fix mechanistic meal binding and history trace

### DIFF
--- a/lib/core/services/services.dart
+++ b/lib/core/services/services.dart
@@ -249,6 +249,7 @@ class Services {
       clinicalDecisionSupportService: cdssService,
       compiledRules: compiledCdssRules,
       importedLabelRuleProvider: importedLabelRuleProvider,
+      foodRepository: foodRepo,
     );
     final cdssCatalogProjectionService =
         CdssCatalogProjectionService(database: cdssDatabase);

--- a/lib/domain/usecases/database_backed_meal_check_usecase.dart
+++ b/lib/domain/usecases/database_backed_meal_check_usecase.dart
@@ -1,4 +1,5 @@
 import '../../core/analysis/nutrition_rules.dart';
+import '../../core/analysis/food_repository.dart';
 import '../../core/models/drug_definition.dart';
 import '../../core/models/intake.dart';
 import '../../core/models/interaction_result.dart';
@@ -10,8 +11,8 @@ import '../entities/meal_composition.dart';
 import '../entities/resolved_variant.dart';
 import '../entities/rule_registry_models.dart';
 import '../entities/runtime_context.dart';
-import '../entities/time_axis_events.dart';
 import 'clinical_decision_support_service.dart';
+import 'catalog_food_to_candidate.dart';
 import 'dosage_note_parser.dart';
 import 'imported_label_rule_provider.dart';
 import 'meal_composition_normalizer.dart';
@@ -32,6 +33,7 @@ class DatabaseBackedMealCheckUseCase {
   final ClinicalDecisionSupportService clinicalDecisionSupportService;
   final List<RuleRegistryEntry> compiledRules;
   final ImportedLabelRuleProvider? importedLabelRuleProvider;
+  final FoodRepository foodRepository;
 
   /// Deterministic mechanistic time-axis simulation layer. The hard-rule
   /// engine (via `clinicalDecisionSupportService`) remains the source of
@@ -48,12 +50,14 @@ class DatabaseBackedMealCheckUseCase {
     required this.clinicalDecisionSupportService,
     required this.compiledRules,
     this.importedLabelRuleProvider,
+    FoodRepository? foodRepository,
     MechanisticConflictEngine? mechanisticEngine,
     MealCompositionNormalizer? mealCompositionNormalizer,
     MedicationEntryValidator? medicationEntryValidator,
     TimeAxisBuilder? timeAxisBuilder,
     DosageNoteParser? dosageNoteParser,
-  })  : mechanisticEngine = mechanisticEngine ?? MechanisticConflictEngine(),
+  })  : foodRepository = foodRepository ?? FoodRepository.createDefault(),
+        mechanisticEngine = mechanisticEngine ?? MechanisticConflictEngine(),
         mealCompositionNormalizer =
             mealCompositionNormalizer ?? MealCompositionNormalizer(),
         medicationEntryValidator =
@@ -799,23 +803,20 @@ class DatabaseBackedMealCheckUseCase {
 
     if (medInputs.isEmpty) return null;
 
-    final totals = meal.computeTotals();
+    final components = <FoodComponent>[];
+    for (var index = 0; index < meal.items.length; index++) {
+      final item = meal.items[index];
+      components.add(
+        mealItemToFoodComponent(
+          item,
+          componentId: 'meal_${meal.id}_${index}_${item.foodId}',
+          catalogMatch: foodRepository.getById(item.foodId),
+        ),
+      );
+    }
     final composition = mealCompositionNormalizer.normalize(
       mealId: 'comp_${meal.id}',
-      components: [
-        FoodComponent(
-          id: 'meal_aggregate_${meal.id}',
-          name: meal.title,
-          physicalForm: MealPhysicalForm.unknown,
-          proteinGrams: totals.totalProteinG,
-          fatGrams: totals.totalFatG,
-          fiberGrams: totals.totalFiberG,
-          carbohydrateGrams: totals.totalCarbsG,
-          calories: null,
-          portionGrams: null,
-          sourceDocId: 'meal_history',
-        ),
-      ],
+      components: components,
     );
 
     final context = timeAxisBuilder.build(
@@ -826,7 +827,7 @@ class DatabaseBackedMealCheckUseCase {
           id: 'meal_${meal.id}',
           startedAt: meal.effectiveOccurredAt,
           compositionId: composition.id,
-          physicalForm: MealPhysicalForm.unknown,
+          physicalForm: composition.mealPhysicalForm,
         ),
       ],
     );

--- a/lib/domain/usecases/mechanistic_conflict_engine.dart
+++ b/lib/domain/usecases/mechanistic_conflict_engine.dart
@@ -36,6 +36,7 @@ class MechanisticConflictEngine {
     required TimeAxisConflictContext context,
     required Map<String, MealComposition> mealCompositionsById,
     String resultId = 'mechanistic_result',
+    String? preferredMealId,
   }) {
     // No valid medication event = insufficient medication context.
     if (context.medicationEvents.isEmpty) {
@@ -63,6 +64,19 @@ class MechanisticConflictEngine {
     // The primary single-dose window for the no-meal path uses the first
     // scoring event (deterministic order is preserved by the time-axis builder).
     final med = scoringEvents.first;
+
+    // An explicitly requested meal must exist. Candidate scoring uses this to
+    // bind each hypothetical meal to its evaluation rather than silently
+    // falling back to a historical meal outside the ordinary lookahead window.
+    if (preferredMealId != null &&
+        !context.mealEvents.any((meal) => meal.id == preferredMealId)) {
+      return MechanisticConflictResult.insufficientContext(
+        id: resultId,
+        reason: MechanisticInteractionType.insufficientMealContext,
+        missingInputs: ['meal_event($preferredMealId)'],
+        sourceRefs: const ['src.hens.foodphysical.2024'],
+      );
+    }
 
     // No meal event = no food-medication interaction modeled.
     if (context.mealEvents.isEmpty) {
@@ -118,10 +132,15 @@ class MechanisticConflictEngine {
         med: event,
         context: context,
         mealCompositionsById: mealCompositionsById,
+        preferredMealId: preferredMealId,
       );
       if (eval == null) {
         // Record which meal composition was unavailable for this dose.
-        final mealForEvent = _primaryMealFor(event, context);
+        final mealForEvent = _primaryMealFor(
+          event,
+          context,
+          preferredMealId: preferredMealId,
+        );
         if (mealForEvent != null) {
           missingCompositionIds.add(mealForEvent.compositionId);
         }
@@ -347,9 +366,16 @@ class MechanisticConflictEngine {
   /// `mealEvents` list always yields the same primary meal.
   MealTimelineEvent? _primaryMealFor(
     MedicationTimelineEvent med,
-    TimeAxisConflictContext context,
-  ) {
+    TimeAxisConflictContext context, {
+    String? preferredMealId,
+  }) {
     if (context.mealEvents.isEmpty) return null;
+    if (preferredMealId != null) {
+      for (final meal in context.mealEvents) {
+        if (meal.id == preferredMealId) return meal;
+      }
+      return null;
+    }
     final sorted = [...context.mealEvents]..sort((a, b) {
         final byMinute = a.minute.compareTo(b.minute);
         return byMinute != 0 ? byMinute : a.id.compareTo(b.id);
@@ -396,8 +422,13 @@ class MechanisticConflictEngine {
     required MedicationTimelineEvent med,
     required TimeAxisConflictContext context,
     required Map<String, MealComposition> mealCompositionsById,
+    String? preferredMealId,
   }) {
-    final primaryMeal = _primaryMealFor(med, context);
+    final primaryMeal = _primaryMealFor(
+      med,
+      context,
+      preferredMealId: preferredMealId,
+    );
     if (primaryMeal == null) return null;
     final composition = mealCompositionsById[primaryMeal.compositionId];
     if (composition == null) return null;

--- a/lib/domain/usecases/mechanistic_next_meal_scorer.dart
+++ b/lib/domain/usecases/mechanistic_next_meal_scorer.dart
@@ -192,16 +192,19 @@ class MechanisticNextMealScorer {
     final samples = <MechanisticCandidateSampleSummary>[];
     final perSampleResults = <MechanisticConflictResult>[];
     for (final offset in sampleOffsets) {
+      final candidateMealId = 'hypothetical_${candidate.id}_$offset';
       final ctx = _hypotheticalContext(
         baseContext: baseContext,
         candidate: candidate,
         compositionId: composition.id,
         candidateMinute: offset,
+        candidateMealId: candidateMealId,
       );
       final result = engine.evaluate(
         context: ctx,
         mealCompositionsById: mergedCompositions,
         resultId: 'cand_${candidate.id}_$offset',
+        preferredMealId: candidateMealId,
       );
       perSampleResults.add(result);
       samples.add(MechanisticCandidateSampleSummary(
@@ -381,11 +384,12 @@ class MechanisticNextMealScorer {
     required CandidateFood candidate,
     required String compositionId,
     required int candidateMinute,
+    required String candidateMealId,
   }) {
     final mealEvents = [
       ...baseContext.mealEvents,
       MealTimelineEvent(
-        id: 'hypothetical_${candidate.id}_$candidateMinute',
+        id: candidateMealId,
         minute: candidateMinute,
         compositionId: compositionId,
         physicalForm: candidate.declaredPhysicalForm,

--- a/test/database_backed_meal_check_usecase_test.dart
+++ b/test/database_backed_meal_check_usecase_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:parkinsum_companion/core/constants/baseline_cdss_rules.dart';
+import 'package:parkinsum_companion/core/analysis/food_repository.dart';
 import 'package:parkinsum_companion/core/db/cdss_database.dart';
 import 'package:parkinsum_companion/core/models/drug_definition.dart';
 import 'package:parkinsum_companion/core/models/food_item.dart';
@@ -8,15 +9,20 @@ import 'package:parkinsum_companion/core/models/interaction_result.dart';
 import 'package:parkinsum_companion/core/models/meal.dart';
 import 'package:parkinsum_companion/core/models/user_profile.dart';
 import 'package:parkinsum_companion/domain/entities/cdss_records.dart';
+import 'package:parkinsum_companion/domain/entities/amino_acid_profile.dart';
+import 'package:parkinsum_companion/domain/entities/meal_composition.dart';
+import 'package:parkinsum_companion/domain/entities/mechanistic_conflict_result.dart';
 import 'package:parkinsum_companion/domain/entities/rule_registry_models.dart';
 import 'package:parkinsum_companion/domain/entities/runtime_context.dart';
 import 'package:parkinsum_companion/domain/usecases/clinical_decision_support_service.dart';
 import 'package:parkinsum_companion/domain/usecases/database_backed_meal_check_usecase.dart';
 import 'package:parkinsum_companion/domain/usecases/fact_conflict_engine.dart';
 import 'package:parkinsum_companion/domain/usecases/imported_label_rule_provider.dart';
+import 'package:parkinsum_companion/domain/usecases/mechanistic_conflict_engine.dart';
 import 'package:parkinsum_companion/domain/usecases/rule_registry_compiler.dart';
 import 'package:parkinsum_companion/domain/usecases/runtime_rule_engine.dart';
 import 'package:parkinsum_companion/domain/usecases/variant_resolver.dart';
+import 'package:parkinsum_companion/domain/entities/time_axis_events.dart';
 
 class QueryBackedCdssDatabase implements CdssDatabase {
   QueryBackedCdssDatabase(this.tables);
@@ -111,6 +117,28 @@ class QueryBackedCdssDatabase implements CdssDatabase {
   @override
   Future<List<Map<String, Object?>>> queryTable(String table) async =>
       tables[table] ?? const <Map<String, Object?>>[];
+}
+
+class RecordingMechanisticConflictEngine extends MechanisticConflictEngine {
+  MealComposition? composition;
+  TimeAxisConflictContext? context;
+
+  @override
+  MechanisticConflictResult evaluate({
+    required TimeAxisConflictContext context,
+    required Map<String, MealComposition> mealCompositionsById,
+    String resultId = 'mechanistic_result',
+    String? preferredMealId,
+  }) {
+    this.context = context;
+    composition = mealCompositionsById.values.single;
+    return super.evaluate(
+      context: context,
+      mealCompositionsById: mealCompositionsById,
+      resultId: resultId,
+      preferredMealId: preferredMealId,
+    );
+  }
 }
 
 void main() {
@@ -1130,5 +1158,110 @@ void main() {
     expect(result.issues, isEmpty);
     expect(result.summary, contains('outside'));
     expect(result.analysisText, contains('historical meal'));
+  });
+
+  test('meal check trace componentizes history with catalog enrichment',
+      () async {
+    final db = QueryBackedCdssDatabase(const {});
+    final service = ClinicalDecisionSupportService(
+      database: db,
+      factConflictEngine: FactConflictEngine(),
+      runtimeRuleEngine: RuntimeRuleEngine(),
+    );
+    final foodRepository = FoodRepository.createDefault()
+      ..replaceAll([
+        FoodItem(
+          id: 'food_enriched',
+          name: 'Enriched tofu',
+          category: FoodCategory.protein,
+          textureClass: 'solid',
+          proteinG: 10,
+          carbsG: 3,
+          fatG: 4,
+          fiberG: 2,
+          sodiumMg: 15,
+          energyKcal: 120,
+          aminoAcidProfile: const AminoAcidProfile(
+            leucine: 2,
+            valine: 1,
+            basis: 'per_100g',
+          ),
+        ),
+      ]);
+    final engine = RecordingMechanisticConflictEngine();
+    final useCase = DatabaseBackedMealCheckUseCase(
+      variantResolver: VariantResolver(database: db),
+      clinicalDecisionSupportService: service,
+      compiledRules: const [],
+      foodRepository: foodRepository,
+      mechanisticEngine: engine,
+    );
+    final mealTime = DateTime.utc(2026, 1, 1, 8, 30);
+
+    final result = await useCase(
+      meal: Meal(
+        id: 'meal_componentized',
+        eatenAt: mealTime,
+        title: 'Mixed history meal',
+        items: [
+          MealItem(
+            foodId: 'food_enriched',
+            foodName: 'Enriched tofu',
+            foodCategory: FoodCategory.protein,
+            quantityFactor: 1.5,
+            foodTags: const [],
+            proteinPer100g: 10,
+            carbsPer100g: 3,
+            fatPer100g: 4,
+            fiberPer100g: 2,
+            sodiumPer100g: 15,
+          ),
+          MealItem(
+            foodId: 'food_uncatalogued',
+            foodName: 'Uncatalogued side',
+            foodCategory: FoodCategory.other,
+            quantityFactor: 0.5,
+            foodTags: const [],
+            proteinPer100g: 2,
+            carbsPer100g: 8,
+            fatPer100g: 1,
+            fiberPer100g: 1,
+            sodiumPer100g: 10,
+          ),
+        ],
+      ),
+      activeDrugs: [
+        DrugDefinition(
+          id: 'drug_levodopa_carbidopa',
+          genericName: 'carbidopa/levodopa',
+          brandNames: const ['Sinemet'],
+          tags: const [DrugTag.levodopaLike],
+          notes: '',
+        ),
+      ],
+      intakes: [
+        Intake(
+          id: 'intake_componentized',
+          drugId: 'drug_levodopa_carbidopa',
+          takenAt: DateTime.utc(2026, 1, 1, 8),
+          dosageNote: '100 mg',
+        ),
+      ],
+      userProfile: UserProfile.defaults(),
+    );
+
+    final components = engine.composition!.foodComponents;
+    expect(result.mechanisticTraceJson, isNotNull);
+    expect(components, hasLength(2));
+    expect(components.first.portionGrams, 150);
+    expect(components.first.calories, 180);
+    expect(components.first.physicalForm, MealPhysicalForm.solid);
+    expect(components.first.aminoAcidProfile!.leucine, 3);
+    expect(components.last.portionGrams, 50);
+    expect(components.last.calories, isNull);
+    expect(components.last.physicalForm, MealPhysicalForm.unknown);
+    expect(components.last.aminoAcidProfile, isNull);
+    expect(
+        engine.context!.mealEvents.single.physicalForm, MealPhysicalForm.solid);
   });
 }

--- a/test/mechanistic_conflict_engine_test.dart
+++ b/test/mechanistic_conflict_engine_test.dart
@@ -325,6 +325,92 @@ void main() {
     );
   });
 
+  test('preferred meal overrides ordinary lookahead selection', () {
+    final now = DateTime.utc(2026, 1, 1, 8);
+    final refMinute = dateTimeToMinute(now);
+    final med = MedicationTimelineEvent(
+      id: 'med',
+      minute: refMinute,
+      context: validator.validate(validLevodopa).normalized!,
+    );
+    const lowProtein = FoodComponent(
+      id: 'lp',
+      name: 'low protein',
+      physicalForm: MealPhysicalForm.solid,
+      proteinGrams: 1,
+      fatGrams: 0,
+      fiberGrams: 0,
+      carbohydrateGrams: 30,
+      calories: 130,
+      portionGrams: 150,
+      sourceDocId: 'synthetic:demo',
+    );
+    final historical = normalizer
+        .normalize(mealId: 'historical', components: const [lowProtein]);
+    final hypothetical = normalizer
+        .normalize(mealId: 'hypothetical', components: const [highProtein]);
+    final ctx = TimeAxisConflictContext(
+      referenceMinute: refMinute,
+      medicationEvents: [med],
+      mealEvents: [
+        MealTimelineEvent(
+          id: 'historical_meal',
+          minute: refMinute - 30,
+          compositionId: historical.id,
+          physicalForm: MealPhysicalForm.solid,
+        ),
+        MealTimelineEvent(
+          id: 'hypothetical_meal',
+          minute: refMinute + 300,
+          compositionId: hypothetical.id,
+          physicalForm: MealPhysicalForm.solid,
+        ),
+      ],
+    );
+    final compositions = {
+      historical.id: historical,
+      hypothetical.id: hypothetical,
+    };
+
+    final ordinary =
+        engine.evaluate(context: ctx, mealCompositionsById: compositions);
+    final preferred = engine.evaluate(
+      context: ctx,
+      mealCompositionsById: compositions,
+      preferredMealId: 'hypothetical_meal',
+    );
+
+    expect(ordinary.primaryEmptyingProfile?.mealId, 'historical_meal');
+    expect(preferred.primaryEmptyingProfile?.mealId, 'hypothetical_meal');
+  });
+
+  test('missing preferred meal returns insufficient meal context', () {
+    final now = DateTime.utc(2026, 1, 1, 8);
+    final ctx = makeContext(
+      now: now,
+      medEntry: validLevodopa,
+      medTakenAt: now,
+      mealStartedAt: now,
+    );
+    final composition =
+        normalizer.normalize(mealId: 'c1', components: const [highProtein]);
+
+    final result = engine.evaluate(
+      context: ctx,
+      mealCompositionsById: {'c1': composition},
+      preferredMealId: 'missing_meal',
+    );
+
+    expect(
+      result.interactionType,
+      MechanisticInteractionType.insufficientMealContext,
+    );
+    expect(
+      result.explanation.missingOrUncertainInputs,
+      contains('meal_event(missing_meal)'),
+    );
+  });
+
   test('explanation always carries source refs and safety boundary text', () {
     final now = DateTime.utc(2026, 1, 1, 8);
     final ctx = makeContext(

--- a/test/mechanistic_multi_point_sampling_test.dart
+++ b/test/mechanistic_multi_point_sampling_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:parkinsum_companion/domain/entities/amino_acid_profile.dart';
 import 'package:parkinsum_companion/domain/entities/meal_composition.dart';
 import 'package:parkinsum_companion/domain/entities/rule_explanation.dart';
 import 'package:parkinsum_companion/domain/entities/time_axis_events.dart';
 import 'package:parkinsum_companion/domain/usecases/mechanistic_next_meal_scorer.dart';
+import 'package:parkinsum_companion/domain/usecases/meal_composition_normalizer.dart';
 import 'package:parkinsum_companion/domain/usecases/medication_entry_validator.dart';
 import 'package:parkinsum_companion/domain/usecases/time_axis_builder.dart';
 
@@ -133,5 +135,100 @@ void main() {
     expect(blob.contains('eat at'), isFalse);
     expect(blob.contains('you should'), isFalse);
     expect(findBannedSubstrings(blob), isEmpty);
+  });
+
+  test('far-window sampling binds the hypothetical meal instead of history',
+      () {
+    final now = DateTime.utc(2026, 1, 1, 8);
+    final start = dateTimeToMinute(now) + 300;
+    final window = UserDefinedMealWindow(
+      window: TimelineWindow(startMinute: start, endMinute: start + 60),
+      source: 'test',
+    );
+    final base = makeCtx(now, window);
+    final historical = MealCompositionNormalizer().normalize(
+      mealId: 'historical',
+      components: const [
+        FoodComponent(
+          id: 'historical_component',
+          name: 'historical meal',
+          physicalForm: MealPhysicalForm.solid,
+          proteinGrams: 3,
+          fatGrams: 1,
+          fiberGrams: 1,
+          carbohydrateGrams: 25,
+          calories: 130,
+          portionGrams: 150,
+          sourceDocId: 'synthetic',
+        ),
+      ],
+    );
+    final ctx = TimeAxisConflictContext(
+      referenceMinute: base.referenceMinute,
+      medicationEvents: base.medicationEvents,
+      mealEvents: [
+        MealTimelineEvent(
+          id: 'historical_meal',
+          minute: dateTimeToMinute(now) - 30,
+          compositionId: historical.id,
+          physicalForm: MealPhysicalForm.solid,
+        ),
+      ],
+      userDefinedWindow: window,
+    );
+    const highProtein = CandidateFood(
+      id: 'high_protein',
+      name: 'high protein',
+      regionalFoodLibraryRef: 'synthetic',
+      declaredPhysicalForm: MealPhysicalForm.solid,
+      components: [
+        FoodComponent(
+          id: 'high',
+          name: 'high protein',
+          physicalForm: MealPhysicalForm.solid,
+          proteinGrams: 40,
+          fatGrams: 4,
+          fiberGrams: 1,
+          carbohydrateGrams: 5,
+          calories: 220,
+          portionGrams: 150,
+          sourceDocId: 'synthetic',
+          aminoAcidProfile: AminoAcidProfile(
+            leucine: 8,
+            basis: 'per_serving',
+          ),
+        ),
+      ],
+    );
+
+    final scores = scorer.score(
+      baseContext: ctx,
+      baseMealCompositionsById: {historical.id: historical},
+      candidates: const [banana, highProtein],
+    );
+    final byId = {for (final score in scores) score.candidateFoodId: score};
+
+    expect(
+      byId['banana']!.upstreamResult?.primaryEmptyingProfile?.mealId,
+      startsWith('hypothetical_banana_'),
+    );
+    expect(
+      byId['high_protein']!.upstreamResult?.primaryEmptyingProfile?.mealId,
+      startsWith('hypothetical_high_protein_'),
+    );
+    expect(
+      byId['banana']!
+          .upstreamResult
+          ?.competitionTimeline
+          ?.lnaaSummary
+          ?.effectiveLoadFactor,
+      isNot(
+        byId['high_protein']!
+            .upstreamResult
+            ?.competitionTimeline
+            ?.lnaaSummary
+            ?.effectiveLoadFactor,
+      ),
+    );
   });
 }


### PR DESCRIPTION
## What changed
- add an optional `preferredMealId` to `MechanisticConflictEngine.evaluate(...)`
- bind each hypothetical next-meal sample to its injected meal event instead of allowing ordinary lookahead selection to fall back to historical meals
- return structured insufficient-meal context when an explicit preferred meal ID is absent
- componentize logged meal history item-by-item in `DatabaseBackedMealCheckUseCase`
- enrich logged components from the shared runtime `FoodRepository` when catalog data exists, preserving physical form, calories, serving-scaled amino-acid profiles, and missing-as-null semantics
- pass normalized meal physical form into the time axis

## Why
The next-meal scorer injected hypothetical meals for user-defined windows, but the engine still selected meals using its ordinary 180-minute lookahead heuristic. For samples beyond that window, an older historical meal could be evaluated instead of the candidate. Separately, the database-backed meal-check trace collapsed logged meals into one anonymous aggregate component, discarding item-level model inputs and provenance.

## Impact
- far-window candidate scoring now evaluates the candidate that was actually sampled
- normal engine calls keep the existing ordinary lookahead behavior
- historical meal traces retain item-level inputs without fabricating unavailable catalog metadata
- CDSS hard-rule decisions remain authoritative; this trace remains additive and educational only

## Validation
- `git diff --check`
- `flutter test test/mechanistic_conflict_engine_test.dart test/mechanistic_multi_point_sampling_test.dart test/database_backed_meal_check_usecase_test.dart`
- `flutter test` (550 tests passed)
- `flutter analyze` (no issues found)