### PR TITLE
Migrate legacy result-analysis disclaimer copy through the compiler

### DIFF
--- a/lib/core/analysis/interaction_engine.dart
+++ b/lib/core/analysis/interaction_engine.dart
@@ -162,13 +162,19 @@ class InteractionEngine {
     required int score,
     required MealTotals totals,
   }) {
+    // Boundary/result-framing copy sourced through the compiler-validated
+    // registry; the localized i18n string is the locale-strict fallback.
+    const copy = ExplanationCopyService();
+    final analysisBindings = {
+      'drugCount': '${drugs.length}',
+      'score': '$score',
+    };
     final segments = <String>[
-      i18n.tr(
-        'legacy.analysis',
-        {
-          'drugCount': '${drugs.length}',
-          'score': '$score',
-        },
+      copy.resolveForLocale(
+        'legacy_analysis',
+        locale: i18n.languageFamily,
+        bindings: analysisBindings,
+        fallback: i18n.tr('legacy.analysis', analysisBindings),
       ),
       i18n.tr(
         'legacy.analysis_protein',
@@ -179,7 +185,11 @@ class InteractionEngine {
     if (meal.items.any((it) => it.foodTags.contains('high_tyramine'))) {
       segments.add(i18n.tr('legacy.analysis_tyramine'));
     }
-    segments.add(i18n.tr('legacy.analysis_followup'));
+    segments.add(copy.resolveForLocale(
+      'legacy_analysis_followup',
+      locale: i18n.languageFamily,
+      fallback: i18n.tr('legacy.analysis_followup'),
+    ));
     return segments.join(' ');
   }
 }

--- a/lib/domain/usecases/explanation_copy_service.dart
+++ b/lib/domain/usecases/explanation_copy_service.dart
@@ -58,12 +58,18 @@ class ExplanationCopyService {
     String templateId, {
     required String locale,
     required String fallback,
+    Map<String, String> bindings = const {},
   }) {
     final template = _registry.byId(templateId);
     if (template == null || !template.localizedText.containsKey(locale)) {
       return fallback;
     }
-    return resolve(templateId, locale: locale, fallback: fallback);
+    return resolve(
+      templateId,
+      locale: locale,
+      fallback: fallback,
+      bindings: bindings,
+    );
   }
 
   /// Shared not-advice boundary copy (compiler-validated; falls back to the

--- a/lib/domain/usecases/safe_copy_template_registry.dart
+++ b/lib/domain/usecases/safe_copy_template_registry.dart
@@ -132,6 +132,33 @@ class SafeCopyTemplateRegistry {
           notes: 'Legacy "no conflict" educational result; mirrors i18n key '
               '`legacy.no_conflict` (en).',
         ),
+        SafeCopyTemplate(
+          templateId: 'legacy_analysis',
+          outputType: 'boundary',
+          defaultLocale: 'en',
+          localizedText: {
+            'en': 'Built-in rules checked this meal against {drugCount} '
+                'medication(s), producing a heuristic screening score of '
+                '{score}/100.',
+          },
+          requiredPlaceholders: ['drugCount', 'score'],
+          allowedPlaceholders: ['drugCount', 'score'],
+          requiredSafetyTerms: ['built-in rules', 'heuristic'],
+          notes: 'Legacy analysis framing; mirrors i18n key `legacy.analysis` '
+              '(en). Frames the result as a built-in heuristic screen.',
+        ),
+        SafeCopyTemplate(
+          templateId: 'legacy_analysis_followup',
+          outputType: 'boundary',
+          defaultLocale: 'en',
+          localizedText: {
+            'en': 'Treat this as a lightweight screening result and confirm '
+                'exact medication timing when you need more specific guidance.',
+          },
+          requiredSafetyTerms: ['screening result'],
+          notes: 'Legacy analysis follow-up disclaimer; mirrors i18n key '
+              '`legacy.analysis_followup` (en).',
+        ),
       ];
 
   SafeCopyTemplate? byId(String id) {

--- a/test/explanation_copy_compiler_test.dart
+++ b/test/explanation_copy_compiler_test.dart
@@ -208,6 +208,7 @@ void main() {
       registry,
       bindingsByTemplate: const {
         'mechanistic_explanation_boundary': {'overlap_percent': '42'},
+        'legacy_analysis': {'drugCount': '1', 'score': '42'},
       },
       contextByTemplate: {
         for (final t in registry.templates)
@@ -228,6 +229,7 @@ void main() {
           registry,
           bindingsByTemplate: const {
             'mechanistic_explanation_boundary': {'overlap_percent': '42'},
+            'legacy_analysis': {'drugCount': '1', 'score': '42'},
           },
           contextByTemplate: {
             for (final t in registry.templates)
@@ -254,6 +256,7 @@ void main() {
       registry,
       bindingsByTemplate: const {
         'mechanistic_explanation_boundary': {'overlap_percent': '42'},
+        'legacy_analysis': {'drugCount': '1', 'score': '42'},
       },
       contextByTemplate: {
         for (final t in registry.templates)

--- a/tool/run_explanation_copy_compile.dart
+++ b/tool/run_explanation_copy_compile.dart
@@ -22,6 +22,7 @@ void main() {
   // Deterministic sample bindings (only where a template declares placeholders).
   const bindings = <String, Map<String, String>>{
     'mechanistic_explanation_boundary': {'overlap_percent': '42'},
+    'legacy_analysis': {'drugCount': '1', 'score': '42'},
   };
 
   // Every template is compiled with a sample context that supplies the


### PR DESCRIPTION
Continues the P6 copy migration to **result/analysis disclaimer copy outside onboarding** — the legacy rule-engine's analysis framing line and its screening-result follow-up disclaimer — using the same locale-strict, compiler-validated, one-template-plus-fallback pattern.

> No medical advice added, deterministic, not wired into scoring. en output is byte-identical; zh/fr/ja keep their existing translations.

## What's included

- **`ExplanationCopyService.resolveForLocale` gains an optional `bindings` map** — so placeholder-bearing boundary strings can be migrated too (bindings flow through to the compiler; the localized `tr()` value stays the locale-strict fallback).
- **Registry (+2 templates, now 11; all compile clean)**:
  - `legacy_analysis` — mirrors `legacy.analysis` (en); placeholders `drugCount`/`score`; requires the `built-in rules` + `heuristic` framing terms.
  - `legacy_analysis_followup` — mirrors `legacy.analysis_followup` (en); requires the `screening result` term.
- **Consumer** (`lib/core/analysis/interaction_engine.dart`, `_buildLegacyAnalysisText`): the analysis framing line and the follow-up disclaimer now resolve through `ExplanationCopyService.resolveForLocale` (en → compiler-validated, byte-identical; zh/fr/ja → existing translation via `tr()` fallback).
- **CLI + tests**: `tool/run_explanation_copy_compile.dart` and the compiler test add sample `legacy_analysis` bindings so `copy:compile` and the "registry compiles cleanly" test stay green.

## Verification

- `dart format` clean; `flutter analyze` — No issues found.
- `flutter test --concurrency=1` — **677 passed**.
- `public:preflight` 0 BLOCKER; `privacy:preflight` pass; firestore 13/13; `copy:compile` 11/11 (0 blocker); `localization:lint` pass; `contribution:route` pass.

## Scope / constraints

No change to the mechanistic engine, importers, scoring algorithm, Firebase rules, or existing public/privacy preflight behavior. One analysis/UI-copy source file changed (boundary/result-framing copy source only). Targets `peripheral-algorithm-integration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)