### PR TITLE
docs: map rule explanation to evidence fields and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 [![CI](https://github.com/albertzhzhou-droid/ParkinSUM/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/albertzhzhou-droid/ParkinSUM/actions/workflows/ci.yml)
 
+A provenance-first Parkinson medication-food interaction prototype for explainable CDSS architecture, Firebase governance, and synthetic-data demos.
+
+**Educational architecture prototype only. Not medical advice or a clinical decision tool.**
+
+![Flutter](https://img.shields.io/badge/Flutter-Prototype-blue)
+![Firebase](https://img.shields.io/badge/Firebase-Governance-orange)
+![Educational Prototype](https://img.shields.io/badge/Scope-Educational%20Prototype-lightgrey)
+![Synthetic Data Only](https://img.shields.io/badge/Data-Synthetic%20Only-green)
+![Public Showcase](https://img.shields.io/badge/Mode-Public%20Showcase-purple)
+
+ParkinSUM Companion is a local-first Flutter prototype that demonstrates how a health-adjacent app can combine synthetic meal logging, medication context, deterministic rule checks, evidence-oriented explanations, and release safety guardrails without making clinical claims.
+
 ParkinSUM Companion is a local-first Flutter prototype for Parkinson's disease diet-medication education, combining meal logging, medication context, deterministic food-drug interaction rules, and evidence-oriented explanations without sending sensitive data to the cloud.
 
 It is a production-architecture prototype designed for educational demonstrations, software architecture review, and academic discussion of local-first digital health prototypes. It is not a medical device and must not be used for diagnosis, treatment, medication timing, dietary guidance, clinical decision-making, patient care, or emergency support.
@@ -220,6 +232,20 @@ Capture requirements are tracked in [docs/media-capture-checklist.md](docs/media
 
 ## Quick Start
 
+## High-Impact Contribution Request
+
+The current priority is [Issue #8](https://github.com/albertzhzhou-droid/ParkinSUM/issues/8): mapping one educational rule explanation to explicit evidence fields.
+
+The most valuable contribution right now is not adding new medical rules. Instead, contributors should help make existing rule explanations more traceable and reviewable by improving:
+
+- source references
+- provenance clarity
+- limitation text
+- safety-boundary wording
+- negative tests that prevent unsupported clinical claims
+
+See [docs/RULE_ENGINE.md](docs/RULE_ENGINE.md) for the contributor-facing rule explanation template and worked example.
+
 Install Flutter, Node.js, and npm first. Then run these commands from the repository root:
 
 ```sh
@@ -353,49 +379,28 @@ If you discuss the project academically, include the safety boundary: educationa
 
 ## Documentation
 
+### Start here
 - [Documentation index](docs/README.md)
-- [Evidence & traceability demo guide](docs/EVIDENCE_AND_TRACEABILITY_DEMO_GUIDE.md)
-- [Capability matrix](docs/CAPABILITY_MATRIX.md)
 - [Public verification guide](docs/PUBLIC_VERIFICATION.md)
-- [Evidence trace bundle](docs/EVIDENCE_TRACE_BUNDLE.md)
-- [Source-quality perturbation report](docs/SOURCE_QUALITY_PERTURBATION_REPORT.md)
+- [Contribution guide](CONTRIBUTING.md)
+- [Rule engine overview](docs/RULE_ENGINE.md)
+
+### Architecture
+- [Architecture overview](docs/ARCHITECTURE.md)
 - [Conflict engine model](docs/CONFLICT_ENGINE_MODEL.md)
 - [Importer & metadata flow](docs/IMPORTER_METADATA_FLOW.md)
-- [Replay runner](docs/REPLAY_RUNNER.md)
-- [Biomedical standards conformance scorecard](docs/BIOMEDICAL_STANDARDS_CONFORMANCE_SCORECARD.md)
-- [Source access & licenses](docs/SOURCE_ACCESS_AND_LICENSES.md)
-- [Manual validation](docs/MANUAL_VALIDATION.md)
+- [Evidence trace bundle](docs/EVIDENCE_TRACE_BUNDLE.md)
+
+### Safety and release
 - [Disclaimer](DISCLAIMER.md)
-- [Security policy](SECURITY.md)
-- [Roadmap](ROADMAP.md)
-- [Contribution guide](CONTRIBUTING.md)
-- [Contribution backlog](docs/contribution-backlog.md)
-- [Secondary creator token flow](docs/secondary-creator-token-flow.md)
-- [Mentor/classmate PR request](docs/mentor-pr-request.md)
-- [Changelog](CHANGELOG.md)
-- [Citation metadata](CITATION.cff)
-- [Repository metadata recommendations](docs/repository-metadata.md)
-- [Social preview brief](docs/media/social-preview.md)
-- [Rule engine testing](docs/rule-engine-testing.md)
-- [Impact one-page summary](docs/impact/one-page-summary.md)
-- [Impact technical case study](docs/impact/technical-case-study.md)
-- [Impact project pitch](docs/impact/project-pitch.md)
-- [Impact FAQ](docs/impact/faq.md)
-- [Impact safety and ethics](docs/impact/safety-and-ethics.md)
-- [v0.1.0-alpha release notes](docs/release/v0.1.0-alpha-notes.md)
-- [Synthetic demo data](docs/release/synthetic-demo-data.md)
-- [Synthetic demo scenarios](docs/demo-scenarios.md)
-- [Release checklist](docs/release/release-checklist.md)
-- [Project website](docs/site/index.html)
-- [GitHub Pages setup](docs/site/README.md)
-- [Public showcase readiness](PUBLIC_SHOWCASE_READINESS.md)
 - [Public demo boundary](docs/PUBLIC_DEMO_BOUNDARY.md)
-- [Architecture overview](docs/ARCHITECTURE.md)
-- [Rule engine overview](docs/RULE_ENGINE.md)
-- [Media capture checklist](docs/media-capture-checklist.md)
-- [Release evidence index](docs/RELEASE_EVIDENCE_INDEX.md)
+- [Release checklist](docs/release/release-checklist.md)
 - [Known risks](docs/known_risks.md)
 
+### Demo and impact
+- [Synthetic demo scenarios](docs/demo-scenarios.md)
+- [Media capture checklist](docs/media-capture-checklist.md)
+- [Impact one-page summary](docs/impact/one-page-summary.md)
 ## Contributing
 
 Contributions are welcome when they keep the public prototype boundary intact. Good first areas include documentation, UI strings, accessibility notes, synthetic sample interactions, and focused tests. Start with [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/docs/RULE_ENGINE.md
+++ b/docs/RULE_ENGINE.md
@@ -172,7 +172,7 @@ phrase ever appears in any copy field.
 
 | Field | Value |
 | --- | --- |
-| `ruleId` | `levodopa_protein_temporal_v1` |
+| `ruleId` | `pd.ldopa.protein.window.v1` |
 | `triggeredConditions` | `drug.active_ingredients contains levodopa`, `meal.protein_band == moderate`, `timing.meal_to_drug within 0-60 min` |
 | `inputFieldsUsed` | `drug.active_ingredients`, `drug.release_type`, `meal.protein_g`, `timestamps.drug_time`, `timestamps.meal_time` |
 | `sourceRefs` | `synthetic:demo_label_carbidopa_levodopa#food_effect` |

--- a/lib/domain/usecases/runtime_rule_engine.dart
+++ b/lib/domain/usecases/runtime_rule_engine.dart
@@ -121,6 +121,26 @@ class RuntimeRuleEngine {
             evidence: {
               'jurisdiction_chain': jurisdictionChain,
               'source_refs': rule.provenance.sourceRefs,
+
+              // 扩展evidence字段，提供更多上下文信息以帮助审查和解释。这个字段不影响规则匹配或优先级排序，但可以在审查过程中提供有价值的线索。
+
+              // Runtime fields inspected by this rule, used to connect the trigger condition
+              // to the explanation and evidence boundary.
+              'input_fields_used':
+                  _collectConditionPaths(rule.conditions).toList()..sort(),
+
+              // Limitation copy prevents this deterministic match from being interpreted
+              // as individualized diagnosis, treatment, medication timing, or diet advice.
+              'limitation_text':
+                  'This rule is an educational prototype explanation only and does not infer individual pharmacokinetics, diagnosis, treatment, medication timing, or diet decisions.',
+
+              // Safety copy keeps the output inside an educational awareness boundary.
+              'safety_boundary':
+                  'Do not change medication, diet, or timing based on this app. Consult a qualified healthcare professional for personal medical guidance.',
+
+              // Short reusable disclaimer for UI, tests, and trace artifacts.
+              'not_advice_text':
+                  'Educational architecture prototype only. Not medical advice or a clinical decision tool.',
             },
           ),
         );
@@ -268,6 +288,84 @@ class RuntimeRuleEngine {
           : _compare(normalizedValue, threshold, op);
     }
     return false;
+  }
+
+  /// This helper is for collecting runtime-context paths referenced by a rule condition tree.
+
+  /// This is used for explanation traceability only. It does not affect rule
+  /// matching or priority. The collected paths help reviewers see which
+  /// synthetic input fields were used to trigger a rule explanation.
+  Set<String> _collectConditionPaths(Map<String, dynamic> node) {
+    final paths = <String>{};
+
+    void visit(Map<String, dynamic> current) {
+      // `all` means every child condition must match. For traceability, collect paths
+      //from every child because each one contributes to the rule trigger.
+      if (current.containsKey('all')) {
+        for (final child in current['all'] as List<dynamic>) {
+          visit(Map<String, dynamic>.from(child as Map));
+        }
+      }
+
+      // `any` means at least one child condition can match. We still collect all
+      // declared paths so the evidence payload shows the full set of inputs that
+      // this rule may inspect.
+      if (current.containsKey('any')) {
+        for (final child in current['any'] as List<dynamic>) {
+          visit(Map<String, dynamic>.from(child as Map));
+        }
+      }
+
+      // `not` wraps another condition. The nested condition still reads runtime
+      // input, so its paths should be included in the trace.
+      if (current.containsKey('not')) {
+        visit(Map<String, dynamic>.from(current['not'] as Map));
+      }
+
+      // Comparison nodes read one runtime path, such as `meal.total_protein_g`.
+      if (current.containsKey('cmp')) {
+        final cmp = Map<String, dynamic>.from(current['cmp'] as Map);
+        final path = cmp['path'];
+        if (path is String) paths.add(path);
+      }
+
+      // Membership nodes read one runtime path and compare it against allowed
+      // values, such as checking whether `drug.substance_tags` contains `levodopa`.
+      if (current.containsKey('in')) {
+        final config = Map<String, dynamic>.from(current['in'] as Map);
+        final path = config['path'];
+        if (path is String) paths.add(path);
+      }
+
+      // Exists nodes only check whether a runtime field is present, but the
+      // field is still part of the trigger explanation.
+      if (current.containsKey('exists')) {
+        final config = Map<String, dynamic>.from(current['exists'] as Map);
+        final path = config['path'];
+        if (path is String) paths.add(path);
+      }
+
+      // Between nodes compare two runtime time fields. Both sides are collected
+      // so the explanation can show the timing inputs used by the rule.
+      if (current.containsKey('between')) {
+        final config = Map<String, dynamic>.from(current['between'] as Map);
+        final leftPath = config['left_path'];
+        final rightPath = config['right_path'];
+        if (leftPath is String) paths.add(leftPath);
+        if (rightPath is String) paths.add(rightPath);
+      }
+
+      // Dose-band nodes read a dose field but do not infer missing units or
+      // clinical meaning. This only records which field was inspected.
+      if (current.containsKey('dose_band')) {
+        final config = Map<String, dynamic>.from(current['dose_band'] as Map);
+        final path = config['path'];
+        if (path is String) paths.add(path);
+      }
+    }
+
+    visit(node);
+    return paths;
   }
 
   bool _compare(dynamic left, dynamic right, String op) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -289,26 +289,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   nested:
     dependency: transitive
     description:
@@ -534,10 +534,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:

--- a/test/runtime_rule_engine_test.dart
+++ b/test/runtime_rule_engine_test.dart
@@ -501,6 +501,79 @@ void main() {
     expect(sameDecisionSorted.first.rule.sourceAuthority,
         greaterThan(sameDecisionSorted.last.rule.sourceAuthority));
   });
+
+  // added test
+  // 验证 levodopa + protein 这个 rule 触发后，返回的 explanation 不是单纯一句提示，不是真实医疗建议，
+  //而是包含清楚的 source、input trace、limitation 和 safety boundary 的教育性解释。
+  test('levodopa protein rule explanation includes evidence boundary fields',
+      () {
+    final context = buildContext(
+      drug: const DrugRuntimeContext(
+        id: 'drug_1',
+        genericName: 'carbidopa/levodopa',
+        brandName: 'Sinemet',
+        activeIngredients: ['carbidopa', 'levodopa'],
+        substanceTags: ['levodopa'],
+        formulation: 'tablet',
+        dosageForm: 'tablet',
+        route: 'oral',
+        releaseType: 'immediate',
+        dailyDoseMg: 300,
+        jurisdiction: 'US',
+      ),
+      meal: const MealRuntimeContext(
+        id: 'meal_1',
+        totalProteinG: 25,
+        tyramineMgEstimate: 1,
+        highFatHighCalorie: false,
+        itemIds: ['food_1'],
+      ),
+      timestamps: TimestampRuntimeContext(
+        drugTime: DateTime.parse('2026-01-01T08:00:00Z'),
+        mealTime: DateTime.parse('2026-01-01T09:00:00Z'),
+        coeventTime: null,
+      ),
+    );
+
+    final matches = engine.evaluateCandidates(context: context, rules: rules);
+    final match = matches.firstWhere(
+      (match) => match.rule.ruleId == 'pd.ldopa.protein.window.v1',
+    );
+
+    final sourceRefs = List<String>.from(match.evidence['source_refs'] as List);
+    final inputFieldsUsed =
+        List<String>.from(match.evidence['input_fields_used'] as List);
+
+    expect(sourceRefs, isNotEmpty);
+    expect(inputFieldsUsed, isNotEmpty);
+
+    final evidenceBoundaryText = [
+      match.explanation,
+      match.evidence['limitation_text'],
+      match.evidence['safety_boundary'],
+      match.evidence['not_advice_text'],
+    ].whereType<String>().join(' ').toLowerCase();
+
+    expect(evidenceBoundaryText, contains('educational'));
+    expect(evidenceBoundaryText, contains('not medical advice'));
+    expect(evidenceBoundaryText, contains('clinical decision tool'));
+    expect(evidenceBoundaryText,
+        contains('consult a qualified healthcare professional'));
+
+    const bannedPhrases = [
+      'take your medication',
+      'change your dose',
+      'avoid protein',
+      'recommended timing',
+      'clinically validated',
+      'diagnose',
+      'treat this condition',
+    ];
+
+    for (final phrase in bannedPhrases) {
+      expect(evidenceBoundaryText, isNot(contains(phrase)));
+    }
+  });
 }
 
 Map<String, dynamic> _testRuleJson({


### PR DESCRIPTION
## Summary

This PR addresses Issue #8 by mapping one educational CDSS-style rule explanation to explicit evidence fields and improving the README as a public open-source showcase.

## What Changed ❓ 
<img width="1206" height="272" alt="image" src="https://github.com/user-attachments/assets/07e365a8-e491-46dc-b860-e5ce82ba31dc" />

- Updated ```docs/RULE_ENGINE.md``` to align the worked example with an existing rule: ```pd.ldopa.protein.window.v1```
- Added evidence-boundary fields to runtime rule output:
  - ```input_fields_used```
  - ```limitation_text```
  - ```safety_boundary```
  - ```not_advice_text```
- Added focused test coverage for the levodopa + protein rule explanation
- Improved ```README``` structure so visitors can more quickly understand the project value, technical architecture, safety boundary, quick start, and contribution path

## Safety boundary 🔢 
This keeps ParkinSUM Companion as an educational architecture prototype only.

It does not add real health data, real medication schedules, patient stories, credentials, Firebase tokens, UIDs, local machine paths, fake screenshots, fake badges, fake metrics, or unsupported clinical claims.

The project remains not medical advice and not a clinical decision tool.

## Verification 🧪 
Attempted:
- [ ] ```flutter analyze```
<img  height="40" alt="image" src="https://github.com/user-attachments/assets/620a4704-edad-400f-89c7-bacd69799b3e" />


- [ ] ```flutter test --concurrency=1```
<img height="34" alt="image" src="https://github.com/user-attachments/assets/b583b5cf-6378-4509-9207-0b6a5ff88464" />

- [ ] ```npm run public:preflight```
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/bc5e5317-62c3-4249-a2c2-7f84005f3a2b" />

- [ ] ```node tool/firestore_rules_contract_check.mjs```
<img width="500"  alt="image" src="https://github.com/user-attachments/assets/417a9ee3-de79-4ddc-bcae-fc627d3aa4bd" />