### PR TITLE
[codex] Add project Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,67 @@
+# Code of Conduct
+
+## Our Pledge
+
+We pledge to make participation in the ParkinSUM community respectful,
+welcoming, and harassment-free for everyone, regardless of age, body size,
+visible or invisible disability, ethnicity, sex characteristics, gender identity
+and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, sexual identity,
+or sexual orientation.
+
+ParkinSUM is an educational software prototype. Community discussion must also
+respect the project's public safety boundary: use synthetic or sample data only,
+do not submit personal health information, and do not present the project as
+medical advice or clinical software.
+
+## Expected Behavior
+
+Examples of behavior that contributes to a positive environment include:
+
+- Being respectful and constructive.
+- Accepting reasonable feedback and correcting mistakes.
+- Focusing criticism on ideas, implementation, evidence, and documentation.
+- Using inclusive language.
+- Respecting the project's synthetic-data and non-clinical public boundary.
+
+## Unacceptable Behavior
+
+Examples of unacceptable behavior include:
+
+- Harassment, intimidation, threats, insults, or sustained disruption.
+- Sexualized language or imagery, unwelcome sexual attention, or unwanted
+  advances.
+- Trolling, personal attacks, or publishing private communications without
+  consent.
+- Sharing private information such as personal health information, account
+  identifiers, real email addresses, full UIDs, credentials, tokens, private
+  screenshots, or local machine paths.
+- Encouraging contributors or users to treat ParkinSUM as diagnosis, treatment,
+  medication timing advice, dietary guidance, patient care, or emergency
+  support.
+
+## Scope
+
+This Code of Conduct applies in all project spaces, including GitHub issues,
+pull requests, discussions, documentation, examples, demo media, and any public
+or private communication made in the context of the project.
+
+## Reporting
+
+Report Code of Conduct concerns privately to:
+
+`parkinsumservice@gmail.com`
+
+Do not include personal health information, credentials, tokens, or other
+private data in a public issue or pull request. If a report involves exposed
+private information or a secret, follow [SECURITY.md](SECURITY.md) as well.
+
+Maintainers will review reports in good faith and may remove content, edit or
+close issues or pull requests, request behavior changes, block accounts, or take
+other reasonable steps to protect the project community and public repository
+boundary.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1,
+available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,9 @@
 Contributions are welcome when they respect the public prototype boundary.
 ParkinSUM is an educational and research prototype, not clinical software.
 
+All contributors must follow the project
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## Data Rules
 
 - Use only synthetic or sample data.


### PR DESCRIPTION
## Summary\n- add root CODE_OF_CONDUCT.md so GitHub detects the project Code of Conduct\n- adapt Contributor Covenant-style expectations to ParkinSUM's synthetic-data and non-clinical public boundary\n- link the Code of Conduct from CONTRIBUTING.md\n\n## Validation\n- npm run public:preflight\n- git diff --check\n\nAuto-merge was not enabled.