### PR TITLE
Migrate i18n onboarding/disclaimer boundary surfaces through the compiler

### DIFF
--- a/lib/core/analysis/interaction_engine.dart
+++ b/lib/core/analysis/interaction_engine.dart
@@ -1,3 +1,4 @@
+import '../../domain/usecases/explanation_copy_service.dart';
 import '../i18n/app_i18n.dart';
 import '../models/drug_definition.dart';
 import '../models/interaction_result.dart';
@@ -107,7 +108,14 @@ class InteractionEngine {
     // 如果没有任何问题，给一个“通过”提示
     if (issues.isEmpty) {
       return InteractionResult.ok(
-        message: i18n.tr('legacy.no_conflict'),
+        // Boundary copy sourced through the compiler-validated registry; the
+        // localized i18n string is the fallback (locale-strict — non-en users
+        // keep their translation).
+        message: const ExplanationCopyService().resolveForLocale(
+          'legacy_no_conflict',
+          locale: i18n.languageFamily,
+          fallback: i18n.tr('legacy.no_conflict'),
+        ),
         mealId: meal.id,
       );
     }

--- a/lib/domain/usecases/explanation_copy_service.dart
+++ b/lib/domain/usecases/explanation_copy_service.dart
@@ -49,6 +49,23 @@ class ExplanationCopyService {
     return fallback;
   }
 
+  /// Locale-strict resolve: returns the compiler-validated text **only** when
+  /// the template actually carries [locale] (so a non-localized template never
+  /// substitutes English for a localized string); otherwise returns [fallback].
+  /// This is the safe seam for migrating localized i18n boundary keys: pass the
+  /// current locale and the existing localized `tr()` value as the fallback.
+  String resolveForLocale(
+    String templateId, {
+    required String locale,
+    required String fallback,
+  }) {
+    final template = _registry.byId(templateId);
+    if (template == null || !template.localizedText.containsKey(locale)) {
+      return fallback;
+    }
+    return resolve(templateId, locale: locale, fallback: fallback);
+  }
+
   /// Shared not-advice boundary copy (compiler-validated; falls back to the
   /// canonical default text).
   String notAdvice({String locale = ''}) => resolve(

--- a/lib/domain/usecases/safe_copy_template_registry.dart
+++ b/lib/domain/usecases/safe_copy_template_registry.dart
@@ -108,6 +108,30 @@ class SafeCopyTemplateRegistry {
           notes: 'Shared default safety-boundary text (consumed at runtime by '
               'ExplanationCopyService).',
         ),
+        // --- Migrated i18n boundary surfaces (en text mirrors app_i18n) -------
+        SafeCopyTemplate(
+          templateId: 'onboarding_safety_education_title',
+          outputType: 'boundary',
+          defaultLocale: 'en',
+          localizedText: {'en': 'Rule guidance is not medical advice'},
+          requiredSafetyTerms: ['not medical advice'],
+          requiresNotAdviceText: true,
+          notes: 'Onboarding safety-education title; mirrors i18n key '
+              '`onboarding.safety_education_title` (en).',
+        ),
+        SafeCopyTemplate(
+          templateId: 'legacy_no_conflict',
+          outputType: 'boundary',
+          defaultLocale: 'en',
+          localizedText: {
+            'en': 'No significant rule conflicts were detected (based only on '
+                'built-in rules; not medical advice).',
+          },
+          requiredSafetyTerms: ['not medical advice'],
+          requiresNotAdviceText: true,
+          notes: 'Legacy "no conflict" educational result; mirrors i18n key '
+              '`legacy.no_conflict` (en).',
+        ),
       ];
 
   SafeCopyTemplate? byId(String id) {

--- a/lib/features/onboarding/onboarding_page.dart
+++ b/lib/features/onboarding/onboarding_page.dart
@@ -5,6 +5,7 @@ import '../../core/i18n/app_i18n.dart';
 import '../../core/models/drug_definition.dart';
 import '../../core/state/app_state.dart';
 import '../../core/theme/liquid_glass_theme.dart';
+import '../../domain/usecases/explanation_copy_service.dart';
 import 'onboarding_flow.dart';
 
 class OnboardingPage extends StatefulWidget {
@@ -171,7 +172,11 @@ class _OnboardingPageState extends State<OnboardingPage> {
           children: [
             _IconLine(
               icon: Icons.health_and_safety_outlined,
-              title: i18n.tr('onboarding.safety_education_title'),
+              title: const ExplanationCopyService().resolveForLocale(
+                'onboarding_safety_education_title',
+                locale: i18n.languageFamily,
+                fallback: i18n.tr('onboarding.safety_education_title'),
+              ),
               body: i18n.tr('onboarding.safety_education_body'),
             ),
             const SizedBox(height: 12),

--- a/test/explanation_copy_service_test.dart
+++ b/test/explanation_copy_service_test.dart
@@ -60,4 +60,36 @@ void main() {
     expect(service.notAdvice(), service.notAdvice());
     expect(service.safetyBoundary(), service.safetyBoundary());
   });
+
+  // 7 — locale-strict resolve returns compiled text for a locale the template
+  // carries (en), and equals the migrated i18n boundary string.
+  test('resolveForLocale returns compiled text for en', () {
+    final text = service.resolveForLocale(
+      'legacy_no_conflict',
+      locale: 'en',
+      fallback: 'FALLBACK',
+    );
+    expect(text, isNot('FALLBACK'));
+    expect(text.toLowerCase(), contains('not medical advice'));
+  });
+
+  // 8 — locale-strict resolve does NOT substitute English for a locale the
+  // template lacks; it returns the (localized) fallback instead.
+  test('resolveForLocale keeps the localized fallback for missing locale', () {
+    const localized = '未检测到显著的规则冲突（仅基于内置规则；并非医疗建议）。';
+    final text = service.resolveForLocale(
+      'legacy_no_conflict',
+      locale: 'zh',
+      fallback: localized,
+    );
+    expect(text, localized);
+  });
+
+  // 9 — unknown template id in resolveForLocale falls back too.
+  test('resolveForLocale falls back for unknown template', () {
+    expect(
+      service.resolveForLocale('nope', locale: 'en', fallback: 'FB'),
+      'FB',
+    );
+  });
 }


### PR DESCRIPTION
Follow-up to PR #63 (merged). That PR landed the `ExplanationCopyService`, the trace-card wiring, and the `safety_boundary_default` template. This PR adds the **next batch of the P6 copy migration** — the two i18n boundary surfaces — which was developed alongside #63 but did not make it into the merge.

> Safe and incremental, locale-correct. No medical advice added, deterministic, not wired into scoring. en output is byte-identical; non-en users keep their existing translations.

## What's included

- **Registry**: two new compiler-validated templates whose en text mirrors the existing `app_i18n` strings — `onboarding_safety_education_title` ("Rule guidance is not medical advice") and `legacy_no_conflict` ("No significant rule conflicts were detected … not medical advice."). Both carry the `not medical advice` boundary term and compile clean (registry now 9 templates).
- **`ExplanationCopyService.resolveForLocale(id, locale, fallback)`**: returns the compiler-validated text **only when the template actually carries the requested locale**; otherwise returns the supplied localized fallback. This guarantees a non-localized template never substitutes English for a zh/fr/ja string.
- **Consumers migrated (call site only; localized `tr()` kept as the fallback)**:
  - `lib/core/analysis/interaction_engine.dart` → `legacy.no_conflict`
  - `lib/features/onboarding/onboarding_page.dart` → `onboarding.safety_education_title`
- **Tests**: `test/explanation_copy_service_test.dart` extended (en → compiled text; missing locale → localized fallback; unknown template → fallback).

## Behavior

en users now see the compiler-validated boundary copy (byte-identical to today). zh/fr/ja users keep their existing translation unchanged, because `resolveForLocale` only overrides when the template has that exact locale.

## Verification

- `dart format` clean; `flutter analyze` — No issues found.
- `flutter test --concurrency=1` — **677 passed**.
- `public:preflight` 0 BLOCKER; `privacy:preflight` pass; firestore 13/13; `copy:compile` 9/9 (0 blocker); `localization:lint` pass; `contribution:route` pass; replay 41/41.

## Scope / constraints

No change to the mechanistic engine, importers, scoring algorithm, Firebase rules, or existing public/privacy preflight behavior. Two consumer call sites changed (boundary-copy source only). Targets `peripheral-algorithm-integration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)