### PR TITLE
Migrate remaining legacy rule-finding lines through the copy compiler

### DIFF
--- a/lib/core/analysis/interaction_engine.dart
+++ b/lib/core/analysis/interaction_engine.dart
@@ -20,6 +20,11 @@ class InteractionEngine {
     String localeTag = 'en-US',
   }) {
     final i18n = AppI18n.fromLocaleTag(localeTag);
+    // Rule-finding/summary copy sourced through the compiler-validated registry;
+    // the localized i18n string is the locale-strict fallback (non-en users keep
+    // their translation). en output is byte-identical to app_i18n.
+    const copy = ExplanationCopyService();
+    final locale = i18n.languageFamily;
     final issues = <InteractionIssue>[];
     var score = 0;
 
@@ -36,14 +41,24 @@ class InteractionEngine {
           issues.add(
             InteractionIssue(
               severity: InteractionSeverity.high,
-              title: i18n.tr('legacy.high_protein_strong'),
-              detail: i18n.tr(
-                'legacy.high_protein_strong_detail',
-                {
+              title: copy.resolveForLocale(
+                'legacy_high_protein_strong',
+                locale: locale,
+                fallback: i18n.tr('legacy.high_protein_strong'),
+              ),
+              detail: () {
+                final bindings = {
                   'protein': totals.totalProteinG.toStringAsFixed(1),
                   'drug': localizedDrugName,
-                },
-              ),
+                };
+                return copy.resolveForLocale(
+                  'legacy_high_protein_strong_detail',
+                  locale: locale,
+                  bindings: bindings,
+                  fallback:
+                      i18n.tr('legacy.high_protein_strong_detail', bindings),
+                );
+              }(),
               relatedDrugId: d.id,
             ),
           );
@@ -53,14 +68,23 @@ class InteractionEngine {
           issues.add(
             InteractionIssue(
               severity: InteractionSeverity.moderate,
-              title: i18n.tr('legacy.high_protein'),
-              detail: i18n.tr(
-                'legacy.high_protein_detail',
-                {
+              title: copy.resolveForLocale(
+                'legacy_high_protein',
+                locale: locale,
+                fallback: i18n.tr('legacy.high_protein'),
+              ),
+              detail: () {
+                final bindings = {
                   'protein': totals.totalProteinG.toStringAsFixed(1),
                   'drug': localizedDrugName,
-                },
-              ),
+                };
+                return copy.resolveForLocale(
+                  'legacy_high_protein_detail',
+                  locale: locale,
+                  bindings: bindings,
+                  fallback: i18n.tr('legacy.high_protein_detail', bindings),
+                );
+              }(),
               relatedDrugId: d.id,
             ),
           );
@@ -76,11 +100,20 @@ class InteractionEngine {
           issues.add(
             InteractionIssue(
               severity: InteractionSeverity.high,
-              title: i18n.tr('legacy.tyramine'),
-              detail: i18n.tr(
-                'legacy.tyramine_detail',
-                {'drug': localizedDrugName},
+              title: copy.resolveForLocale(
+                'legacy_tyramine',
+                locale: locale,
+                fallback: i18n.tr('legacy.tyramine'),
               ),
+              detail: () {
+                final bindings = {'drug': localizedDrugName};
+                return copy.resolveForLocale(
+                  'legacy_tyramine_detail',
+                  locale: locale,
+                  bindings: bindings,
+                  fallback: i18n.tr('legacy.tyramine_detail', bindings),
+                );
+              }(),
               relatedDrugId: d.id,
             ),
           );
@@ -96,8 +129,16 @@ class InteractionEngine {
           issues.add(
             InteractionIssue(
               severity: InteractionSeverity.low,
-              title: i18n.tr('legacy.mineral'),
-              detail: i18n.tr('legacy.mineral_detail'),
+              title: copy.resolveForLocale(
+                'legacy_mineral',
+                locale: locale,
+                fallback: i18n.tr('legacy.mineral'),
+              ),
+              detail: copy.resolveForLocale(
+                'legacy_mineral_detail',
+                locale: locale,
+                fallback: i18n.tr('legacy.mineral_detail'),
+              ),
               relatedDrugId: d.id,
             ),
           );
@@ -111,9 +152,9 @@ class InteractionEngine {
         // Boundary copy sourced through the compiler-validated registry; the
         // localized i18n string is the fallback (locale-strict — non-en users
         // keep their translation).
-        message: const ExplanationCopyService().resolveForLocale(
+        message: copy.resolveForLocale(
           'legacy_no_conflict',
-          locale: i18n.languageFamily,
+          locale: locale,
           fallback: i18n.tr('legacy.no_conflict'),
         ),
         mealId: meal.id,
@@ -131,14 +172,19 @@ class InteractionEngine {
     return InteractionResult(
       mealId: meal.id,
       status: InteractionStatus.warning,
-      summary: i18n.tr(
-        'legacy.summary',
-        {
+      summary: () {
+        final bindings = {
           'score': '$boundedScore',
           'severity': severityLabel,
           'count': '${issues.length}',
-        },
-      ),
+        };
+        return copy.resolveForLocale(
+          'legacy_summary',
+          locale: locale,
+          bindings: bindings,
+          fallback: i18n.tr('legacy.summary', bindings),
+        );
+      }(),
       analysisText: _buildLegacyAnalysisText(
         i18n: i18n,
         meal: meal,
@@ -165,29 +211,39 @@ class InteractionEngine {
     // Boundary/result-framing copy sourced through the compiler-validated
     // registry; the localized i18n string is the locale-strict fallback.
     const copy = ExplanationCopyService();
+    final locale = i18n.languageFamily;
     final analysisBindings = {
       'drugCount': '${drugs.length}',
       'score': '$score',
     };
+    final proteinBindings = {
+      'protein': totals.totalProteinG.toStringAsFixed(1),
+    };
     final segments = <String>[
       copy.resolveForLocale(
         'legacy_analysis',
-        locale: i18n.languageFamily,
+        locale: locale,
         bindings: analysisBindings,
         fallback: i18n.tr('legacy.analysis', analysisBindings),
       ),
-      i18n.tr(
-        'legacy.analysis_protein',
-        {'protein': totals.totalProteinG.toStringAsFixed(1)},
+      copy.resolveForLocale(
+        'legacy_analysis_protein',
+        locale: locale,
+        bindings: proteinBindings,
+        fallback: i18n.tr('legacy.analysis_protein', proteinBindings),
       ),
     ];
 
     if (meal.items.any((it) => it.foodTags.contains('high_tyramine'))) {
-      segments.add(i18n.tr('legacy.analysis_tyramine'));
+      segments.add(copy.resolveForLocale(
+        'legacy_analysis_tyramine',
+        locale: locale,
+        fallback: i18n.tr('legacy.analysis_tyramine'),
+      ));
     }
     segments.add(copy.resolveForLocale(
       'legacy_analysis_followup',
-      locale: i18n.languageFamily,
+      locale: locale,
       fallback: i18n.tr('legacy.analysis_followup'),
     ));
     return segments.join(' ');

--- a/lib/domain/usecases/safe_copy_template_registry.dart
+++ b/lib/domain/usecases/safe_copy_template_registry.dart
@@ -192,6 +192,154 @@ class SafeCopyTemplateRegistry {
           notes: 'Legacy analysis follow-up disclaimer; mirrors i18n key '
               '`legacy.analysis_followup` (en).',
         ),
+        // --- Migrated legacy rule-finding lines (informational outputs) -------
+        // These are the rule engine's finding/summary lines (not safety-boundary
+        // disclaimers), so outputType is `informational` with no required safety
+        // terms; placeholder + banned-phrase validation still applies. en text
+        // mirrors app_i18n byte-identical (locale-strict; non-en keeps tr()).
+        // Excluded by design: `legacy.severity.{high,moderate,low}` (one/two-word
+        // enum labels — no governance value).
+        SafeCopyTemplate(
+          templateId: 'legacy_high_protein_strong',
+          outputType: 'informational',
+          defaultLocale: 'en',
+          localizedText: {
+            'en': 'High protein timing may strongly affect levodopa absorption',
+          },
+          requiredSafetyTerms: [],
+          notes: 'Legacy rule finding title; mirrors i18n key '
+              '`legacy.high_protein_strong` (en).',
+        ),
+        SafeCopyTemplate(
+          templateId: 'legacy_high_protein_strong_detail',
+          outputType: 'informational',
+          defaultLocale: 'en',
+          localizedText: {
+            'en': 'This meal contains about {protein} g of protein, which is '
+                'in a higher-risk range. Taking it close to {drug} may compete '
+                'more strongly for absorption.',
+          },
+          requiredPlaceholders: ['protein', 'drug'],
+          allowedPlaceholders: ['protein', 'drug'],
+          requiredSafetyTerms: [],
+          notes: 'Legacy rule finding detail; mirrors i18n key '
+              '`legacy.high_protein_strong_detail` (en).',
+        ),
+        SafeCopyTemplate(
+          templateId: 'legacy_high_protein',
+          outputType: 'informational',
+          defaultLocale: 'en',
+          localizedText: {
+            'en': 'Protein may affect medication absorption',
+          },
+          requiredSafetyTerms: [],
+          notes: 'Legacy rule finding title; mirrors i18n key '
+              '`legacy.high_protein` (en).',
+        ),
+        SafeCopyTemplate(
+          templateId: 'legacy_high_protein_detail',
+          outputType: 'informational',
+          defaultLocale: 'en',
+          localizedText: {
+            'en': 'This meal contains about {protein} g of protein and may '
+                'compete with {drug} during absorption. Consider scheduling '
+                'higher-protein meals away from dosing time.',
+          },
+          requiredPlaceholders: ['protein', 'drug'],
+          allowedPlaceholders: ['protein', 'drug'],
+          requiredSafetyTerms: [],
+          notes: 'Legacy rule finding detail; mirrors i18n key '
+              '`legacy.high_protein_detail` (en).',
+        ),
+        SafeCopyTemplate(
+          templateId: 'legacy_tyramine',
+          outputType: 'informational',
+          defaultLocale: 'en',
+          localizedText: {
+            'en': 'Possible high-tyramine food risk',
+          },
+          requiredSafetyTerms: [],
+          notes: 'Legacy rule finding title; mirrors i18n key '
+              '`legacy.tyramine` (en).',
+        ),
+        SafeCopyTemplate(
+          templateId: 'legacy_tyramine_detail',
+          outputType: 'informational',
+          defaultLocale: 'en',
+          localizedText: {
+            'en': 'This meal includes foods marked as high tyramine. Combined '
+                'with {drug}, it may increase adverse-effect risk.',
+          },
+          requiredPlaceholders: ['drug'],
+          allowedPlaceholders: ['drug'],
+          requiredSafetyTerms: [],
+          notes: 'Legacy rule finding detail; mirrors i18n key '
+              '`legacy.tyramine_detail` (en).',
+        ),
+        SafeCopyTemplate(
+          templateId: 'legacy_mineral',
+          outputType: 'informational',
+          defaultLocale: 'en',
+          localizedText: {
+            'en': 'Meal timing note for mineral supplements',
+          },
+          requiredSafetyTerms: [],
+          notes: 'Legacy rule finding title; mirrors i18n key '
+              '`legacy.mineral` (en).',
+        ),
+        SafeCopyTemplate(
+          templateId: 'legacy_mineral_detail',
+          outputType: 'informational',
+          defaultLocale: 'en',
+          localizedText: {
+            'en': 'This meal includes dairy and may suggest higher calcium '
+                'content. Some mineral supplements can have different '
+                'absorption or GI tolerance when taken with food.',
+          },
+          requiredSafetyTerms: [],
+          notes: 'Legacy rule finding detail; mirrors i18n key '
+              '`legacy.mineral_detail` (en).',
+        ),
+        SafeCopyTemplate(
+          templateId: 'legacy_summary',
+          outputType: 'informational',
+          defaultLocale: 'en',
+          localizedText: {
+            'en': 'Overall score {score}/100 ({severity}), with {count} '
+                'possible food-drug or nutrition-related alerts.',
+          },
+          requiredPlaceholders: ['score', 'severity', 'count'],
+          allowedPlaceholders: ['score', 'severity', 'count'],
+          requiredSafetyTerms: [],
+          notes: 'Legacy result summary line; mirrors i18n key '
+              '`legacy.summary` (en).',
+        ),
+        SafeCopyTemplate(
+          templateId: 'legacy_analysis_protein',
+          outputType: 'informational',
+          defaultLocale: 'en',
+          localizedText: {
+            'en': 'The current meal estimate contains about {protein} g of '
+                'protein.',
+          },
+          requiredPlaceholders: ['protein'],
+          allowedPlaceholders: ['protein'],
+          requiredSafetyTerms: [],
+          notes: 'Legacy analysis protein segment; mirrors i18n key '
+              '`legacy.analysis_protein` (en).',
+        ),
+        SafeCopyTemplate(
+          templateId: 'legacy_analysis_tyramine',
+          outputType: 'informational',
+          defaultLocale: 'en',
+          localizedText: {
+            'en': 'This meal also contains foods tagged as higher tyramine '
+                'risk in the built-in catalog.',
+          },
+          requiredSafetyTerms: [],
+          notes: 'Legacy analysis tyramine segment; mirrors i18n key '
+              '`legacy.analysis_tyramine` (en).',
+        ),
       ];
 
   SafeCopyTemplate? byId(String id) {

--- a/test/explanation_copy_compiler_test.dart
+++ b/test/explanation_copy_compiler_test.dart
@@ -209,6 +209,14 @@ void main() {
       bindingsByTemplate: const {
         'mechanistic_explanation_boundary': {'overlap_percent': '42'},
         'legacy_analysis': {'drugCount': '1', 'score': '42'},
+        'legacy_high_protein_strong_detail': {
+          'protein': '40.0',
+          'drug': 'Sample'
+        },
+        'legacy_high_protein_detail': {'protein': '25.0', 'drug': 'Sample'},
+        'legacy_tyramine_detail': {'drug': 'Sample'},
+        'legacy_summary': {'score': '42', 'severity': 'Moderate', 'count': '2'},
+        'legacy_analysis_protein': {'protein': '25.0'},
       },
       contextByTemplate: {
         for (final t in registry.templates)
@@ -230,6 +238,18 @@ void main() {
           bindingsByTemplate: const {
             'mechanistic_explanation_boundary': {'overlap_percent': '42'},
             'legacy_analysis': {'drugCount': '1', 'score': '42'},
+            'legacy_high_protein_strong_detail': {
+              'protein': '40.0',
+              'drug': 'Sample'
+            },
+            'legacy_high_protein_detail': {'protein': '25.0', 'drug': 'Sample'},
+            'legacy_tyramine_detail': {'drug': 'Sample'},
+            'legacy_summary': {
+              'score': '42',
+              'severity': 'Moderate',
+              'count': '2'
+            },
+            'legacy_analysis_protein': {'protein': '25.0'},
           },
           contextByTemplate: {
             for (final t in registry.templates)
@@ -257,6 +277,14 @@ void main() {
       bindingsByTemplate: const {
         'mechanistic_explanation_boundary': {'overlap_percent': '42'},
         'legacy_analysis': {'drugCount': '1', 'score': '42'},
+        'legacy_high_protein_strong_detail': {
+          'protein': '40.0',
+          'drug': 'Sample'
+        },
+        'legacy_high_protein_detail': {'protein': '25.0', 'drug': 'Sample'},
+        'legacy_tyramine_detail': {'drug': 'Sample'},
+        'legacy_summary': {'score': '42', 'severity': 'Moderate', 'count': '2'},
+        'legacy_analysis_protein': {'protein': '25.0'},
       },
       contextByTemplate: {
         for (final t in registry.templates)

--- a/test/explanation_copy_service_test.dart
+++ b/test/explanation_copy_service_test.dart
@@ -92,4 +92,30 @@ void main() {
       'FB',
     );
   });
+
+  // 10 — a placeholder-bearing legacy finding resolves to compiled en text with
+  // its bindings substituted (rule-finding/informational migration).
+  test('resolveForLocale renders bindings for a legacy finding (en)', () {
+    final text = service.resolveForLocale(
+      'legacy_high_protein_strong_detail',
+      locale: 'en',
+      bindings: const {'protein': '40.0', 'drug': 'Levodopa'},
+      fallback: 'FALLBACK',
+    );
+    expect(text, isNot('FALLBACK'));
+    expect(text, contains('40.0'));
+    expect(text, contains('Levodopa'));
+  });
+
+  // 11 — a non-en locale keeps the localized fallback for a legacy finding
+  // (locale-strict; no English substitution).
+  test('resolveForLocale keeps localized fallback for a legacy finding', () {
+    const localized = '可能存在高酪胺食物风险';
+    final text = service.resolveForLocale(
+      'legacy_tyramine',
+      locale: 'zh',
+      fallback: localized,
+    );
+    expect(text, localized);
+  });
 }

--- a/tool/run_explanation_copy_compile.dart
+++ b/tool/run_explanation_copy_compile.dart
@@ -23,6 +23,11 @@ void main() {
   const bindings = <String, Map<String, String>>{
     'mechanistic_explanation_boundary': {'overlap_percent': '42'},
     'legacy_analysis': {'drugCount': '1', 'score': '42'},
+    'legacy_high_protein_strong_detail': {'protein': '40.0', 'drug': 'Sample'},
+    'legacy_high_protein_detail': {'protein': '25.0', 'drug': 'Sample'},
+    'legacy_tyramine_detail': {'drug': 'Sample'},
+    'legacy_summary': {'score': '42', 'severity': 'Moderate', 'count': '2'},
+    'legacy_analysis_protein': {'protein': '25.0'},
   };
 
   // Every template is compiled with a sample context that supplies the


### PR DESCRIPTION
## Summary

Completes the P6 copy-migration for the rule engine's result surface: the
remaining `legacy.*` finding/summary lines are now sourced through the
compiler-validated `SafeCopyTemplateRegistry` / `ExplanationCopyService` instead
of raw `i18n.tr(...)` calls.

These lines are **rule findings / informational outputs** (e.g. "Protein may
affect medication absorption"), not safety-boundary disclaimers — so they use a
new `informational` output type with **no** required safety terms, but keep full
placeholder + banned-phrase validation. Migration is **locale-strict and
byte-identical**: en output is unchanged (template `en` text mirrors `app_i18n`
exactly), and non-en users keep their existing translations via the `tr()`
fallback. No medical meaning changes; nothing is wired into scoring.

## Changes

- **`safe_copy_template_registry.dart`** — add 11 `informational` templates:
  `legacy_high_protein_strong`(+`_detail`), `legacy_high_protein`(+`_detail`),
  `legacy_tyramine`(+`_detail`), `legacy_mineral`(+`_detail`), `legacy_summary`,
  `legacy_analysis_protein`, `legacy_analysis_tyramine`. Registry now 25
  templates, all compiling 0-blocker. Trivial enum labels
  (`legacy.severity.{high,moderate,low}`) are intentionally excluded — they carry
  no governance value.
- **`interaction_engine.dart`** — route every remaining `legacy.*` consumer call
  site through `resolveForLocale(..., bindings, fallback: i18n.tr(key, params))`.
- **`tool/run_explanation_copy_compile.dart`** + **`explanation_copy_compiler_test.dart`**
  — add deterministic sample bindings for the 5 placeholder-bearing templates
  (the gotcha that previously broke "registry compiles cleanly").
- **`explanation_copy_service_test.dart`** — placeholder legacy finding renders
  bindings (en); non-en locale keeps the localized fallback.

## Safety

Educational prototype only. Deterministic; not wired into scoring; no medical
advice / dose / timing / diet instruction added; no clinical-calibration claim;
no PHI.

## Verification

- `dart format` clean, `flutter analyze` no issues
- `flutter test --concurrency=1` → 679 passed
- `copy:compile` → 25/25 templates, 0 blocker
- `public:preflight` 0 BLOCKER, `privacy:preflight` pass
- `firestore_rules_contract_check` 13/13
- `localization:lint` pass
- `mechanistic_replay` 41/41

🤖 Generated with [Claude Code](https://claude.com/claude-code)