### PR TITLE
Migrate onboarding safety/account-scope disclaimer body copy through the compiler

### DIFF
--- a/lib/domain/usecases/safe_copy_template_registry.dart
+++ b/lib/domain/usecases/safe_copy_template_registry.dart
@@ -132,6 +132,39 @@ class SafeCopyTemplateRegistry {
           notes: 'Legacy "no conflict" educational result; mirrors i18n key '
               '`legacy.no_conflict` (en).',
         ),
+        SafeCopyTemplate(
+          templateId: 'onboarding_safety_education_body',
+          outputType: 'boundary',
+          defaultLocale: 'en',
+          localizedText: {
+            'en': 'ParkinSUM gives conservative prompts from medication, meal, '
+                'and regional rules. Medication changes, stopping therapy, or '
+                'clinical diet decisions still need a physician or pharmacist.',
+          },
+          requiredSafetyTerms: ['physician or pharmacist'],
+          notes: 'Onboarding safety-education body; mirrors i18n key '
+              '`onboarding.safety_education_body` (en).',
+        ),
+        SafeCopyTemplate(
+          templateId: 'onboarding_account_scope_title',
+          outputType: 'boundary',
+          defaultLocale: 'en',
+          localizedText: {'en': 'Account data stays user-scoped'},
+          notes: 'Onboarding account-scope title; mirrors i18n key '
+              '`onboarding.account_scope_title` (en). Data-scope disclaimer; no '
+              'medical safety term required.',
+        ),
+        SafeCopyTemplate(
+          templateId: 'onboarding_account_scope_body',
+          outputType: 'boundary',
+          defaultLocale: 'en',
+          localizedText: {
+            'en': 'After onboarding, profile, medications, intakes, and later '
+                'audit records are saved under the current account user space.',
+          },
+          notes: 'Onboarding account-scope body; mirrors i18n key '
+              '`onboarding.account_scope_body` (en). Data-scope disclaimer.',
+        ),
       ];
 
   SafeCopyTemplate? byId(String id) {

--- a/lib/features/onboarding/onboarding_page.dart
+++ b/lib/features/onboarding/onboarding_page.dart
@@ -177,13 +177,25 @@ class _OnboardingPageState extends State<OnboardingPage> {
                 locale: i18n.languageFamily,
                 fallback: i18n.tr('onboarding.safety_education_title'),
               ),
-              body: i18n.tr('onboarding.safety_education_body'),
+              body: const ExplanationCopyService().resolveForLocale(
+                'onboarding_safety_education_body',
+                locale: i18n.languageFamily,
+                fallback: i18n.tr('onboarding.safety_education_body'),
+              ),
             ),
             const SizedBox(height: 12),
             _IconLine(
               icon: Icons.privacy_tip_outlined,
-              title: i18n.tr('onboarding.account_scope_title'),
-              body: i18n.tr('onboarding.account_scope_body'),
+              title: const ExplanationCopyService().resolveForLocale(
+                'onboarding_account_scope_title',
+                locale: i18n.languageFamily,
+                fallback: i18n.tr('onboarding.account_scope_title'),
+              ),
+              body: const ExplanationCopyService().resolveForLocale(
+                'onboarding_account_scope_body',
+                locale: i18n.languageFamily,
+                fallback: i18n.tr('onboarding.account_scope_body'),
+              ),
             ),
           ],
         ),


### PR DESCRIPTION
Follow-up to merged PR #63 (ExplanationCopyService + trace-card wiring) and PR #64 (`resolveForLocale` + first two i18n boundary templates). This continues the P6 copy migration with the **rest of the onboarding safety panel's disclaimer strings**, using the same locale-strict pattern.

> Safe and incremental, locale-correct. No medical advice added, deterministic, not wired into scoring. en output is byte-identical; non-en users keep their existing translations.

## What's included

- **Registry** (now 12 templates; all compile clean): three new compiler-validated templates mirroring the en `app_i18n` strings —
  - `onboarding_safety_education_body` (requires the `physician or pharmacist` boundary term),
  - `onboarding_account_scope_title` and `onboarding_account_scope_body` (data-scope disclaimers; no medical safety term required, still placeholder/banned-phrase validated).
- **Consumer** (`lib/features/onboarding/onboarding_page.dart`): the safety-education body and the account-scope title/body now resolve through `ExplanationCopyService.resolveForLocale` — en sees the compiler-validated copy (byte-identical), zh/fr/ja keep their existing translation via the `tr()` fallback.

## Verification

- `dart format` clean; `flutter analyze` — No issues found.
- `flutter test --concurrency=1` — **677 passed**.
- `public:preflight` 0 BLOCKER; `privacy:preflight` pass; firestore 13/13; `copy:compile` 12/12 (0 blocker); `localization:lint` pass; `contribution:route` pass.

## Scope / constraints

No change to the mechanistic engine, importers, scoring algorithm, Firebase rules, or existing public/privacy preflight behavior. One onboarding UI file changed (boundary-copy source only). Targets `peripheral-algorithm-integration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)