### PR TITLE
Release v0.2.0-beta: version bump + release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ release language must preserve the educational-only safety boundary and must not
 claim clinical validation, medical-device status, treatment guidance, or
 real-world patient-care readiness.
 
+## v0.2.0-beta - 2026-06-02
+
+### Added
+
+- Public beta release package for ParkinSUM Companion, consolidating the
+  peripheral-algorithm integration line (P1–P12) and the compiler-governed copy
+  layer on top of the v0.1.0-alpha showcase.
+- Canonical release notes at `docs/release/v0.2.0-beta-notes.md`.
+- Deterministic, review-only peripheral support algorithms, each with a CLI
+  report and unit tests: input quality gate (P1), catalog resolution engine
+  (P2), source version drift checker (P3), local evidence graph builder (P4),
+  synthetic scenario fuzzer (P5), explanation copy compiler + safe copy template
+  registry (P6), localization safety lint (P7), local privacy preflight (P8),
+  source access contract checker (P9), public demo walkthrough generator (P10),
+  contribution safety router (P11), and release snapshot generator (P12).
+- Runtime copy migration: user-facing boundary/disclaimer and legacy
+  rule-finding copy is now resolved through the compiler-validated
+  `ExplanationCopyService` (locale-strict; English byte-identical to the existing
+  `app_i18n` source; non-English translations preserved via fallback).
+- An i18n parity drift guard that pins every migrated template to its live
+  `app_i18n` source so copy cannot silently diverge.
+- Capability matrix and per-feature documentation for the peripheral layer.
+
+### Changed
+
+- App version metadata bumped to `0.2.0+2`.
+
+### Safety / Not Included
+
+- No change to the deterministic scoring engine, importers, or Firebase rules.
+- No clinical validation, medical-device clearance, regulatory approval, or
+  patient-outcome evidence. The peripheral algorithms are review-only report
+  tooling and are not wired into scoring.
+- Educational synthetic/sample data only; no real patient data, credentials, or
+  production deployment.
+
 ## v0.1.0-alpha - 2026-05-25
 
 ### Added

--- a/docs/release/v0.2.0-beta-notes.md
+++ b/docs/release/v0.2.0-beta-notes.md
@@ -1,0 +1,113 @@
+# ParkinSUM Companion v0.2.0-beta Release Notes
+
+ParkinSUM Companion v0.2.0-beta is a public educational showcase release that
+builds on v0.1.0-alpha by adding a layer of deterministic, review-only
+peripheral support algorithms and a compiler-governed user-facing copy layer.
+
+This release is not a clinical product. It must not be used for diagnosis,
+treatment, medication timing, individualized dietary guidance, patient care, or
+emergency support.
+
+## What This Beta Adds Over the Alpha
+
+- **Peripheral support algorithms (P1–P12)** — twelve deterministic, auditable
+  support modules, each with a command-line report artifact and unit tests:
+  - P1 input quality gate, P2 catalog resolution engine, P3 source version
+    drift checker, P4 local evidence graph builder, P5 synthetic scenario
+    fuzzer, P6 explanation copy compiler + safe copy template registry, P7
+    localization safety lint, P8 local privacy preflight, P9 source access
+    contract checker, P10 public demo walkthrough generator, P11 contribution
+    safety router, P12 release snapshot generator.
+  - These are review-only tooling. They compose existing artifacts, never
+    fabricate data, and are not wired into scoring.
+- **Compiler-governed copy layer** — user-facing boundary/disclaimer copy and
+  the legacy rule-finding lines now resolve through the compiler-validated
+  `ExplanationCopyService`. Resolution is locale-strict: English output is
+  byte-identical to the existing `app_i18n` source, and non-English translations
+  are preserved via fallback. A parity drift guard pins each migrated template to
+  its live i18n source so copy cannot silently diverge.
+- **Documentation** — a capability matrix plus per-feature docs describing each
+  peripheral module's scope, tests, safety boundary, and limitations.
+
+## App Status
+
+- Release tag: `v0.2.0-beta`
+- Flutter package: `parkinsum_companion`
+- App version metadata: `0.2.0+2`
+- Release type: public beta showcase
+- Default public-demo backend: local mode
+- Firebase-backed paths: internal operator validation only
+- Public contact: `parkinsumservice@gmail.com`
+
+This beta is suitable for architecture review, educational demonstration,
+portfolio review, and academic software-engineering discussion. It is not ready
+for real user health-data collection or clinical deployment.
+
+## Safety Boundary
+
+ParkinSUM Companion is educational software only.
+
+- It does not diagnose, treat, monitor, prevent, or manage disease.
+- It does not provide individualized medical, medication, dietary, clinical, or
+  emergency advice.
+- It has no patient-outcome validation.
+- It is not reviewed, cleared, or approved as a medical device.
+- The peripheral algorithms are deterministic report/governance tooling; they do
+  not change the scoring engine and add no medical advice.
+- Public demos must use synthetic or sample data only.
+
+Do not enter real health information, symptoms, medication schedules, patient
+identifiers, Firebase tokens, service-account credentials, private user exports,
+or raw operator audit logs.
+
+## Known Limitations
+
+- Rule coverage and peripheral algorithms are prototype-scoped and should be
+  reviewed as software architecture, not clinical authority.
+- Recommendation and conflict outputs are educational awareness text, not
+  patient-specific guidance.
+- The app has not undergone clinical, legal, privacy, regulatory, security, or
+  accessibility sign-off for public health use.
+- The peripheral report tools are deterministic but pattern-based and
+  conservative; they are not compliance certifications or clinical validation.
+- Firebase-backed flows require project access and are retained for internal
+  operator validation rather than public-demo use.
+- Android release signing is not configured for production distribution.
+
+## How To Run Locally
+
+Install Flutter, Node.js, and npm, then run from the repository root:
+
+```sh
+flutter pub get
+dart format --output=none --set-exit-if-changed .
+flutter analyze
+flutter test
+npm ci
+npm run public:preflight
+npm run privacy:preflight
+npm run copy:compile
+npm run localization:lint
+flutter run -d chrome
+```
+
+## What Is Not Included
+
+- Android signing keys, Play Store deployment, app-store deployment, Firebase
+  deployment, or production release automation.
+- Private keys, `.env` files, service-account files, Firebase admin credentials,
+  production tokens, or operator secrets.
+- Real patient records, real medication schedules, clinical screenshots, raw
+  operator logs, or private Firebase exports.
+- Claims of diagnosis, treatment, clinical validation, privacy certification,
+  legal approval, regulatory clearance, or production patient-care readiness.
+
+## Related Release Files
+
+- `CHANGELOG.md`
+- `docs/release/v0.1.0-alpha-notes.md`
+- `docs/CAPABILITY_MATRIX.md`
+- `docs/release/release-checklist.md`
+- `docs/PUBLIC_DEMO_BOUNDARY.md`
+- `docs/known_risks.md`
+- `docs/RELEASE_EVIDENCE_INDEX.md`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: parkinsum_companion
 description: ParkinSUM Companion (local-first) Flutter app.
 publish_to: "none"
 
-version: 0.1.0+1
+version: 0.2.0+2
 
 environment:
   sdk: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
## Summary

Prepares the **v0.2.0-beta** public educational showcase release on `main`, on
top of v0.1.0-alpha. Docs + version metadata only — no code or scoring change.

- Bump app version metadata to `0.2.0+2` (`pubspec.yaml`).
- Add the `v0.2.0-beta` `CHANGELOG.md` entry (peripheral-algorithm line P1–P12 +
  the compiler-governed copy layer).
- Add canonical release notes at `docs/release/v0.2.0-beta-notes.md`, mirroring
  the alpha notes structure (status, safety boundary, limitations, run steps,
  what-is-not-included).

After merge, a `v0.2.0-beta` tag + GitHub pre-release will be cut from this
commit.

## Safety

Educational prototype only. Docs + version metadata only; no change to the
scoring engine, importers, or Firebase rules; no medical advice; no PHI.

## Verification

- `dart format --output=none --set-exit-if-changed .` → clean
- `flutter analyze` → no issues
- `public:preflight` → 0 BLOCKER
- `privacy:preflight` → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)