### PR TITLE
Harden peripheral security boundaries

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -269,12 +269,90 @@ service cloud.firestore {
     }
 
     function validAppCatalogWrite(table, rowId) {
-      return safeId(rowId) &&
-      (
-        table in ['foods', 'medications', 'interaction_rules'] ||
-        table.matches('^live_probe.*$')
-      ) &&
-      request.resource.data.keys().size() <= 48;
+      return safeId(rowId) && (
+        (table == 'foods' && validFoodCatalogRow(rowId)) ||
+        (table == 'medications' && validMedicationCatalogRow(rowId)) ||
+        (table == 'interaction_rules' && validInteractionRuleCatalogRow(rowId)) ||
+        (table.matches('^live_probe.*$') && validLiveProbeCatalogRow())
+      );
+    }
+
+    function validFoodCatalogRow(rowId) {
+      return request.resource.data.keys().hasOnly([
+        'id', 'name', 'category', 'aliases', 'description', 'sourceSystem',
+        'sourceFoodCode', 'jurisdiction', 'textureClass', 'iddsiLevel',
+        'proteinG', 'carbsG', 'fatG', 'fiberG', 'sodiumMg',
+        'missingNutrientFields', 'energyKcal', 'waterG', 'aminoAcidProfile',
+        'basisType', 'preparationState', 'qualifierKind', '_synced_at_ms'
+      ]) &&
+      validString('id', 160) &&
+      request.resource.data.id == rowId &&
+      validString('name', 240) &&
+      validString('category', 64) &&
+      optionalStringList('aliases', 64) &&
+      optionalString('description', 1200) &&
+      optionalString('sourceSystem', 120) &&
+      optionalString('sourceFoodCode', 160) &&
+      optionalString('jurisdiction', 32) &&
+      optionalString('textureClass', 64) &&
+      optionalNumber('iddsiLevel') &&
+      optionalNumber('proteinG') &&
+      optionalNumber('carbsG') &&
+      optionalNumber('fatG') &&
+      optionalNumber('fiberG') &&
+      optionalNumber('sodiumMg') &&
+      optionalStringList('missingNutrientFields', 32) &&
+      optionalNumber('energyKcal') &&
+      optionalNumber('waterG') &&
+      optionalMap('aminoAcidProfile', 48) &&
+      optionalString('basisType', 80) &&
+      optionalString('preparationState', 120) &&
+      optionalString('qualifierKind', 80) &&
+      optionalNumber('_synced_at_ms');
+    }
+
+    function validMedicationCatalogRow(rowId) {
+      return request.resource.data.keys().hasOnly([
+        'id', 'genericName', 'brandNames', 'aliases', 'tags', 'notes',
+        'interactionSummary', 'sourceSystem', 'sourceProductCode',
+        'jurisdiction', 'route', 'dosageForm', 'releaseType', '_synced_at_ms'
+      ]) &&
+      validString('id', 160) &&
+      request.resource.data.id == rowId &&
+      validString('genericName', 240) &&
+      optionalStringList('brandNames', 64) &&
+      optionalStringList('aliases', 64) &&
+      optionalStringList('tags', 32) &&
+      optionalString('notes', 1200) &&
+      optionalString('interactionSummary', 1200) &&
+      optionalString('sourceSystem', 120) &&
+      optionalString('sourceProductCode', 160) &&
+      optionalString('jurisdiction', 32) &&
+      optionalString('route', 80) &&
+      optionalString('dosageForm', 120) &&
+      optionalString('releaseType', 80) &&
+      optionalNumber('_synced_at_ms');
+    }
+
+    function validInteractionRuleCatalogRow(rowId) {
+      return request.resource.data.keys().hasOnly([
+        'id', 'drugId', 'ruleType', 'target', 'severity', 'weight',
+        'description', '_synced_at_ms'
+      ]) &&
+      validString('id', 160) &&
+      request.resource.data.id == rowId &&
+      validString('drugId', 160) &&
+      validString('ruleType', 120) &&
+      validString('target', 240) &&
+      request.resource.data.severity is int &&
+      optionalNumber('weight') &&
+      optionalString('description', 1200) &&
+      optionalNumber('_synced_at_ms');
+    }
+
+    function validLiveProbeCatalogRow() {
+      return request.resource.data.keys().hasOnly(['probe']) &&
+      validString('probe', 160);
     }
 
     match /users/{uid} {

--- a/lib/core/utils/local_p0_import_locator_io.dart
+++ b/lib/core/utils/local_p0_import_locator_io.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:archive/archive.dart';
 
+import '../../data/datasources/remote/archive_import_support.dart';
 import 'local_p0_import_locator.dart';
 
 class _IoLocalP0ImportLocator implements LocalP0ImportLocator {
@@ -53,7 +54,7 @@ class _IoLocalP0ImportLocator implements LocalP0ImportLocator {
     if (entity == FileSystemEntityType.file &&
         path.toLowerCase().endsWith('.zip')) {
       resolvedPaths['ciqual'] = path;
-      return File(path).readAsBytes();
+      return _readArchiveBytes(File(path));
     }
     final directory = entity == FileSystemEntityType.directory
         ? Directory(path)
@@ -76,8 +77,16 @@ class _IoLocalP0ImportLocator implements LocalP0ImportLocator {
       );
     }
     final archive = Archive();
+    var totalBytes = 0;
     for (final file in requiredFiles.cast<File>()) {
-      final bytes = await file.readAsBytes();
+      final bytes = await _readExpandedEntryBytes(file);
+      totalBytes += bytes.length;
+      if (totalBytes >
+          ArchiveImportSupport.defaultLimits.maxTotalUncompressedBytes) {
+        throw const FormatException(
+          'Ciqual XML files exceed total expanded-size limit.',
+        );
+      }
       archive.addFile(
           ArchiveFile(file.uri.pathSegments.last, bytes.length, bytes));
     }
@@ -98,7 +107,7 @@ class _IoLocalP0ImportLocator implements LocalP0ImportLocator {
     }
     if (entity == FileSystemEntityType.file) {
       resolvedPaths[key] = path;
-      return File(path).readAsBytes();
+      return _readArchiveBytes(File(path));
     }
     final directory = Directory(path);
     final candidate = _findFirst(
@@ -116,7 +125,22 @@ class _IoLocalP0ImportLocator implements LocalP0ImportLocator {
       );
     }
     resolvedPaths[key] = candidate.path;
-    return candidate.readAsBytes();
+    return _readArchiveBytes(candidate);
+  }
+
+  Future<List<int>> _readArchiveBytes(File file) async {
+    ArchiveImportSupport.validateCompressedInputLength(await file.length());
+    return file.readAsBytes();
+  }
+
+  Future<List<int>> _readExpandedEntryBytes(File file) async {
+    final length = await file.length();
+    if (length > ArchiveImportSupport.defaultLimits.maxEntryUncompressedBytes) {
+      throw FormatException(
+        'Import file exceeds expanded-size limit: ${file.path}',
+      );
+    }
+    return file.readAsBytes();
   }
 
   File? _findFirst(List<File> files, List<String> patterns) {

--- a/lib/data/datasources/remote/archive_import_support.dart
+++ b/lib/data/datasources/remote/archive_import_support.dart
@@ -13,20 +13,67 @@ import 'package:csv/csv.dart';
 class ArchiveImportSupport {
   const ArchiveImportSupport._();
 
-  static Map<String, List<int>> unzipFiles(List<int> zipBytes) {
+  static const defaultLimits = ArchiveImportLimits();
+
+  static void validateCompressedInputLength(
+    int length, {
+    ArchiveImportLimits limits = defaultLimits,
+  }) {
+    if (length > limits.maxCompressedArchiveBytes) {
+      throw FormatException(
+        'Archive exceeds compressed-size limit '
+        '(${limits.maxCompressedArchiveBytes} bytes).',
+      );
+    }
+  }
+
+  static Map<String, List<int>> unzipFiles(
+    List<int> zipBytes, {
+    ArchiveImportLimits limits = defaultLimits,
+  }) {
+    validateCompressedInputLength(zipBytes.length, limits: limits);
     final archive = ZipDecoder().decodeBytes(zipBytes);
+    final archiveFiles = archive.files.where((item) => item.isFile).toList();
+    if (archiveFiles.length > limits.maxFileCount) {
+      throw FormatException(
+        'Archive exceeds file-count limit (${limits.maxFileCount}).',
+      );
+    }
     final files = <String, List<int>>{};
-    for (final item in archive.files) {
-      if (!item.isFile) continue;
-      files[item.name] = item.content is List<int>
+    var totalExpandedBytes = 0;
+    for (final item in archiveFiles) {
+      final name = _validatedEntryName(item.name);
+      if (item.isSymbolicLink) {
+        throw FormatException(
+            'Archive symbolic links are not supported: $name');
+      }
+      if (files.containsKey(name)) {
+        throw FormatException('Archive contains duplicate file name: $name');
+      }
+      if (item.size > limits.maxEntryUncompressedBytes) {
+        throw FormatException(
+          'Archive entry exceeds expanded-size limit: $name.',
+        );
+      }
+      totalExpandedBytes += item.size;
+      if (totalExpandedBytes > limits.maxTotalUncompressedBytes) {
+        throw FormatException(
+          'Archive exceeds total expanded-size limit '
+          '(${limits.maxTotalUncompressedBytes} bytes).',
+        );
+      }
+      files[name] = item.content is List<int>
           ? List<int>.from(item.content as List<int>)
           : utf8.encode('${item.content}');
     }
     return files;
   }
 
-  static Map<String, String> unzipTextFiles(List<int> zipBytes) {
-    final files = unzipFiles(zipBytes);
+  static Map<String, String> unzipTextFiles(
+    List<int> zipBytes, {
+    ArchiveImportLimits limits = defaultLimits,
+  }) {
+    final files = unzipFiles(zipBytes, limits: limits);
     return {
       for (final entry in files.entries) entry.key: utf8.decode(entry.value),
     };
@@ -77,4 +124,30 @@ class ArchiveImportSupport {
     if (line.contains(',')) return ',';
     return null;
   }
+
+  static String _validatedEntryName(String rawName) {
+    final name = rawName.replaceAll('\\', '/');
+    final segments = name.split('/');
+    if (name.isEmpty ||
+        name.startsWith('/') ||
+        RegExp(r'^[A-Za-z]:/').hasMatch(name) ||
+        segments.any((segment) => segment == '..')) {
+      throw FormatException('Archive contains unsafe file name: $rawName');
+    }
+    return name;
+  }
+}
+
+class ArchiveImportLimits {
+  final int maxCompressedArchiveBytes;
+  final int maxFileCount;
+  final int maxEntryUncompressedBytes;
+  final int maxTotalUncompressedBytes;
+
+  const ArchiveImportLimits({
+    this.maxCompressedArchiveBytes = 16 * 1024 * 1024,
+    this.maxFileCount = 128,
+    this.maxEntryUncompressedBytes = 16 * 1024 * 1024,
+    this.maxTotalUncompressedBytes = 64 * 1024 * 1024,
+  });
 }

--- a/lib/data/datasources/remote/dailymed_p0_importer.dart
+++ b/lib/data/datasources/remote/dailymed_p0_importer.dart
@@ -23,6 +23,7 @@ import 'source_fetch_client.dart';
 /// - 同时把可解析到的 SPL section 全量落成 `drug_label_section`，让药品详情页和后续正文索引
 ///   可以直接消费更完整的官方标签文本。
 class DailyMedP0Importer {
+  static const int maxSplXmlCharacters = 16 * 1024 * 1024;
   final SourceFetchClient fetchClient;
 
   const DailyMedP0Importer({required this.fetchClient});
@@ -72,6 +73,7 @@ class DailyMedP0Importer {
     List<Map<String, dynamic>> packaging = const <Map<String, dynamic>>[],
     List<Map<String, dynamic>> media = const <Map<String, dynamic>>[],
   }) {
+    validateSplXmlLength(xml.length);
     final document = XmlDocument.parse(xml);
     final setId = _firstAttr(document, 'setId', 'root') ??
         _firstAttr(document, 'id', 'root') ??
@@ -389,6 +391,17 @@ class DailyMedP0Importer {
       conceptVariantCrosswalks: crosswalks,
       projectedDrugs: [projectedDrug],
     );
+  }
+
+  static void validateSplXmlLength(
+    int length, {
+    int maxCharacters = maxSplXmlCharacters,
+  }) {
+    if (length > maxCharacters) {
+      throw FormatException(
+        'DailyMed SPL XML exceeds the $maxCharacters character limit.',
+      );
+    }
   }
 
   Future<List<dynamic>> _safeFetchJsonList(String url) async {

--- a/lib/data/datasources/remote/fao_fbdg_p1_importer.dart
+++ b/lib/data/datasources/remote/fao_fbdg_p1_importer.dart
@@ -19,6 +19,12 @@ class FaoFbdgP1Importer {
     required String countryCode,
     required String url,
   }) async {
+    final uri = Uri.parse(url);
+    if (uri.scheme != 'https' ||
+        (uri.host != 'fao.org' && !uri.host.endsWith('.fao.org'))) {
+      throw ArgumentError.value(
+          url, 'url', 'Expected an official FAO HTTPS URL.');
+    }
     final html = await fetchClient.getText(url);
     return importCountryPage(
       countryCode: countryCode,

--- a/lib/data/datasources/remote/source_fetch_client.dart
+++ b/lib/data/datasources/remote/source_fetch_client.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
 
@@ -27,27 +28,74 @@ abstract class SourceFetchClient {
 }
 
 class HttpSourceFetchClient implements SourceFetchClient {
+  static const int maxResponseBytes = 16 * 1024 * 1024;
+
   final http.Client _client;
+  final int responseByteLimit;
   final Map<String, Map<String, String>> _lastMetadata =
       <String, Map<String, String>>{};
 
-  HttpSourceFetchClient({http.Client? client})
-      : _client = client ?? http.Client();
+  HttpSourceFetchClient({
+    http.Client? client,
+    this.responseByteLimit = maxResponseBytes,
+  }) : _client = client ?? http.Client();
 
   @override
   Future<String> getText(String url, {Map<String, String>? headers}) async {
-    final response = await _client.get(Uri.parse(url), headers: headers);
-    _ensureSuccess(response, url);
+    final response = await _getBounded(url, headers: headers);
     _captureMetadata(url, response);
     return response.body;
   }
 
   @override
   Future<List<int>> getBytes(String url, {Map<String, String>? headers}) async {
-    final response = await _client.get(Uri.parse(url), headers: headers);
-    _ensureSuccess(response, url);
+    final response = await _getBounded(url, headers: headers);
     _captureMetadata(url, response);
     return response.bodyBytes;
+  }
+
+  Future<http.Response> _getBounded(
+    String url, {
+    Map<String, String>? headers,
+  }) async {
+    final uri = Uri.parse(url);
+    if (uri.scheme != 'https' || uri.host.isEmpty || uri.userInfo.isNotEmpty) {
+      throw StateError('Refusing non-HTTPS or malformed source URL: $url');
+    }
+    final request = http.Request('GET', uri)
+      ..followRedirects = false
+      ..maxRedirects = 0;
+    if (headers != null) request.headers.addAll(headers);
+    final streamed = await _client.send(request);
+    if (streamed.statusCode < 200 || streamed.statusCode >= 300) {
+      await streamed.stream.drain<void>();
+      throw StateError(
+        'Failed to fetch $url: HTTP ${streamed.statusCode}',
+      );
+    }
+    final declaredLength = streamed.contentLength;
+    if (declaredLength != null && declaredLength > responseByteLimit) {
+      await streamed.stream.drain<void>();
+      throw StateError(
+        'Failed to fetch $url: response exceeds $responseByteLimit bytes.',
+      );
+    }
+    final bytes = BytesBuilder(copy: false);
+    await for (final chunk in streamed.stream) {
+      if (bytes.length + chunk.length > responseByteLimit) {
+        throw StateError(
+          'Failed to fetch $url: response exceeds $responseByteLimit bytes.',
+        );
+      }
+      bytes.add(chunk);
+    }
+    return http.Response.bytes(
+      bytes.takeBytes(),
+      streamed.statusCode,
+      headers: streamed.headers,
+      reasonPhrase: streamed.reasonPhrase,
+      request: streamed.request,
+    );
   }
 
   void _captureMetadata(String url, http.Response response) {
@@ -83,14 +131,6 @@ class HttpSourceFetchClient implements SourceFetchClient {
   }) async {
     final text = await getText(url, headers: headers);
     return jsonDecode(text) as List<dynamic>;
-  }
-
-  void _ensureSuccess(http.Response response, String url) {
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw StateError(
-        'Failed to fetch $url: HTTP ${response.statusCode}',
-      );
-    }
   }
 }
 

--- a/lib/domain/entities/source_version_drift.dart
+++ b/lib/domain/entities/source_version_drift.dart
@@ -51,6 +51,9 @@ class SourceVersionDriftFindingType {
       'assumption_registry_unreferenced';
   static const String documentationClaimMismatch =
       'documentation_claim_mismatch';
+  static const String duplicateSourceRegistryId =
+      'duplicate_source_registry_id';
+  static const String invalidTimestamp = 'invalid_timestamp';
 }
 
 /// One source/version metadata record (supplied by the CLI collector or tests).

--- a/lib/domain/usecases/explanation_copy_service.dart
+++ b/lib/domain/usecases/explanation_copy_service.dart
@@ -13,8 +13,10 @@
 library;
 
 import '../entities/explanation_copy.dart';
+import '../entities/localization_safety_lint.dart';
 import '../entities/rule_explanation.dart';
 import 'explanation_copy_compiler.dart';
+import 'localization_safety_lint.dart';
 import 'safe_copy_template_registry.dart';
 
 class ExplanationCopyService {
@@ -37,7 +39,7 @@ class ExplanationCopyService {
     CopyCompileContext context = const CopyCompileContext(),
   }) {
     final template = _registry.byId(templateId);
-    if (template == null) return fallback;
+    if (template == null) return _validatedFallback(fallback);
     final result = _compiler.compile(
       template,
       bindings: bindings,
@@ -46,7 +48,7 @@ class ExplanationCopyService {
     );
     final text = result.compiled?.text;
     if (result.valid && text != null && text.trim().isNotEmpty) return text;
-    return fallback;
+    return _validatedFallback(fallback);
   }
 
   /// Locale-strict resolve: returns the compiler-validated text **only** when
@@ -61,7 +63,7 @@ class ExplanationCopyService {
   }) {
     final template = _registry.byId(templateId);
     if (template == null || !template.localizedText.containsKey(locale)) {
-      return fallback;
+      return _validatedFallback(fallback);
     }
     return resolve(templateId, locale: locale, fallback: fallback);
   }
@@ -81,4 +83,23 @@ class ExplanationCopyService {
         locale: locale,
         fallback: RuleExplanation.defaultSafetyBoundary,
       );
+
+  String _validatedFallback(String fallback) {
+    final report = const LocalizationSafetyLint().lint(
+      [
+        LocalizationSurface(
+          surfaceId: 'runtime_fallback',
+          locale: '-',
+          key: 'runtime_fallback',
+          text: fallback,
+          source: 'runtime_fallback',
+          expectedSafetyRole: 'plain',
+        ),
+      ],
+      const LocalizationSafetyLintConfig(),
+    );
+    return report.blockerCount == 0
+        ? fallback
+        : RuleExplanation.defaultSafetyBoundary;
+  }
 }

--- a/lib/domain/usecases/local_ai_recommendation_adapter.dart
+++ b/lib/domain/usecases/local_ai_recommendation_adapter.dart
@@ -105,6 +105,18 @@ class LocalAiRecommendationPolishResult {
 /// - 这是“受限增强器”，不是事实来源，也不能覆盖硬规则；
 /// - 任意网络/JSON/契约失败都必须回退到 deterministic 结果。
 class LocalAiRecommendationAdapter implements LocalResponsePolisher {
+  static const _unsafeGeneratedCopyPhrases = <String>[
+    'adjust your dose',
+    'recommended dose',
+    'recommended timing',
+    'take your medication at',
+    'avoid protein',
+    'safe for you',
+    'confirmed safe',
+    'clinically validated',
+    'patient-calibrated',
+  ];
+
   final http.Client _client;
 
   LocalAiRecommendationAdapter({
@@ -180,7 +192,11 @@ class LocalAiRecommendationAdapter implements LocalResponsePolisher {
       timeout: const Duration(milliseconds: 12000),
     );
     final polished = payload?['polished_text']?.toString().trim();
-    if (polished == null || polished.isEmpty) return null;
+    if (polished == null ||
+        polished.isEmpty ||
+        _containsUnsafeGeneratedCopy(polished)) {
+      return null;
+    }
     return polished;
   }
 
@@ -253,7 +269,7 @@ class LocalAiRecommendationAdapter implements LocalResponsePolisher {
       schemaName: 'meal_conflict_polish',
       timeout: _timeout(userProfile),
     );
-    if (payload == null) return result;
+    if (payload == null || _containsUnsafeGeneratedCopy(payload)) return result;
     final issueDetails =
         (payload['issue_details'] as List<dynamic>? ?? const <dynamic>[])
             .map((item) => item.toString().trim())
@@ -385,7 +401,7 @@ class LocalAiRecommendationAdapter implements LocalResponsePolisher {
       schemaName: 'safe_rerank',
       timeout: _timeout(userProfile),
     );
-    if (payload == null) return null;
+    if (payload == null || _containsUnsafeGeneratedCopy(payload)) return null;
 
     return _safeResult(
       payload: payload,
@@ -599,10 +615,11 @@ class LocalAiRecommendationAdapter implements LocalResponsePolisher {
     required Duration timeout,
   }) async {
     if (provider == LocalAiProviders.ollama) {
-      final response = await _client.get(
+      final response = await _getNoRedirect(
         _ollamaTagsUri(endpoint),
         headers: {'Accept': 'application/json'},
-      ).timeout(timeout);
+        timeout: timeout,
+      );
       if (response.statusCode < 200 || response.statusCode >= 300) {
         return false;
       }
@@ -633,51 +650,47 @@ class LocalAiRecommendationAdapter implements LocalResponsePolisher {
   }) {
     final uri = Uri.parse(endpoint);
     return switch (provider) {
-      LocalAiProviders.ollama => _client
-          .post(
-            uri,
-            headers: {'Content-Type': 'application/json'},
-            body: jsonEncode({
-              'model': model,
-              'stream': false,
-              'messages': const [
-                {'role': 'user', 'content': 'reply with {"ok":true}'}
-              ],
-              'format': {
-                'type': 'object',
-                'properties': {
-                  'ok': {'type': 'boolean'}
-                },
-                'required': ['ok']
+      LocalAiProviders.ollama => _postJsonNoRedirect(
+          uri,
+          {
+            'model': model,
+            'stream': false,
+            'messages': const [
+              {'role': 'user', 'content': 'reply with {"ok":true}'}
+            ],
+            'format': {
+              'type': 'object',
+              'properties': {
+                'ok': {'type': 'boolean'}
               },
-            }),
-          )
-          .timeout(timeout),
-      LocalAiProviders.openAiCompat => _client
-          .post(
-            uri,
-            headers: {'Content-Type': 'application/json'},
-            body: jsonEncode({
-              'model': model,
-              'messages': const [
-                {'role': 'user', 'content': 'reply with {"ok":true}'}
-              ],
-              'response_format': {
-                'type': 'json_schema',
-                'json_schema': {
-                  'name': 'availability_probe',
-                  'schema': {
-                    'type': 'object',
-                    'properties': {
-                      'ok': {'type': 'boolean'}
-                    },
-                    'required': ['ok']
-                  }
+              'required': ['ok']
+            },
+          },
+          timeout,
+        ),
+      LocalAiProviders.openAiCompat => _postJsonNoRedirect(
+          uri,
+          {
+            'model': model,
+            'messages': const [
+              {'role': 'user', 'content': 'reply with {"ok":true}'}
+            ],
+            'response_format': {
+              'type': 'json_schema',
+              'json_schema': {
+                'name': 'availability_probe',
+                'schema': {
+                  'type': 'object',
+                  'properties': {
+                    'ok': {'type': 'boolean'}
+                  },
+                  'required': ['ok']
                 }
               }
-            }),
-          )
-          .timeout(timeout),
+            }
+          },
+          timeout,
+        ),
       _ => throw UnsupportedError('Unsupported provider'),
     };
   }
@@ -727,20 +740,18 @@ class LocalAiRecommendationAdapter implements LocalResponsePolisher {
     required Duration timeout,
   }) async {
     try {
-      final response = await _client
-          .post(
-            Uri.parse(endpoint),
-            headers: {'Content-Type': 'application/json'},
-            body: jsonEncode({
-              'model': model,
-              'stream': false,
-              'messages': [
-                {'role': 'user', 'content': prompt}
-              ],
-              'format': schema,
-            }),
-          )
-          .timeout(timeout);
+      final response = await _postJsonNoRedirect(
+        Uri.parse(endpoint),
+        {
+          'model': model,
+          'stream': false,
+          'messages': [
+            {'role': 'user', 'content': prompt}
+          ],
+          'format': schema,
+        },
+        timeout,
+      );
       if (response.statusCode < 200 || response.statusCode >= 300) return null;
       final json = jsonDecode(response.body) as Map<String, dynamic>;
       final content =
@@ -789,25 +800,23 @@ class LocalAiRecommendationAdapter implements LocalResponsePolisher {
     required Duration timeout,
   }) async {
     try {
-      final response = await _client
-          .post(
-            Uri.parse(endpoint),
-            headers: {'Content-Type': 'application/json'},
-            body: jsonEncode({
-              'model': model,
-              'messages': [
-                {'role': 'user', 'content': prompt}
-              ],
-              'response_format': {
-                'type': 'json_schema',
-                'json_schema': {
-                  'name': schemaName,
-                  'schema': schema,
-                }
-              }
-            }),
-          )
-          .timeout(timeout);
+      final response = await _postJsonNoRedirect(
+        Uri.parse(endpoint),
+        {
+          'model': model,
+          'messages': [
+            {'role': 'user', 'content': prompt}
+          ],
+          'response_format': {
+            'type': 'json_schema',
+            'json_schema': {
+              'name': schemaName,
+              'schema': schema,
+            }
+          }
+        },
+        timeout,
+      );
       if (response.statusCode < 200 || response.statusCode >= 300) return null;
       final json = jsonDecode(response.body) as Map<String, dynamic>;
       final choices = json['choices'] as List<dynamic>? ?? const [];
@@ -827,6 +836,7 @@ class LocalAiRecommendationAdapter implements LocalResponsePolisher {
     required List<FoodRecommendation> candidates,
     required LocalAiAvailability availability,
   }) {
+    if (_containsUnsafeGeneratedCopy(payload)) return null;
     final requestedIds =
         (payload['candidate_ids'] as List<dynamic>? ?? const [])
             .map((value) => value.toString())
@@ -898,6 +908,53 @@ class LocalAiRecommendationAdapter implements LocalResponsePolisher {
         .where((item) => item.isNotEmpty)
         .toList(growable: false);
     return values.isEmpty ? fallback : values;
+  }
+
+  Future<http.Response> _getNoRedirect(
+    Uri uri, {
+    required Map<String, String> headers,
+    required Duration timeout,
+  }) {
+    final request = http.Request('GET', uri)
+      ..headers.addAll(headers)
+      ..followRedirects = false
+      ..maxRedirects = 0;
+    return _sendNoRedirect(request, timeout);
+  }
+
+  Future<http.Response> _postJsonNoRedirect(
+    Uri uri,
+    Map<String, dynamic> body,
+    Duration timeout,
+  ) {
+    final request = http.Request('POST', uri)
+      ..headers['Content-Type'] = 'application/json'
+      ..body = jsonEncode(body)
+      ..followRedirects = false
+      ..maxRedirects = 0;
+    return _sendNoRedirect(request, timeout);
+  }
+
+  Future<http.Response> _sendNoRedirect(
+    http.BaseRequest request,
+    Duration timeout,
+  ) async {
+    final streamed = await _client.send(request).timeout(timeout);
+    return http.Response.fromStream(streamed);
+  }
+
+  bool _containsUnsafeGeneratedCopy(Object? value) {
+    if (value is Map) {
+      return value.values.any(_containsUnsafeGeneratedCopy);
+    }
+    if (value is Iterable) {
+      return value.any(_containsUnsafeGeneratedCopy);
+    }
+    if (value is! String) return false;
+    final normalized = value
+        .toLowerCase()
+        .replaceAll(RegExp(r'[\u200B-\u200D\u2060\uFEFF]'), '');
+    return _unsafeGeneratedCopyPhrases.any(normalized.contains);
   }
 }
 

--- a/lib/domain/usecases/localization_safety_lint.dart
+++ b/lib/domain/usecases/localization_safety_lint.dart
@@ -165,25 +165,21 @@ class LocalizationSafetyLint {
     // Per-surface rules B–G.
     for (final s in surfaces) {
       final role = s.expectedSafetyRole;
-      final lower = s.text.toLowerCase();
+      final normalizedText = _normalizedForScan(s.text);
+      final lower = normalizedText.toLowerCase();
 
-      // Rule G allowlist: policy values are exempt from banned/overconfidence.
-      final isPolicyValue =
-          role == 'policy_value' || _safeAllowlist.contains(s.text.trim());
+      // Rule G allowlist: only exact, reviewed policy values are exempt.
+      // A role label alone must never disable scanning of arbitrary text.
+      final isPolicyValue = _safeAllowlist.contains(s.text.trim());
 
       // Rule B — safety boundary for boundary/explanation surfaces.
       if (role == 'boundary' || role == 'explanation') {
-        final hasBoundary = lower.contains('educational') ||
-            lower.contains('not medical advice') ||
+        final hasBoundary = lower.contains('not medical advice') ||
             lower.contains('not clinically calibrated') ||
             lower.contains('not clinical validation') ||
-            lower.contains('modeled') ||
-            lower.contains('simulated') ||
-            lower.contains('source-linked') ||
             // CJK / FR equivalents used in project copy.
-            s.text.contains('教育') ||
-            s.text.contains('未经临床校准') ||
-            s.text.contains('不是医疗建议');
+            normalizedText.contains('未经临床校准') ||
+            normalizedText.contains('不是医疗建议');
         if (!hasBoundary) {
           findings.add(LocalizationSafetyFinding(
             severity: 'warn',
@@ -229,7 +225,7 @@ class LocalizationSafetyLint {
       if (!isPolicyValue) {
         for (final entry in bannedFamilies.entries) {
           for (final pattern in entry.value) {
-            if (_isBannedHit(s.text, lower, pattern, entry.key)) {
+            if (_isBannedHit(normalizedText, lower, pattern, entry.key)) {
               findings.add(LocalizationSafetyFinding(
                 severity: 'blocker',
                 findingType: bannedPhrase,
@@ -338,21 +334,34 @@ class LocalizationSafetyLint {
     final isLatin = family == 'en' || family == 'fr';
     final hay = isLatin ? lower : raw;
     final needle = isLatin ? pattern.toLowerCase() : pattern;
-    if (!hay.contains(needle)) return false;
-    // Allow safe negated/allowlist phrases (e.g. "not clinically validated").
-    for (final safe in _safeAllowlist) {
-      if (hay.contains(safe.toLowerCase()) &&
-          safe.toLowerCase().contains(needle)) {
-        return false;
+    var start = 0;
+    while (true) {
+      final index = hay.indexOf(needle, start);
+      if (index < 0) break;
+      if (!isLatin || !_negatedAt(hay, index)) return true;
+      start = index + needle.length;
+    }
+    if (isLatin) {
+      final compactHay = hay.replaceAll(RegExp(r'\s+'), '');
+      final compactNeedle = needle.replaceAll(RegExp(r'\s+'), '');
+      var compactStart = 0;
+      while (true) {
+        final index = compactHay.indexOf(compactNeedle, compactStart);
+        if (index < 0) return false;
+        if (!_negatedAtCompact(compactHay, index)) return true;
+        compactStart = index + compactNeedle.length;
       }
     }
-    if (isLatin && _negatedNearby(hay, needle)) return false;
-    return true;
+    return false;
   }
 
   bool _negatedNearby(String hay, String needle) {
     final idx = hay.indexOf(needle);
     if (idx < 0) return false;
+    return _negatedAt(hay, idx);
+  }
+
+  bool _negatedAt(String hay, int idx) {
     final start = (idx - 8).clamp(0, hay.length);
     final prefix = hay.substring(start, idx);
     return prefix.contains('not ') ||
@@ -361,6 +370,21 @@ class LocalizationSafetyLint {
         prefix.contains('pas ') ||
         prefix.contains('no ');
   }
+
+  bool _negatedAtCompact(String hay, int idx) {
+    final start = (idx - 8).clamp(0, hay.length);
+    final prefix = hay.substring(start, idx);
+    return prefix.endsWith('not') ||
+        prefix.endsWith('never') ||
+        prefix.endsWith('non') ||
+        prefix.endsWith('pas') ||
+        prefix.endsWith('no');
+  }
+
+  String _normalizedForScan(String text) => text.replaceAll(
+        RegExp(r'[\u200B-\u200D\u2060\uFEFF]'),
+        ' ',
+      );
 
   Set<String> _placeholders(String text) {
     final out = <String>{};

--- a/lib/domain/usecases/source_version_drift_checker.dart
+++ b/lib/domain/usecases/source_version_drift_checker.dart
@@ -42,6 +42,7 @@ class SourceVersionDriftChecker {
     SourceVersionDriftFindingType.sourceRegistryMismatch,
     SourceVersionDriftFindingType.generatedArtifactStale,
     SourceVersionDriftFindingType.assumptionRegistryUnreferenced,
+    SourceVersionDriftFindingType.invalidTimestamp,
   };
 
   SourceVersionDriftReport check(
@@ -89,6 +90,21 @@ class SourceVersionDriftChecker {
         suggestedFix: fix,
         safetyBoundary: _safetyBoundary,
       );
+    }
+
+    final registryIds = <String>{};
+    for (final r in records.where((record) =>
+        record.recordType == SourceVersionRecordType.sourceAccessRegistry &&
+        record.sourceId.isNotEmpty)) {
+      if (!registryIds.add(r.sourceId)) {
+        findings.add(f(
+          SourceVersionDriftSeverity.blocker,
+          SourceVersionDriftFindingType.duplicateSourceRegistryId,
+          r,
+          'Duplicate source-access registry id can overwrite authority state.',
+          fix: 'Keep exactly one reviewed registry record per source id.',
+        ));
+      }
     }
 
     for (final r in records) {
@@ -177,7 +193,14 @@ class SourceVersionDriftChecker {
               fix: 'Emit a deterministic generated_at in the artifact.'));
         } else if (refTime != null) {
           final gen = _parseDate(r.generatedAt);
-          if (gen != null) {
+          if (gen == null) {
+            findings.add(f(
+                SourceVersionDriftSeverity.warn,
+                SourceVersionDriftFindingType.invalidTimestamp,
+                r,
+                'Generated artifact has an invalid generated_at timestamp.',
+                fix: 'Emit a valid ISO-8601 generated_at timestamp.'));
+          } else {
             final ageDays = refTime.difference(gen).inDays;
             if (ageDays > config.stalenessThresholdDays) {
               findings.add(f(
@@ -249,7 +272,7 @@ class SourceVersionDriftChecker {
               'source fixture-only.',
               fix: 'Do not claim production readiness for a fixture-only '
                   'source.'));
-        } else if (reg == null && registryLoaded) {
+        } else if (reg == null) {
           findings.add(f(
               SourceVersionDriftSeverity.blocker,
               SourceVersionDriftFindingType.fixtureStatusMismatch,

--- a/test/explanation_copy_service_test.dart
+++ b/test/explanation_copy_service_test.dart
@@ -92,4 +92,15 @@ void main() {
       'FB',
     );
   });
+
+  test('unsafe runtime fallback degrades to canonical safety boundary', () {
+    expect(
+      service.resolveForLocale(
+        'nope',
+        locale: 'en',
+        fallback: 'adjust your dose now',
+      ),
+      RuleExplanation.defaultSafetyBoundary,
+    );
+  });
 }

--- a/test/firebase_user_binding_test.dart
+++ b/test/firebase_user_binding_test.dart
@@ -114,6 +114,10 @@ void main() {
     expect(rules, contains('match /cdss_tables/{table}/rows/{rowId}'));
     expect(rules, contains('match /app_catalog/{table}/rows/{rowId}'));
     expect(rules, contains('validAppCatalogWrite(table, rowId)'));
+    expect(rules, contains('validFoodCatalogRow(rowId)'));
+    expect(rules, contains('validMedicationCatalogRow(rowId)'));
+    expect(rules, contains('validInteractionRuleCatalogRow(rowId)'));
+    expect(rules, contains("keys().hasOnly(['probe'])"));
     expect(rules, contains('allow read, write: if false;'));
     expect(rules, isNot(contains('allow read, write: if true')));
     expect(

--- a/test/local_ai_recommendation_adapter_test.dart
+++ b/test/local_ai_recommendation_adapter_test.dart
@@ -156,6 +156,23 @@ void main() {
     expect(result.provider, LocalAiProviders.ollama);
   });
 
+  test('local AI requests disable automatic redirects', () async {
+    final client = MockClient((request) async {
+      expect(request.followRedirects, isFalse);
+      expect(request.maxRedirects, 0);
+      return http.Response('redirect blocked', 307, headers: {
+        'location': 'https://example.com/capture',
+      });
+    });
+    final adapter = LocalAiRecommendationAdapter(client: client);
+
+    final result = await adapter.probe(
+      userProfile: buildProfile(provider: LocalAiProviders.ollama),
+    );
+
+    expect(result.available, isFalse);
+  });
+
   test('rerank rejects ids outside the safe whitelist', () async {
     final client = MockClient((request) async {
       if (request.url.path == '/api/tags') {
@@ -305,5 +322,62 @@ void main() {
     expect(polished.scoreFactors.single.code, 'protein_timing_penalty');
     expect(polished.summary, contains('levodopa'));
     expect(polished.issues.single.detail, contains('plain language'));
+  });
+
+  test('meal conflict polish rejects unsafe generated actions', () async {
+    final client = MockClient((request) async {
+      if (request.url.path == '/api/tags') {
+        return http.Response(
+          jsonEncode({
+            'models': [
+              {'name': 'llama3.2:latest', 'model': 'llama3.2:latest'}
+            ]
+          }),
+          200,
+        );
+      }
+      return http.Response(
+        jsonEncode({
+          'message': {
+            'content': jsonEncode({
+              'summary': 'unsafe',
+              'analysis_text': 'unsafe',
+              'key_findings': ['unsafe'],
+              'next_actions': ['Adjust your dose now.'],
+              'data_notes': ['unsafe'],
+              'issue_details': ['unsafe'],
+              'safety_alignment': 'unsafe',
+            }),
+          }
+        }),
+        200,
+      );
+    });
+    final adapter = LocalAiRecommendationAdapter(client: client);
+    final original = InteractionResult(
+      mealId: 'meal_1',
+      status: InteractionStatus.warning,
+      summary: 'deterministic summary',
+      analysisText: 'deterministic analysis',
+      issues: const [],
+      generatedAt: DateTime(2026, 5, 12),
+      score: 81,
+    );
+
+    final polished = await adapter.polishInteractionResult(
+      userProfile: buildProfile(provider: LocalAiProviders.ollama),
+      meal: Meal(
+        id: 'meal_1',
+        title: 'Dinner',
+        eatenAt: DateTime(2026, 5, 12, 18),
+        items: const [],
+      ),
+      result: original,
+      activeDrugs: const [],
+      intakes: const [],
+    );
+
+    expect(polished.summary, original.summary);
+    expect(polished.nextActions, original.nextActions);
   });
 }

--- a/test/localization_safety_lint_test.dart
+++ b/test/localization_safety_lint_test.dart
@@ -193,4 +193,21 @@ void main() {
     expect(hasType(r, LocalizationSafetyLint.noLocaleDictionaryDiscovered),
         isTrue);
   });
+
+  test('19. safe negation does not hide a later affirmative claim', () {
+    final r = lintOne(s('x', 'en', 'k',
+        'This is not clinically validated. This is clinically validated.'));
+    expect(hasType(r, LocalizationSafetyLint.bannedPhrase), isTrue);
+  });
+
+  test('20. zero-width characters do not bypass banned phrase scan', () {
+    final r = lintOne(s('x', 'en', 'k', 'Use the recommended\u200Bdose now.'));
+    expect(hasType(r, LocalizationSafetyLint.bannedPhrase), isTrue);
+  });
+
+  test('21. arbitrary policy values are still scanned', () {
+    final r =
+        lintOne(s('x', 'en', 'k', 'adjust your dose', role: 'policy_value'));
+    expect(hasType(r, LocalizationSafetyLint.bannedPhrase), isTrue);
+  });
 }

--- a/test/p0_importers_test.dart
+++ b/test/p0_importers_test.dart
@@ -2,12 +2,15 @@ import 'dart:convert';
 
 import 'package:archive/archive.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:parkinsum_companion/core/db/cdss_database.dart';
 import 'package:parkinsum_companion/core/models/drug_definition.dart';
 import 'package:parkinsum_companion/core/models/food_item.dart';
 import 'package:parkinsum_companion/core/models/meal.dart';
 import 'package:parkinsum_companion/core/models/user_profile.dart';
 import 'package:parkinsum_companion/data/datasources/remote/ciqual_p0_importer.dart';
+import 'package:parkinsum_companion/data/datasources/remote/archive_import_support.dart';
 import 'package:parkinsum_companion/data/datasources/remote/dailymed_p0_importer.dart';
 import 'package:parkinsum_companion/data/datasources/remote/ema_p1_importer.dart';
 import 'package:parkinsum_companion/data/datasources/remote/fdc_p0_importer.dart';
@@ -42,6 +45,95 @@ import 'package:parkinsum_companion/domain/usecases/runtime_rule_engine.dart';
 //   - group('Resumable orchestrator'): retry / resume / metadata persistence
 //     for both local-bytes and remote-fetch import paths.
 void main() {
+  group('Official source HTTP safety', () {
+    test('disables redirects for official source fetches', () async {
+      late http.Request seen;
+      final client = HttpSourceFetchClient(
+        client: MockClient((request) async {
+          seen = request;
+          return http.Response('ok', 200);
+        }),
+      );
+
+      expect(await client.getText('https://example.org/source'), 'ok');
+      expect(seen.followRedirects, isFalse);
+      expect(seen.maxRedirects, 0);
+    });
+
+    test('rejects non-HTTPS source URLs before transport', () async {
+      final client = HttpSourceFetchClient(
+        client: MockClient((_) async => http.Response('unexpected', 200)),
+      );
+
+      await expectLater(
+        client.getText('http://127.0.0.1/internal'),
+        throwsStateError,
+      );
+    });
+
+    test('rejects responses above the streaming limit', () async {
+      final client = HttpSourceFetchClient(
+        client: MockClient(
+          (_) async => http.Response.bytes(const [1, 2], 200),
+        ),
+        responseByteLimit: 1,
+      );
+
+      await expectLater(
+        client.getBytes('https://example.org/oversized'),
+        throwsStateError,
+      );
+    });
+  });
+
+  group('Archive import safety limits', () {
+    const smallLimits = ArchiveImportLimits(
+      maxCompressedArchiveBytes: 1024,
+      maxFileCount: 2,
+      maxEntryUncompressedBytes: 32,
+      maxTotalUncompressedBytes: 48,
+    );
+
+    test('rejects compressed archives above the configured limit', () {
+      expect(
+        () => ArchiveImportSupport.validateCompressedInputLength(
+          1025,
+          limits: smallLimits,
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects archive entries above the expanded-size limit', () {
+      final archive = Archive()
+        ..addFile(ArchiveFile('large.txt', 33, List<int>.filled(33, 65)));
+      final zipBytes = ZipEncoder().encode(archive)!;
+
+      expect(
+        () => ArchiveImportSupport.unzipFiles(zipBytes, limits: smallLimits),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects unsafe archive entry paths', () {
+      final archive = Archive()
+        ..addFile(ArchiveFile('../outside.txt', 1, const [65]));
+      final zipBytes = ZipEncoder().encode(archive)!;
+
+      expect(
+        () => ArchiveImportSupport.unzipFiles(zipBytes, limits: smallLimits),
+        throwsFormatException,
+      );
+    });
+  });
+
+  test('DailyMed direct XML parser rejects oversized payload lengths', () {
+    expect(
+      () => DailyMedP0Importer.validateSplXmlLength(11, maxCharacters: 10),
+      throwsFormatException,
+    );
+  });
+
   test('Ciqual importer parses xml rows into foods and observations', () {
     const importer = CiqualP0Importer(
       fetchClient: FakeSourceFetchClient(textByUrl: {}),
@@ -393,6 +485,20 @@ void main() {
     expect(
       bundle.countryDietProfiles.single.avoidanceNotesJson,
       allOf(contains('reduce_salt'), contains('adequate_water')),
+    );
+  });
+
+  test('FAO remote fetch rejects non-official hosts', () async {
+    const importer = FaoFbdgP1Importer(
+      fetchClient: FakeSourceFetchClient(textByUrl: {}),
+    );
+
+    await expectLater(
+      importer.fetchCountryPage(
+        countryCode: 'CN',
+        url: 'https://127.0.0.1/internal',
+      ),
+      throwsArgumentError,
     );
   });
 

--- a/test/source_version_drift_checker_test.dart
+++ b/test/source_version_drift_checker_test.dart
@@ -340,4 +340,38 @@ void main() {
     expect(r.blockerCount, 0);
     expect(r.pass, isTrue);
   });
+
+  test('production claim without registry record is BLOCKER', () {
+    final r = run([
+      const SourceVersionRecord(
+        recordId: 'use1',
+        sourceId: 'src.missing',
+        recordType: SourceVersionRecordType.sourceAdapter,
+        implementationStatus: 'implemented_production_ready',
+        bibliographyRefs: ['src.missing'],
+      ),
+    ]);
+    expect(hasType(r, SourceVersionDriftFindingType.fixtureStatusMismatch),
+        isTrue);
+    expect(r.pass, isFalse);
+  });
+
+  test('duplicate registry source id is BLOCKER', () {
+    final r = run([reg('src.dup'), reg('src.dup')]);
+    expect(hasType(r, SourceVersionDriftFindingType.duplicateSourceRegistryId),
+        isTrue);
+    expect(r.pass, isFalse);
+  });
+
+  test('malformed generated artifact timestamp is reported', () {
+    final r = run([
+      const SourceVersionRecord(
+        recordId: 'art:bad-date',
+        recordType: SourceVersionRecordType.generatedArtifact,
+        generatedAt: 'not-a-date',
+        metadata: {'exists': 'true'},
+      ),
+    ]);
+    expect(hasType(r, SourceVersionDriftFindingType.invalidTimestamp), isTrue);
+  });
 }

--- a/tool/firebase_ops.mjs
+++ b/tool/firebase_ops.mjs
@@ -171,6 +171,7 @@ async function runUserWriteProbe() {
   const uid = required(args.uid, '--uid');
   const runId = args['run-id'] ?? `user_rights_${Date.now()}`;
   requireUidConfirmation(uid);
+  requireSafeSegment(runId, '--run-id');
   requireProjectConfirmation();
 
   const summary = {
@@ -315,9 +316,16 @@ function countExportedDocuments(node) {
 }
 
 function requireUidConfirmation(uid) {
+  requireSafeSegment(uid, '--uid');
   if (dryRun) return;
   if (args.confirm !== uid) {
     throw new Error(`Execute mode requires --confirm ${uid}`);
+  }
+}
+
+function requireSafeSegment(value, flag) {
+  if (!/^[A-Za-z0-9._:-]+$/.test(String(value))) {
+    throw new Error(`${flag} must be one safe path segment.`);
   }
 }
 

--- a/tool/firebase_stage_test_accounts.mjs
+++ b/tool/firebase_stage_test_accounts.mjs
@@ -23,6 +23,7 @@ if (args.help) {
 }
 
 try {
+  requireStageEnvironment();
   requireProjectConfirmation();
   const runId = args['run-id'] ?? `stage_${Date.now()}`;
   const password = args.password ?? `ParkinSUM-${runId}-T3st!`;
@@ -205,6 +206,17 @@ function requireProjectConfirmation() {
   if (dryRun) return;
   if (args['confirm-project'] !== projectId) {
     throw new Error(`Execute mode requires --confirm-project ${projectId}`);
+  }
+}
+
+function requireStageEnvironment() {
+  if (environment !== 'stage') {
+    throw new Error('Stage test accounts may only be created in --env stage.');
+  }
+  if (projectId !== defaultProjectForEnvironment('stage')) {
+    throw new Error(
+      `Stage test accounts require project ${defaultProjectForEnvironment('stage')}.`,
+    );
   }
 }
 

--- a/tool/firebase_token_refresh.mjs
+++ b/tool/firebase_token_refresh.mjs
@@ -26,6 +26,11 @@ if (args.help) {
 }
 
 const payload = JSON.parse(fs.readFileSync(input, 'utf8'));
+if (payload.environment !== environment || payload.projectId !== projectId) {
+  throw new Error(
+    `Token file environment/project mismatch: expected ${environment}/${projectId}.`,
+  );
+}
 const account = payload.accounts?.find((entry) => entry.role === role);
 if (!account) {
   throw new Error(`Role not found in token file: ${role}`);
@@ -33,6 +38,7 @@ if (!account) {
 if (!args['reset-password'] && !account.refreshToken) {
   throw new Error(`Role ${role} has no refreshToken in token file.`);
 }
+requireSafeSegment(account.uid, 'token file uid');
 
 const refreshed = args['reset-password']
   ? await resetPasswordAndSignIn(account)
@@ -74,6 +80,9 @@ returns a cached pre-removal ID token.
 }
 
 async function resetPasswordAndSignIn(account) {
+  if (args['confirm-project'] !== projectId) {
+    throw new Error(`--reset-password requires --confirm-project ${projectId}`);
+  }
   if (!account.email) {
     throw new Error(`Role ${role} has no email in token file.`);
   }
@@ -171,6 +180,12 @@ function normalizeEnvironment(value) {
     throw new Error(`Invalid environment: ${value}. Use dev, stage, or prod.`);
   }
   return normalized;
+}
+
+function requireSafeSegment(value, label) {
+  if (!/^[A-Za-z0-9._:-]+$/.test(String(value))) {
+    throw new Error(`${label} must be one safe path segment.`);
+  }
 }
 
 function defaultProjectForEnvironment(env) {

--- a/tool/firestore_rules_contract_check.mjs
+++ b/tool/firestore_rules_contract_check.mjs
@@ -60,6 +60,14 @@ const checks = [
       /match\s+\/app_catalog\/\{table\}\/rows\/\{rowId\}[\s\S]*allow\s+write:\s*if\s+isAdminOrImporter\(\)\s*&&\s*validAppCatalogWrite\(table,\s*rowId\);/s.test(rules),
   },
   {
+    name: 'app_catalog schema gate uses per-table allowlists',
+    pass:
+      /table\s*==\s*'foods'\s*&&\s*validFoodCatalogRow\(rowId\)/.test(rules) &&
+      /table\s*==\s*'medications'\s*&&\s*validMedicationCatalogRow\(rowId\)/.test(rules) &&
+      /table\s*==\s*'interaction_rules'\s*&&\s*validInteractionRuleCatalogRow\(rowId\)/.test(rules) &&
+      /function\s+validLiveProbeCatalogRow\(\)[\s\S]*keys\(\)\.hasOnly\(\['probe'\]\)/s.test(rules),
+  },
+  {
     name: 'top-level cdss_tables are closed',
     pass:
       /match\s+\/cdss_tables\/\{table\}\/rows\/\{rowId\}\s*\{\s*allow\s+read,\s*write:\s*if\s+false;/s.test(rules),

--- a/tool/firestore_seed_upload.mjs
+++ b/tool/firestore_seed_upload.mjs
@@ -4,24 +4,31 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-const payloadPath = process.argv[2] ?? 'build/firebase_seed/official_core_seed.json';
-const dryRun = process.argv.includes('--dry-run');
+const args = parseArgs(process.argv.slice(2));
+const payloadPath = args._[0] ?? 'build/firebase_seed/official_core_seed.json';
+const execute = Boolean(args.execute);
 const payload = JSON.parse(fs.readFileSync(payloadPath, 'utf8'));
 const projectId = payload.projectId ?? 'parkinsum-companion';
 const databaseId = payload.databaseId ?? '(default)';
-const token = loadFirebaseAccessToken();
 
 if (!payload.documents || !Array.isArray(payload.documents)) {
   throw new Error(`Invalid payload: ${payloadPath}`);
 }
 
 console.log(`project=${projectId} database=${databaseId} documents=${payload.documents.length}`);
-console.log(`snapshot=${payload.snapshotId} dryRun=${dryRun}`);
+console.log(`snapshot=${payload.snapshotId} execute=${execute}`);
 console.log(`counts=${JSON.stringify(payload.counts ?? {})}`);
 
-if (dryRun) {
+if (!execute) {
   process.exit(0);
 }
+if (args['confirm-project'] !== projectId) {
+  throw new Error(`Execute mode requires --confirm-project ${projectId}`);
+}
+requireSafeProjectId(projectId);
+requireSafeDatabaseId(databaseId);
+for (const doc of payload.documents) requireSafeDocumentPath(doc.path);
+const token = loadFirebaseAccessToken();
 
 const baseName = `projects/${projectId}/databases/${databaseId}/documents`;
 const endpoint =
@@ -71,6 +78,29 @@ function loadFirebaseAccessToken() {
   return tokenInfo.access_token;
 }
 
+function requireSafeProjectId(value) {
+  if (!/^[a-z][a-z0-9-]{4,61}[a-z0-9]$/.test(String(value))) {
+    throw new Error('Invalid Firestore projectId.');
+  }
+}
+
+function requireSafeDatabaseId(value) {
+  if (value !== '(default)' && !/^[A-Za-z0-9._-]{1,160}$/.test(String(value))) {
+    throw new Error('Invalid Firestore databaseId.');
+  }
+}
+
+function requireSafeDocumentPath(value) {
+  const segments = String(value ?? '').split('/');
+  if (
+    segments.length < 2 ||
+    segments.length % 2 !== 0 ||
+    segments.some((segment) => !/^[A-Za-z0-9._:-]{1,160}$/.test(segment))
+  ) {
+    throw new Error(`Invalid Firestore document path: ${value}`);
+  }
+}
+
 function toFirestoreFields(input) {
   const fields = {};
   for (const [key, value] of Object.entries(input)) {
@@ -95,4 +125,24 @@ function toFirestoreValue(value) {
     return { mapValue: { fields: toFirestoreFields(value) } };
   }
   return { stringValue: String(value) };
+}
+
+function parseArgs(argv) {
+  const parsed = { _: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('--')) {
+      parsed._.push(token);
+      continue;
+    }
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (next == null || next.startsWith('--')) {
+      parsed[key] = true;
+    } else {
+      parsed[key] = next;
+      i += 1;
+    }
+  }
+  return parsed;
 }


### PR DESCRIPTION
## Summary

- bound ZIP expansion, official-source HTTP response streaming, and DailyMed direct XML parsing
- prevent redirect-based SSRF in official fetches and localhost Local AI requests
- constrain Firestore shared catalog writes with per-table schemas and row-id binding
- reject unsafe Local AI copy replacement and close localization fallback, negation, zero-width, and arbitrary policy-value bypasses
- harden source-drift checks and privileged Firebase operator tooling

## Verification

- `flutter test` (`698/698`)
- `flutter analyze`
- `npm run public:preflight`
- `npm run security:backend` (`15/15`)
- `npm run rules:contract` (`14/14`)
- `npm run copy:compile` (`12/12`)
- `npm run privacy:preflight`
- `npm run localization:lint`
- `npm run source:access`
- `npm run input:quality`
- `npm run catalog:resolve`
- `npm run source:drift`

## Safety Review Note

`npm run contribution:route` intentionally returns blocker review routing because the patch contains:

- Firestore rule changes
- safety-sensitive importer changes
- Local AI denylist phrases such as `adjust your dose` and `safe for you`
- negative tests that exercise unsafe copy

Please apply the suggested `safety-review`, `firebase-rules`, `importer`, `localization`, `security-sensitive`, and `needs-source-review` labels.

## Deferred Follow-Up

- add signed manifest or checksum-manifest attestation for local FDC and DailyMed packages before authoritative promotion
- add explicit direct-call parser caps to internal Ciqual and EMA XML helper APIs before wider reuse
- enforce expiry, cleanup, and revocation workflow for temporary privileged Firebase test-token files
