### PR TITLE
[codex] Clarify replay Local AI consent naming

### DIFF
--- a/lib/core/constants/local_ai_replay_scenarios.dart
+++ b/lib/core/constants/local_ai_replay_scenarios.dart
@@ -41,13 +41,14 @@ const localAiReplayScenarioDataset = RecommendationBenchmarkDataset(
       ],
       expectedTopFoodIds: <String>['food_banana', 'food_apple'],
       expectedRiskTags: <String>[],
-      expectAiGateOpen: true,
+      userConsentedToAi: true,
       notes:
           'No next-meal window and no parsable dose: a gate reason must fire and '
           'Local AI must not rerank.',
     ),
-    // 2 — Low-risk next-meal: no drugs, low-protein fruit, clear window. The
-    // gate is open, so Local AI may reorder the safe whitelist.
+    // 2 — Low-risk next-meal: no drugs, low-protein fruit, clear window. User
+    // consent is enabled and the safety checks permit Local AI to reorder the
+    // safe whitelist.
     RecommendationBenchmarkCase(
       caseId: 'replay_low_risk_next_meal',
       title: 'Low-risk next meal allows safe Local AI reranking',
@@ -61,10 +62,10 @@ const localAiReplayScenarioDataset = RecommendationBenchmarkDataset(
       intakeSpecs: <RecommendationBenchmarkIntakeSpec>[],
       expectedTopFoodIds: <String>['food_banana', 'food_apple'],
       expectedRiskTags: <String>[],
-      expectAiGateOpen: true,
+      userConsentedToAi: true,
       notes:
-          'No medications and a clear window: the safety gate is open and Local '
-          'AI may only reorder the deterministic whitelist.',
+          'No medications and a clear window: with consent enabled, the safety '
+          'checks permit Local AI to reorder only the deterministic whitelist.',
     ),
     // 3 — Source fallback / partial provenance: a CN diet profile over US seed
     // foods exercises jurisdiction fallback + capped synthetic provenance. AI
@@ -82,7 +83,7 @@ const localAiReplayScenarioDataset = RecommendationBenchmarkDataset(
       intakeSpecs: <RecommendationBenchmarkIntakeSpec>[],
       expectedTopFoodIds: <String>['food_banana'],
       expectedRiskTags: <String>[],
-      expectAiGateOpen: false,
+      userConsentedToAi: false,
       notes:
           'US-seed foods under a CN diet profile rely on jurisdiction fallback '
           'with capped synthetic provenance; AI disabled for this case.',
@@ -113,14 +114,14 @@ const localAiReplayScenarioDataset = RecommendationBenchmarkDataset(
       ],
       expectedTopFoodIds: <String>['food_banana'],
       expectedRiskTags: <String>[],
-      expectAiGateOpen: true,
+      userConsentedToAi: true,
       notes:
           'A legacy-migrated meal time is too low-quality to rerank against; the '
           'conservative ranking is kept and Local AI cannot rerank.',
     ),
     // 5 — Medication catalog selection context: an active levodopa selection
-    // with low-protein candidates. The gate is open (no penalty), so the
-    // medication context flows into a safe AI-assisted path.
+    // with low-protein candidates. Consent is enabled and deterministic safety
+    // checks permit the medication context to flow into a safe AI-assisted path.
     RecommendationBenchmarkCase(
       caseId: 'replay_medication_catalog_selection_context',
       title: 'Medication catalog selection flows into a safe AI path',
@@ -142,10 +143,10 @@ const localAiReplayScenarioDataset = RecommendationBenchmarkDataset(
       ],
       expectedTopFoodIds: <String>['food_banana', 'food_apple'],
       expectedRiskTags: <String>[],
-      expectAiGateOpen: true,
+      userConsentedToAi: true,
       notes:
-          'A levodopa catalog selection with low-protein candidates keeps the '
-          'gate open; the medication context flows into the safe AI path.',
+          'A levodopa catalog selection with low-protein candidates and consent '
+          'enabled can flow into the safe AI path.',
     ),
   ],
 );

--- a/lib/domain/entities/recommendation_benchmark_models.dart
+++ b/lib/domain/entities/recommendation_benchmark_models.dart
@@ -25,7 +25,12 @@ class RecommendationBenchmarkCase {
   final List<RecommendationBenchmarkIntakeSpec> intakeSpecs;
   final List<String> expectedTopFoodIds;
   final List<String> expectedRiskTags;
-  final bool expectAiGateOpen;
+
+  /// Whether the synthetic user profile grants Local AI consent for this
+  /// replay case. This is not the same as the final safety gate outcome; the
+  /// orchestrator may still block Local AI when deterministic inputs are
+  /// incomplete or unsafe to rerank.
+  final bool userConsentedToAi;
   final String notes;
 
   const RecommendationBenchmarkCase({
@@ -47,7 +52,7 @@ class RecommendationBenchmarkCase {
     this.intakeSpecs = const <RecommendationBenchmarkIntakeSpec>[],
     required this.expectedTopFoodIds,
     required this.expectedRiskTags,
-    required this.expectAiGateOpen,
+    required this.userConsentedToAi,
     required this.notes,
   });
 }
@@ -110,7 +115,7 @@ const defaultRecommendationBenchmarkDataset = RecommendationBenchmarkDataset(
       nextMealWindowEndMinutesAfterMeal: 390,
       expectedTopFoodIds: <String>['food_banana', 'food_apple'],
       expectedRiskTags: <String>['levodopa_sensitive'],
-      expectAiGateOpen: true,
+      userConsentedToAi: true,
       notes:
           'High-protein tofu/oats should not outrank lower-protein fruit near a sensitive levodopa window.',
     ),
@@ -144,7 +149,7 @@ const defaultRecommendationBenchmarkDataset = RecommendationBenchmarkDataset(
       nextMealWindowEndMinutesAfterMeal: 360,
       expectedTopFoodIds: <String>['food_banana'],
       expectedRiskTags: <String>['timing_window_unclear'],
-      expectAiGateOpen: true,
+      userConsentedToAi: true,
       notes:
           'The benchmark checks that rerank stays within conservative ordering instead of making aggressive changes under interaction pressure.',
     ),
@@ -165,7 +170,7 @@ const defaultRecommendationBenchmarkDataset = RecommendationBenchmarkDataset(
       nextMealWindowEndMinutesAfterMeal: 300,
       expectedTopFoodIds: <String>['food_tofu', 'food_banana'],
       expectedRiskTags: <String>[],
-      expectAiGateOpen: true,
+      userConsentedToAi: true,
       notes:
           'Until a full CN authoritative nutrient export is integrated, tofu/banana stay useful replay candidates for China-facing food ranking.',
     ),
@@ -185,7 +190,7 @@ const defaultRecommendationBenchmarkDataset = RecommendationBenchmarkDataset(
       activeDrugIds: <String>['drug_levodopa_carbidopa'],
       expectedTopFoodIds: <String>['food_banana', 'food_apple'],
       expectedRiskTags: <String>['missing_next_meal_window'],
-      expectAiGateOpen: false,
+      userConsentedToAi: false,
       notes:
           'If the timing window is missing, AI should stay gated off and deterministic ranking should be used directly.',
     ),

--- a/lib/domain/usecases/recommendation_replay_runner.dart
+++ b/lib/domain/usecases/recommendation_replay_runner.dart
@@ -61,7 +61,7 @@ class RecommendationReplayRunner {
     final hybrid = await hybridOrchestrator.recommend(
       request: request.copyWith(
         mode: RecommendationMode.hybridLocalLlm,
-        userConsentedToAi: benchmarkCase.expectAiGateOpen,
+        userConsentedToAi: benchmarkCase.userConsentedToAi,
       ),
       candidateFoods: candidates,
     );
@@ -164,14 +164,14 @@ class RecommendationReplayRunner {
         registrationRegion: benchmarkCase.registrationRegion,
         displayLocale: benchmarkCase.displayLocale,
         dietProfileRegion: benchmarkCase.dietProfileRegion,
-        localAiConsentEnabled: benchmarkCase.expectAiGateOpen,
+        localAiConsentEnabled: benchmarkCase.userConsentedToAi,
       ),
       history: [meal],
       activeDrugs: drugs,
       intakes: intakes,
       now: now,
       mode: RecommendationMode.hybridLocalLlm,
-      userConsentedToAi: benchmarkCase.expectAiGateOpen,
+      userConsentedToAi: benchmarkCase.userConsentedToAi,
     );
   }
 


### PR DESCRIPTION
## Summary
- rename replay benchmark field `expectAiGateOpen` to `userConsentedToAi`
- document that user consent is separate from the final deterministic safety gate outcome
- update Local AI replay scenario notes that previously implied consent and gate-open were the same concept

## Validation
- flutter test test/local_ai_scenario_replay_test.dart test/local_ai_safety_contract_test.dart test/rule_explanation_schema_test.dart
- flutter analyze
- npm run public:preflight
- git diff --check

Note: local Flutter tooling rewrote pubspec.lock during validation; that generated drift was restored and is not included.