### PR TITLE
Fix unparseable explanation_copy_service_test (merge artifact)

### DIFF
--- a/test/explanation_copy_service_test.dart
+++ b/test/explanation_copy_service_test.dart
@@ -117,6 +117,10 @@ void main() {
       fallback: localized,
     );
     expect(text, localized);
+  });
+
+  // 12 — a runtime fallback that itself contains a banned prescriptive phrase is
+  // never surfaced; the service degrades to the canonical safety boundary.
   test('unsafe runtime fallback degrades to canonical safety boundary', () {
     expect(
       service.resolveForLocale(


### PR DESCRIPTION
## Summary

CI on `peripheral-algorithm-integration` (run "Peripheral algorithm integration"
#73) failed at the **dart format** step with exit code 65 — the source could not
be parsed:

```
line 131, column 1 of test/explanation_copy_service_test.dart: Expected to find ')'.
```

The recent `main` → `peripheral-algorithm-integration` merge dropped the closing
`});` of the test *"resolveForLocale keeps localized fallback for a legacy
finding"*, so the following test (`unsafe runtime fallback degrades to canonical
safety boundary`) ended up nested inside it and the file no longer parsed.

## Fix

Restore the missing test closure (and add the new test's doc comment). **Test-only
change** — no production code touched. The behavior under test (a runtime
`fallback` containing a banned prescriptive phrase degrades to
`RuleExplanation.defaultSafetyBoundary` via the existing `_validatedFallback`) is
unchanged and now actually runs.

## Verification

- `dart format --output=none --set-exit-if-changed .` → clean (exit 0)
- `flutter analyze` → no issues
- `flutter test --concurrency=1` → **700 passed** (was unparseable before)

## Safety

Educational prototype only; test-only fix; no medical advice / dose / timing /
diet added; no scoring change; no PHI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)