### PR TITLE
[codex] Build 30-second demo website

### DIFF
--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -1,7 +1,13 @@
-# ParkinSUM GitHub Pages Site
+# ParkinSUM Demo Website
 
-This folder contains a lightweight static landing page for ParkinSUM Companion.
-It uses plain HTML and CSS only; no build system is required.
+This folder contains a lightweight static demo website for ParkinSUM Companion.
+It is designed to help a reviewer understand the project in about 30 seconds:
+what the app does, what the core flow looks like, how the rule/explanation path
+works, and which demo/release formats are appropriate.
+
+It uses plain HTML and CSS only; no build system is required. The site reuses
+the app logo, wordmark, and redacted real-device screenshots from
+`docs/assets/`.
 
 ## Local Preview
 
@@ -55,6 +61,7 @@ after checking that existing documentation links still work.
   raw operator logs, Firebase tokens, service-account files, or signing keys.
 - Keep all claims conservative: educational prototype, not medical advice, not a
   medical device, and no clinical validation is claimed.
-- Demo media placeholders point to `docs/assets/screenshots/` and
-  `docs/assets/demo/`; add real media only after following
-  `docs/media-capture-checklist.md`.
+- Screenshot media should come from `docs/assets/screenshots/`.
+- Short GIF or video links should be added only after following
+  `docs/media-capture-checklist.md` and verifying that the media renders
+  correctly on GitHub.

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -5,296 +5,250 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="ParkinSUM Companion is an educational Flutter prototype for local-first diet-medication awareness demonstrations using synthetic data."
+      content="ParkinSUM Companion demo site: understand the educational local-first Flutter prototype, demo flows, screenshots, and release options in 30 seconds."
     />
-    <title>ParkinSUM Companion | Educational Prototype</title>
-    <link
-      rel="icon"
-      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%23166146'/%3E%3Ctext x='32' y='40' text-anchor='middle' font-size='24' font-family='Arial' font-weight='700' fill='white'%3EPS%3C/text%3E%3C/svg%3E"
-    />
+    <title>ParkinSUM Companion | 30-Second Demo</title>
+    <link rel="icon" href="../assets/brand/parkinsum-icon.png" />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <header class="site-header">
-      <nav class="nav" aria-label="Main navigation">
-        <a class="brand" href="#home" aria-label="ParkinSUM Companion home">
-          ParkinSUM
-        </a>
-        <div class="nav-links">
-          <a href="#problem">Problem</a>
-          <a href="#features">Features</a>
-          <a href="#architecture">Architecture</a>
-          <a href="#safety">Safety</a>
-          <a href="#demo">Demo</a>
-          <a href="#impact">Impact</a>
-          <a href="#roadmap">Roadmap</a>
-        </div>
+    <header class="topbar">
+      <a class="brand" href="#overview" aria-label="ParkinSUM demo home">
+        <img src="../assets/brand/parkinsum-icon.png" alt="" />
+        <span>ParkinSUM Demo</span>
+      </a>
+      <nav aria-label="Demo sections">
+        <a href="#overview">Overview</a>
+        <a href="#screens">Screens</a>
+        <a href="#try">Try it</a>
+        <a href="#safety">Safety</a>
       </nav>
     </header>
 
     <main>
-      <section class="hero" id="home">
-        <div class="hero-content">
-          <p class="eyebrow">Educational digital-health prototype</p>
-          <h1>ParkinSUM Companion</h1>
-          <p class="hero-copy">
-            A local-first Flutter prototype that demonstrates how meal logging,
-            medication context, deterministic rule checks, and evidence-oriented
-            explanations can support education about Parkinson's disease
-            diet-medication awareness.
+      <section class="hero" id="overview">
+        <div class="hero-copy">
+          <img
+            class="wordmark"
+            src="../assets/brand/parkinsum-wordmark.png"
+            alt="ParkinSUM"
+          />
+          <p class="eyebrow">30-second project demo</p>
+          <h1>
+            A local-first Flutter prototype for educational food-medication
+            interaction awareness.
+          </h1>
+          <p class="lead">
+            ParkinSUM combines synthetic meal logging, medication context,
+            deterministic rule checks, and evidence-oriented explanations so a
+            reviewer can see how the app reaches a conservative educational
+            result.
           </p>
-          <div class="cta-row" aria-label="Primary actions">
-          <a class="button primary" href="https://github.com/albertzhzhou-droid/ParkinSUM">
-            View GitHub repository
-          </a>
-          <a class="button" href="../wiki/">Open showcase wiki</a>
-          <a class="button" href="../../DISCLAIMER.md">Read safety disclaimer</a>
-          <a class="button" href="../../ROADMAP.md">View roadmap</a>
-          <a class="button" href="#demo">View demo</a>
+          <div class="action-row" aria-label="Primary actions">
+            <a class="button primary" href="#screens">See app screens</a>
+            <a class="button" href="#try">Try / release options</a>
+            <a
+              class="button"
+              href="https://github.com/albertzhzhou-droid/ParkinSUM"
+            >
+              GitHub repo
+            </a>
           </div>
-          <p class="boundary-note">
-            Educational prototype only. Synthetic/demo data only. Not medical
-            advice, not a medical device, and no clinical validation is claimed.
+          <p class="boundary">
+            Synthetic/demo data only. Not medical advice, not a medical device,
+            and no clinical validation is claimed.
           </p>
+        </div>
+
+        <div class="hero-stage" aria-label="ParkinSUM app preview">
+          <div class="glass-device">
+            <img
+              src="../assets/screenshots/catalog-showcase.png"
+              alt="Catalog page with ParkinSUM branded showcase module"
+            />
+          </div>
+          <div class="quick-read">
+            <article>
+              <span>01</span>
+              <strong>Log synthetic context</strong>
+              <p>Meals, medication selections, and timeline entries.</p>
+            </article>
+            <article>
+              <span>02</span>
+              <strong>Run deterministic checks</strong>
+              <p>Rules stay inspectable and repeatable.</p>
+            </article>
+            <article>
+              <span>03</span>
+              <strong>Explain the result</strong>
+              <p>Scores, findings, limitations, and next-action text.</p>
+            </article>
+          </div>
         </div>
       </section>
 
-      <section class="section" id="problem">
-        <div class="section-header">
-          <p class="eyebrow">Problem</p>
-          <h2>Health education tools need clear boundaries and explainable behavior.</h2>
+      <section class="strip" aria-label="Core promise">
+        <article>
+          <strong>Local-first</strong>
+          <span>public demos avoid server dependence</span>
+        </article>
+        <article>
+          <strong>Explainable</strong>
+          <span>outputs show rule weights and evidence context</span>
+        </article>
+        <article>
+          <strong>Guardrailed</strong>
+          <span>the repo keeps education separate from clinical use</span>
+        </article>
+      </section>
+
+      <section class="section" id="screens">
+        <div class="section-heading">
+          <p class="eyebrow">Real app flow</p>
+          <h2>Four screens explain the app without reading the code.</h2>
         </div>
-        <div class="split">
-          <p>
-            People learning about Parkinson's disease diet-medication topics may
-            see complex interactions between meals, medication timing, evidence
-            sources, and safety warnings. Public software demos can easily
-            overstate what they prove if they do not separate education from
-            medical advice.
-          </p>
-          <p>
-            ParkinSUM focuses on the software pattern: local-first data flow,
-            deterministic rule checks, source-aware explanations, and visible
-            safety language. The goal is to make the prototype understandable
-            for teachers, mentors, digital-health reviewers, and non-technical
-            visitors without asking them to inspect the code first.
-          </p>
+        <div class="screen-grid">
+          <figure class="screen-card large">
+            <img
+              src="../assets/screenshots/next-meal-setup.png"
+              alt="Next-meal setup screen with time-window controls"
+            />
+            <figcaption>
+              <strong>1. Plan a next-meal window</strong>
+              <span>
+                The user gives the timing window; the app keeps the recommendation
+                path conservative when information is incomplete.
+              </span>
+            </figcaption>
+          </figure>
+          <figure class="screen-card">
+            <img
+              src="../assets/screenshots/next-meal-results.png"
+              alt="Next-meal results with ranked synthetic food candidates"
+            />
+            <figcaption>
+              <strong>2. Rank synthetic food candidates</strong>
+              <span>
+                The prototype surfaces candidate foods, allow labels, and short
+                rationale bullets.
+              </span>
+            </figcaption>
+          </figure>
+          <figure class="screen-card">
+            <img
+              src="../assets/screenshots/conflict-explanation.png"
+              alt="Conflict explanation dialog with rule weights and model trace"
+            />
+            <figcaption>
+              <strong>3. Show the explanation layer</strong>
+              <span>
+                Rule weights, key findings, model trace, and safety boundaries
+                are visible in the result.
+              </span>
+            </figcaption>
+          </figure>
+          <figure class="screen-card">
+            <img
+              src="../assets/screenshots/analytics-local-ai.png"
+              alt="Analytics and local AI configuration screen"
+            />
+            <figcaption>
+              <strong>4. Configure local AI polish</strong>
+              <span>
+                Optional local models can polish wording after deterministic
+                checks have already gated the result.
+              </span>
+            </figcaption>
+          </figure>
         </div>
       </section>
 
-      <section class="section alt" id="features">
-        <div class="section-header">
-          <p class="eyebrow">Prototype features</p>
-          <h2>What the alpha demonstrates</h2>
+      <section class="section workflow" id="workflow">
+        <div class="section-heading">
+          <p class="eyebrow">System shape</p>
+          <h2>The demo follows one inspectable data path.</h2>
         </div>
-        <div class="feature-grid">
-          <article class="feature-card">
-            <h3>Meal and context flow</h3>
-            <p>
-              A Flutter app flow for synthetic meal entries, medication context,
-              timeline review, and educational result screens.
-            </p>
-          </article>
-          <article class="feature-card">
-            <h3>Deterministic checks</h3>
-            <p>
-              Rule-based interaction checks that show why a prototype result was
-              produced instead of relying on opaque medical claims.
-            </p>
-          </article>
-          <article class="feature-card">
-            <h3>Evidence-oriented copy</h3>
-            <p>
-              User-facing explanations are designed to point back to rule logic,
-              source context, and known limitations.
-            </p>
-          </article>
-          <article class="feature-card">
-            <h3>Public guardrails</h3>
-            <p>
-              Repository policies, release notes, CI checks, and safety
-              documents keep the public showcase limited to education and
-              synthetic/demo data.
-            </p>
-          </article>
-        </div>
+        <ol class="flow">
+          <li>
+            <span>Meal + medication context</span>
+            <p>Synthetic entries from the app timeline and catalog screens.</p>
+          </li>
+          <li>
+            <span>Local-first state</span>
+            <p>Public demos stay local and avoid real accounts or health records.</p>
+          </li>
+          <li>
+            <span>Rule engine</span>
+            <p>Deterministic checks produce conservative, reproducible outputs.</p>
+          </li>
+          <li>
+            <span>Evidence explanation</span>
+            <p>The UI shows what mattered, what is missing, and what is limited.</p>
+          </li>
+        </ol>
       </section>
 
-      <section class="section" id="architecture">
-        <div class="section-header">
-          <p class="eyebrow">Architecture</p>
-          <h2>A small local-first prototype with visible rule boundaries</h2>
+      <section class="section launch" id="try">
+        <div class="section-heading">
+          <p class="eyebrow">Demo delivery</p>
+          <h2>Use the right demo format for the audience.</h2>
         </div>
-        <div class="architecture-flow" aria-label="Architecture flow">
-          <div>Flutter UI</div>
-          <div>App state</div>
-          <div>Local-first data layer</div>
-          <div>Deterministic rule engine</div>
-          <div>Evidence explanation</div>
-          <div>Educational output</div>
+        <div class="launch-grid">
+          <a class="launch-card" href="../site/">
+            <span class="badge">Available now</span>
+            <h3>30-second website</h3>
+            <p>
+              Use this static Pages site for reviewers who need the project
+              purpose, flow, and safety boundary immediately.
+            </p>
+          </a>
+          <a
+            class="launch-card"
+            href="https://github.com/albertzhzhou-droid/ParkinSUM/releases"
+          >
+            <span class="badge">Release channel</span>
+            <h3>Demo APK</h3>
+            <p>
+              Publish Android artifacts only as clearly labeled demo/debug APKs
+              from the GitHub Releases page.
+            </p>
+          </a>
+          <a class="launch-card" href="../PUBLIC_VERIFICATION.md">
+            <span class="badge">Source run</span>
+            <h3>Flutter web demo</h3>
+            <p>
+              Build or run the app from source when the reviewer needs an
+              interactive browser demo instead of screenshots.
+            </p>
+          </a>
+          <a class="launch-card" href="../media-capture-checklist.md">
+            <span class="badge">Media policy</span>
+            <h3>Short video / GIF</h3>
+            <p>
+              A short recording is useful only after it renders correctly on
+              GitHub and passes synthetic-data media checks.
+            </p>
+          </a>
         </div>
-        <p class="section-copy">
-          Firebase-backed paths exist for internal operator validation and
-          governance review, but the public showcase is intended to run in local
-          mode with synthetic or sample data. See the
-          <a href="../ARCHITECTURE.md">architecture overview</a> and
-          <a href="../RULE_ENGINE.md">rule engine overview</a> for technical
-          detail.
-        </p>
       </section>
 
       <section class="section safety" id="safety">
-        <div class="section-header">
+        <div class="safety-copy">
           <p class="eyebrow">Safety boundary</p>
-          <h2>What this project is, and what it is not</h2>
+          <h2>This is an educational software prototype.</h2>
+          <p>
+            ParkinSUM is for software architecture review, educational
+            walkthroughs, and synthetic-data demonstrations. It must not be used
+            for diagnosis, treatment, medication timing, dietary guidance,
+            clinical decision-making, patient care, or emergency support.
+          </p>
         </div>
-        <div class="safety-grid">
-          <div>
-            <h3>Appropriate use</h3>
-            <ul>
-              <li>Educational software demonstration</li>
-              <li>Architecture and mentoring discussion</li>
-              <li>Synthetic-data walkthroughs</li>
-              <li>Open-source review of app structure and rule explanations</li>
-            </ul>
-          </div>
-          <div>
-            <h3>Not appropriate for</h3>
-            <ul>
-              <li>Diagnosis, treatment, monitoring, or prevention</li>
-              <li>Medication timing or individualized dietary advice</li>
-              <li>Real patient records or real medication schedules</li>
-              <li>Claims of clinical validation or medical-device approval</li>
-            </ul>
-          </div>
-        </div>
-        <p class="section-copy">
-          Read the <a href="../../DISCLAIMER.md">safety disclaimer</a> and
-          <a href="../PUBLIC_DEMO_BOUNDARY.md">public demo boundary</a> before
-          presenting or reusing this project.
-        </p>
-      </section>
-
-      <section class="section alt" id="demo">
-        <div class="section-header">
-          <p class="eyebrow">Demo media</p>
-          <h2>Media slots are ready for synthetic screenshots and GIFs.</h2>
-        </div>
-        <div class="media-grid">
-          <figure class="media-placeholder">
-            <div class="placeholder-box">Screenshot placeholder</div>
-            <figcaption>
-              Dashboard:
-              <code>../assets/screenshots/dashboard.png</code>
-            </figcaption>
-          </figure>
-          <figure class="media-placeholder">
-            <div class="placeholder-box">Screenshot placeholder</div>
-            <figcaption>
-              Meal entry:
-              <code>../assets/screenshots/meal-entry.png</code>
-            </figcaption>
-          </figure>
-          <figure class="media-placeholder">
-            <div class="placeholder-box">Video placeholder</div>
-            <figcaption>
-              Short demo:
-              verified external video or future local asset
-            </figcaption>
-          </figure>
-        </div>
-        <p class="section-copy">
-          Real public media should be captured only with synthetic or sample
-          data. Follow the
-          <a href="../media-capture-checklist.md">media capture checklist</a>
-          before adding screenshots, GIFs, or videos.
-        </p>
-      </section>
-
-      <section class="section" id="impact">
-        <div class="section-header">
-          <p class="eyebrow">Impact materials</p>
-          <h2>Reusable documents for GitHub, school, and portfolio contexts</h2>
-        </div>
-        <div class="feature-grid">
-          <article class="feature-card">
-            <h3>One-page summary</h3>
-            <p>
-              A concise overview of the problem, prototype, architecture,
-              safety boundary, current status, and next milestones.
-            </p>
-            <a href="../impact/one-page-summary.md">Read summary</a>
-          </article>
-          <article class="feature-card">
-            <h3>Technical case study</h3>
-            <p>
-              A longer explanation of local-first design, Flutter architecture,
-              deterministic rules, synthetic data, and limited claims.
-            </p>
-            <a href="../impact/technical-case-study.md">Read case study</a>
-          </article>
-          <article class="feature-card">
-            <h3>Project pitch</h3>
-            <p>
-              Reusable short and presentation-length wording for mentors,
-              teachers, reviewers, and digital-health audiences.
-            </p>
-            <a href="../impact/project-pitch.md">Read pitch</a>
-          </article>
-          <article class="feature-card">
-            <h3>FAQ and ethics</h3>
-            <p>
-              Plain-language answers about medical advice, synthetic data,
-              local-first design, and why conflict decisions are deterministic.
-            </p>
-            <a href="../impact/faq.md">Read FAQ</a>
-            <a href="../impact/safety-and-ethics.md">Read ethics note</a>
-          </article>
-        </div>
-      </section>
-
-      <section class="section" id="roadmap">
-        <div class="section-header">
-          <p class="eyebrow">Roadmap</p>
-          <h2>Next steps keep the prototype educational and reviewable.</h2>
-        </div>
-        <div class="roadmap-list">
-          <div>
-            <h3>Demo polish</h3>
-            <p>Capture synthetic screenshots and a short demo GIF.</p>
-          </div>
-          <div>
-            <h3>Accessibility and localization</h3>
-            <p>Improve readable copy, language coverage, and inclusive UI review.</p>
-          </div>
-          <div>
-            <h3>Evidence review</h3>
-            <p>Keep rule explanations traceable and limitations visible.</p>
-          </div>
-          <div>
-            <h3>Public-release hygiene</h3>
-            <p>Maintain CI, safety docs, release notes, and synthetic-data checks.</p>
-          </div>
-        </div>
-        <div class="cta-row">
-          <a class="button primary" href="../../ROADMAP.md">View roadmap</a>
-          <a class="button" href="../wiki/">Open showcase wiki</a>
-          <a class="button" href="https://github.com/albertzhzhou-droid/ParkinSUM">
-            View GitHub repository
-          </a>
+        <div class="safety-actions">
+          <a class="button primary" href="../../DISCLAIMER.md">Read disclaimer</a>
+          <a class="button" href="../PUBLIC_DEMO_BOUNDARY.md">Demo boundary</a>
+          <a class="button" href="../wiki/">Animated wiki</a>
         </div>
       </section>
     </main>
-
-    <footer class="footer">
-      <p>
-        ParkinSUM Companion is an educational prototype. Use synthetic/demo data
-        only. Not medical advice, not a medical device, and no clinical
-        validation is claimed.
-      </p>
-      <a href="https://github.com/albertzhzhou-droid/ParkinSUM">
-        GitHub repository
-      </a>
-    </footer>
   </body>
 </html>

--- a/docs/site/styles.css
+++ b/docs/site/styles.css
@@ -1,17 +1,17 @@
 :root {
   color-scheme: light;
-  --bg: #f7faf8;
-  --surface: #ffffff;
-  --surface-alt: #eef5f0;
-  --text: #17211b;
-  --muted: #52645a;
-  --line: #d9e5dd;
-  --primary: #166146;
-  --primary-dark: #0f4532;
-  --accent: #dbeee4;
-  --warning: #fff4d7;
-  --warning-line: #e3c879;
-  --shadow: 0 16px 40px rgba(18, 43, 31, 0.1);
+  --ink: #182033;
+  --muted: #626b83;
+  --line: rgba(111, 124, 160, 0.22);
+  --panel: rgba(255, 255, 255, 0.66);
+  --panel-strong: rgba(255, 255, 255, 0.86);
+  --blue: #1467e8;
+  --teal: #10c8a5;
+  --violet: #5c5b9f;
+  --rose: #ffeaf3;
+  --mint: #e3fbf3;
+  --sky: #e7f0ff;
+  --shadow: 0 24px 70px rgba(57, 65, 107, 0.14);
 }
 
 * {
@@ -24,103 +24,174 @@ html {
 
 body {
   margin: 0;
-  background: var(--bg);
-  color: var(--text);
+  min-width: 320px;
+  background:
+    radial-gradient(circle at 12% 12%, rgba(84, 122, 255, 0.24), transparent 30%),
+    radial-gradient(circle at 82% 18%, rgba(255, 211, 229, 0.68), transparent 28%),
+    radial-gradient(circle at 48% 88%, rgba(161, 250, 225, 0.58), transparent 30%),
+    linear-gradient(135deg, #edf0ff 0%, #fff6fb 48%, #e9fbf6 100%);
+  color: var(--ink);
   font-family:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     sans-serif;
-  line-height: 1.6;
+  line-height: 1.55;
 }
 
 a {
-  color: var(--primary);
+  color: inherit;
   text-decoration: none;
 }
 
 a:hover {
-  text-decoration: underline;
+  text-decoration: none;
 }
 
-.site-header {
+img {
+  display: block;
+  max-width: 100%;
+}
+
+.topbar {
   position: sticky;
   top: 0;
-  z-index: 10;
-  border-bottom: 1px solid var(--line);
-  background: rgba(247, 250, 248, 0.95);
-  backdrop-filter: blur(10px);
-}
-
-.nav {
+  z-index: 20;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 24px;
-  max-width: 1120px;
-  margin: 0 auto;
-  padding: 14px 24px;
+  gap: 20px;
+  width: min(1180px, calc(100% - 32px));
+  margin: 14px auto 0;
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 8px;
+  padding: 10px 14px;
+  background: rgba(255, 255, 255, 0.62);
+  box-shadow: 0 14px 40px rgba(65, 72, 110, 0.1);
+  backdrop-filter: blur(22px) saturate(150%);
 }
 
 .brand {
-  color: var(--text);
-  font-size: 1.05rem;
-  font-weight: 800;
-  letter-spacing: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ink);
+  font-weight: 850;
 }
 
-.nav-links {
+.brand img {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+}
+
+.topbar nav {
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 14px;
-  font-size: 0.95rem;
+  gap: 8px;
 }
 
-.nav-links a {
+.topbar nav a {
+  border-radius: 8px;
+  padding: 8px 10px;
   color: var(--muted);
+  font-size: 0.92rem;
+  font-weight: 760;
+}
+
+.topbar nav a:hover {
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--ink);
+}
+
+.hero,
+.section,
+.strip {
+  width: min(1180px, calc(100% - 32px));
+  margin: 0 auto;
 }
 
 .hero {
-  background:
-    linear-gradient(135deg, rgba(22, 97, 70, 0.9), rgba(25, 80, 89, 0.86)),
-    linear-gradient(45deg, #dbeee4, #f7faf8);
-  color: #fff;
+  display: grid;
+  grid-template-columns: minmax(0, 0.86fr) minmax(420px, 1.14fr);
+  gap: 34px;
+  min-height: calc(100svh - 92px);
+  padding: 58px 0 32px;
+  align-items: center;
 }
 
-.hero-content {
-  max-width: 1120px;
-  margin: 0 auto;
-  padding: 86px 24px 76px;
+.hero-copy,
+.hero-stage,
+.strip,
+.screen-card,
+.flow li,
+.launch-card,
+.safety {
+  border: 1px solid rgba(255, 255, 255, 0.74);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(24px) saturate(150%);
+}
+
+.hero-copy {
+  padding: clamp(22px, 4vw, 38px);
+}
+
+.wordmark {
+  width: min(310px, 78vw);
+  margin-bottom: 22px;
 }
 
 .eyebrow {
   margin: 0 0 10px;
-  color: inherit;
-  font-size: 0.82rem;
-  font-weight: 800;
-  letter-spacing: 0.08em;
+  color: var(--violet);
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0;
   text-transform: uppercase;
 }
 
-.hero h1 {
-  max-width: 780px;
-  margin: 0;
-  font-size: clamp(2.4rem, 6vw, 4.8rem);
-  line-height: 1.02;
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 760px;
+  margin-bottom: 18px;
+  font-size: clamp(2.15rem, 4.7vw, 4.35rem);
+  line-height: 1.03;
   letter-spacing: 0;
 }
 
-.hero-copy {
-  max-width: 760px;
-  margin: 24px 0 0;
-  color: rgba(255, 255, 255, 0.92);
-  font-size: 1.16rem;
+h2 {
+  margin-bottom: 0;
+  font-size: clamp(1.75rem, 3vw, 2.75rem);
+  line-height: 1.12;
+  letter-spacing: 0;
 }
 
-.cta-row {
+h3 {
+  margin-bottom: 10px;
+  font-size: 1.12rem;
+  letter-spacing: 0;
+}
+
+.lead {
+  max-width: 690px;
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 1.1rem;
+}
+
+.action-row,
+.safety-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
-  margin-top: 28px;
+  gap: 10px;
+  margin-top: 24px;
 }
 
 .button {
@@ -128,261 +199,313 @@ a:hover {
   align-items: center;
   justify-content: center;
   min-height: 44px;
-  border: 1px solid var(--line);
+  border: 1px solid rgba(92, 91, 159, 0.25);
   border-radius: 8px;
-  padding: 10px 16px;
-  background: var(--surface);
-  color: var(--primary-dark);
-  font-weight: 800;
-  box-shadow: 0 2px 0 rgba(18, 43, 31, 0.08);
+  padding: 10px 15px;
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--violet);
+  font-weight: 840;
+  transition:
+    transform 160ms ease,
+    background 160ms ease,
+    box-shadow 160ms ease;
 }
 
-.button:hover {
-  text-decoration: none;
-  transform: translateY(-1px);
+.button:hover,
+.launch-card:hover {
+  transform: translateY(-2px);
 }
 
 .button.primary {
-  border-color: var(--primary);
-  background: var(--primary);
-  color: #fff;
+  border-color: transparent;
+  background: linear-gradient(135deg, var(--blue), var(--teal));
+  color: #ffffff;
+  box-shadow: 0 12px 28px rgba(20, 103, 232, 0.2);
 }
 
-.hero .button {
-  border-color: rgba(255, 255, 255, 0.34);
+.boundary {
+  margin: 18px 0 0;
+  border-left: 4px solid var(--teal);
+  padding-left: 12px;
+  color: #2a3348;
+  font-weight: 760;
 }
 
-.hero .button:not(.primary) {
-  background: rgba(255, 255, 255, 0.94);
+.hero-stage {
+  padding: clamp(16px, 2.5vw, 24px);
 }
 
-.boundary-note {
-  display: inline-block;
-  max-width: 760px;
-  margin: 26px 0 0;
-  border: 1px solid rgba(255, 255, 255, 0.34);
+.glass-device {
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.82);
   border-radius: 8px;
-  padding: 12px 14px;
-  background: rgba(255, 255, 255, 0.12);
-  color: rgba(255, 255, 255, 0.95);
-  font-weight: 700;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.95),
+    0 20px 56px rgba(58, 72, 118, 0.18);
+}
+
+.glass-device img {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+}
+
+.quick-read {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.quick-read article {
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 8px;
+  padding: 14px;
+  background: rgba(255, 255, 255, 0.56);
+}
+
+.quick-read span {
+  display: inline-flex;
+  margin-bottom: 8px;
+  color: var(--blue);
+  font-size: 0.76rem;
+  font-weight: 900;
+}
+
+.quick-read strong {
+  display: block;
+  line-height: 1.25;
+}
+
+.quick-read p {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  margin-bottom: 34px;
+  padding: 0;
+}
+
+.strip article {
+  padding: 18px;
+  background: rgba(255, 255, 255, 0.42);
+}
+
+.strip strong,
+.strip span {
+  display: block;
+}
+
+.strip strong {
+  font-size: 1.02rem;
+}
+
+.strip span {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 0.94rem;
 }
 
 .section {
-  max-width: 1120px;
-  margin: 0 auto;
-  padding: 72px 24px;
+  padding: 58px 0;
 }
 
-.section.alt {
-  max-width: none;
-  background: var(--surface-alt);
+.section-heading {
+  max-width: 780px;
+  margin-bottom: 24px;
 }
 
-.section.alt > * {
-  max-width: 1120px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.section-header {
-  max-width: 760px;
-  margin-bottom: 30px;
-}
-
-.section-header .eyebrow {
-  color: var(--primary);
-}
-
-.section h2 {
-  margin: 0;
-  font-size: clamp(1.8rem, 3vw, 2.7rem);
-  line-height: 1.15;
-  letter-spacing: 0;
-}
-
-.split {
+.screen-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 30px;
-  color: var(--muted);
-  font-size: 1.05rem;
+  grid-template-columns: 1.15fr 0.85fr;
+  gap: 16px;
 }
 
-.feature-grid,
-.media-grid,
-.roadmap-list,
-.safety-grid {
+.screen-card {
+  overflow: hidden;
+  margin: 0;
+  padding: 0;
+}
+
+.screen-card.large {
+  grid-row: span 3;
+}
+
+.screen-card img {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  border-bottom: 1px solid var(--line);
+}
+
+.screen-card figcaption {
+  display: grid;
+  gap: 6px;
+  padding: 16px;
+}
+
+.screen-card figcaption strong {
+  font-size: 1rem;
+}
+
+.screen-card figcaption span {
+  color: var(--muted);
+  font-size: 0.94rem;
+}
+
+.workflow {
+  padding-top: 36px;
+}
+
+.flow {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 18px;
-}
-
-.feature-card,
-.roadmap-list > div,
-.safety-grid > div,
-.media-placeholder {
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--surface);
-  padding: 20px;
-  box-shadow: var(--shadow);
-}
-
-.feature-card h3,
-.roadmap-list h3,
-.safety-grid h3 {
-  margin: 0 0 10px;
-  font-size: 1.1rem;
-}
-
-.feature-card p,
-.roadmap-list p {
+  gap: 14px;
   margin: 0;
-  color: var(--muted);
+  padding: 0;
+  list-style: none;
+  counter-reset: flow;
 }
 
-.architecture-flow {
+.flow li {
+  position: relative;
+  min-height: 190px;
+  padding: 48px 18px 18px;
+  counter-increment: flow;
+}
+
+.flow li::before {
+  content: counter(flow);
+  position: absolute;
+  top: 16px;
+  left: 18px;
   display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
-  gap: 10px;
-  margin: 28px 0;
-}
-
-.architecture-flow div {
-  display: flex;
-  align-items: center;
-  min-height: 84px;
-  border: 1px solid var(--line);
+  place-items: center;
+  width: 28px;
+  height: 28px;
   border-radius: 8px;
-  padding: 14px;
-  background: var(--surface);
-  color: var(--primary-dark);
-  font-weight: 800;
-  box-shadow: var(--shadow);
+  background: linear-gradient(135deg, var(--blue), var(--teal));
+  color: #fff;
+  font-size: 0.82rem;
+  font-weight: 900;
 }
 
-.section-copy {
-  max-width: 820px;
-  margin: 24px 0 0;
+.flow span {
+  display: block;
+  font-weight: 850;
+}
+
+.flow p {
+  margin: 10px 0 0;
   color: var(--muted);
-  font-size: 1.03rem;
+}
+
+.launch-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.launch-card {
+  min-height: 220px;
+  padding: 18px;
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.launch-card p {
+  color: var(--muted);
+}
+
+.badge {
+  display: inline-flex;
+  margin-bottom: 16px;
+  border: 1px solid rgba(16, 200, 165, 0.28);
+  border-radius: 8px;
+  padding: 5px 9px;
+  background: rgba(227, 251, 243, 0.78);
+  color: #08715f;
+  font-size: 0.78rem;
+  font-weight: 850;
 }
 
 .safety {
-  background: var(--warning);
-  border-block: 1px solid var(--warning-line);
-  max-width: none;
-}
-
-.safety > * {
-  max-width: 1120px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.safety-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.safety-grid ul {
-  margin: 0;
-  padding-left: 20px;
-  color: var(--muted);
-}
-
-.media-grid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.media-placeholder {
-  margin: 0;
-}
-
-.placeholder-box {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 24px;
   align-items: center;
-  justify-content: center;
-  min-height: 180px;
-  border: 1px dashed #95aa9e;
-  border-radius: 8px;
-  background:
-    linear-gradient(135deg, rgba(22, 97, 70, 0.08), rgba(25, 80, 89, 0.05)),
-    #f8fbf9;
-  color: var(--muted);
-  font-weight: 800;
-}
-
-figcaption {
-  margin-top: 12px;
-  color: var(--muted);
-}
-
-code {
-  overflow-wrap: anywhere;
-  color: var(--primary-dark);
-  font-family:
-    "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
-}
-
-.footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 18px;
-  border-top: 1px solid var(--line);
+  margin-bottom: 44px;
   padding: 24px;
-  background: var(--surface);
+  background:
+    linear-gradient(135deg, rgba(255, 234, 243, 0.86), rgba(231, 240, 255, 0.82)),
+    var(--panel-strong);
+}
+
+.safety-copy p:last-child {
+  margin-bottom: 0;
   color: var(--muted);
 }
 
-.footer p {
-  margin: 0;
-}
-
-@media (max-width: 860px) {
-  .nav {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-
-  .nav-links {
-    justify-content: flex-start;
-  }
-
-  .hero-content {
-    padding-top: 58px;
-  }
-
-  .split,
-  .safety-grid,
-  .media-grid {
+@media (max-width: 980px) {
+  .hero {
     grid-template-columns: 1fr;
+    min-height: auto;
   }
 
-  .feature-grid,
-  .roadmap-list,
-  .architecture-flow {
+  .screen-grid,
+  .flow,
+  .launch-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .footer {
-    align-items: flex-start;
-    flex-direction: column;
+  .screen-card.large {
+    grid-row: auto;
+  }
+
+  .safety {
+    grid-template-columns: 1fr;
   }
 }
 
-@media (max-width: 560px) {
-  .section,
-  .hero-content {
-    padding-left: 18px;
-    padding-right: 18px;
+@media (max-width: 720px) {
+  .topbar {
+    align-items: flex-start;
+    flex-direction: column;
   }
 
-  .feature-grid,
-  .roadmap-list,
-  .architecture-flow {
+  .topbar nav {
+    justify-content: flex-start;
+  }
+
+  .quick-read,
+  .strip,
+  .screen-grid,
+  .flow,
+  .launch-grid {
     grid-template-columns: 1fr;
+  }
+
+  .hero {
+    width: min(100% - 24px, 1180px);
+    padding-top: 32px;
+  }
+
+  .section,
+  .strip {
+    width: min(100% - 24px, 1180px);
+  }
+
+  .action-row,
+  .safety-actions {
+    flex-direction: column;
   }
 
   .button {


### PR DESCRIPTION
## Summary\n- replace the placeholder Pages landing page with a 30-second demo website\n- reuse the ParkinSUM logo, wordmark, and redacted real-device screenshots\n- add demo delivery options for the static website, release APK, Flutter web demo, and short video/GIF policy\n- keep the public safety boundary explicit and conservative\n\n## Validation\n- npm run public:preflight\n- git diff --check\n- checked 15 local HTML resource references; missing: 0\n\nAuto-merge was not enabled.