### PR TITLE
Add reviewer-friendly Local AI replay report workflow

### DIFF
--- a/docs/LOCAL_AI_REPLAY_REPORT.md
+++ b/docs/LOCAL_AI_REPLAY_REPORT.md
@@ -1,0 +1,56 @@
+# Local AI Scenario Replay — Reviewer Report
+
+Educational/research prototype. Synthetic/demo fixtures only. The replay is
+engineering review material — **not medical advice, not clinically calibrated,
+and it carries no clinical-validation claim.**
+
+## What it is
+
+A deterministic replay of five fixed synthetic archetypes through the same
+conservative + hybrid next-meal orchestrators the app uses, with an offline
+scripted Local AI stand-in (no network, no real model):
+
+| Archetype | Expected behaviour |
+| --- | --- |
+| `missing_medication_time_or_dose` | Data-quality gate keeps the conservative ranking |
+| `low_risk_next_meal` | Gate open; Local AI may reorder the safe whitelist only |
+| `source_fallback_partial_provenance` | AI consent off; deterministic path recorded |
+| `safety_gate_blocks_local_ai` | Low-quality meal time blocks AI reranking |
+| `medication_catalog_selection_context` | Medication context flows into the safe AI path |
+
+The report pins one safety invariant: **the Local AI path may only reorder the
+deterministic candidate whitelist** — it can never add, drop, or invent a
+candidate, and it never overrides gate decisions.
+
+## How to run
+
+```sh
+flutter test test/local_ai_replay_report_test.dart
+```
+
+This one command regenerates and verifies the reviewer artifact:
+
+- `build/recommendation_scenario_replay/latest.md` — reviewer Markdown (per
+  archetype: rankings, decision path, gate reasons, invariant status,
+  expected-id matches, and a why-allowed/why-blocked note).
+- `build/recommendation_scenario_replay/latest.json` — structured snapshot of
+  the same fields.
+
+Both artifacts are **timestamp-free and deterministic**: regenerating them on
+unchanged code produces byte-identical files. If a regenerated report differs
+from a previously reviewed one, engine/gate/scenario behaviour actually changed
+— review the diff rather than regenerating it away.
+
+The broader scenario assertions (decision paths, candidate-set invariant, JSON
+byte-stability) live in:
+
+```sh
+flutter test test/local_ai_scenario_replay_test.dart
+```
+
+## Why there is no `dart run` CLI
+
+The orchestrator transitively imports Flutter via `app_i18n`, so a plain-Dart
+CLI cannot compile without a larger i18n refactor. The focused test above is
+the supported one-command entry point; a Flutter-free import path for the
+orchestrator remains documented future work.

--- a/lib/core/constants/local_ai_replay_scenarios.dart
+++ b/lib/core/constants/local_ai_replay_scenarios.dart
@@ -150,3 +150,31 @@ const localAiReplayScenarioDataset = RecommendationBenchmarkDataset(
     ),
   ],
 );
+
+/// Reviewer-facing notes per archetype (keyed by the case's first focus tag).
+///
+/// Each entry explains, in non-clinical engineering language, what the
+/// archetype represents and why Local AI is expected to be allowed or blocked.
+/// Used by the reviewer Markdown report; not shown in the app UI.
+const Map<String, String> localAiReplayArchetypeNotes = <String, String>{
+  'missing_medication_time_or_dose':
+      'A medication intake is logged without a parsable dose and the meal has '
+          'no next-meal window. The data-quality gate keeps the conservative '
+          'ranking, so Local AI may polish wording but must not rerank.',
+  'low_risk_next_meal':
+      'No medications and a clear next-meal window. The safety gate is open, '
+          'so Local AI may reorder the already-safe candidate whitelist (and '
+          'nothing else).',
+  'source_fallback_partial_provenance':
+      'Candidates resolve through jurisdiction fallback with capped synthetic '
+          'provenance, and Local AI consent is off. The deterministic '
+          'conservative path is recorded unchanged.',
+  'safety_gate_blocks_local_ai':
+      'The only meal time is a legacy-migrated value of unknown precision. '
+          'The gate treats it as too low-quality to rerank against, so Local '
+          'AI reranking is blocked even though the user consented.',
+  'medication_catalog_selection_context':
+      'An active medication catalog selection with low-risk candidates and '
+          'consent enabled. The medication context flows into the safe AI '
+          'path; the rerank is still whitelist-bound.',
+};

--- a/lib/domain/entities/recommendation_replay_models.dart
+++ b/lib/domain/entities/recommendation_replay_models.dart
@@ -25,6 +25,12 @@ class RecommendationReplayCaseReport {
     required this.missingExpectedTopFoodIds,
   });
 
+  /// Safety invariant: the AI path may only reorder the deterministic
+  /// candidate set; it must never add or drop a candidate. False here means
+  /// a candidate id was invented or lost between the two paths.
+  bool get aiPreservedCandidateSet =>
+      _sortedEquals(deterministicRanking, aiRanking);
+
   String toMarkdown() {
     final lines = <String>[
       '## ${benchmarkCase.caseId} · ${benchmarkCase.title}',
@@ -60,11 +66,47 @@ class RecommendationReplayCaseReport {
         'missing_expected_top_food_ids': missingExpectedTopFoodIds,
         // Safety invariant: the AI path may only reorder the deterministic
         // candidate set; it must never add or drop a candidate.
-        'ai_preserved_candidate_set': _sortedEquals(
-          deterministicRanking,
-          aiRanking,
-        ),
+        'ai_preserved_candidate_set': aiPreservedCandidateSet,
       };
+
+  /// One reviewer-facing section per case: every audit-relevant field plus a
+  /// short safety note. [archetypeNote] explains what the archetype represents
+  /// and why Local AI is expected to be allowed or blocked.
+  String toReviewerMarkdown({String? archetypeNote}) {
+    final aiBlocked = !aiUsed || gateReasons.isNotEmpty;
+    final lines = <String>[
+      '## ${benchmarkCase.caseId}',
+      '',
+      '**${benchmarkCase.title}**',
+      '',
+      if (archetypeNote != null && archetypeNote.isNotEmpty) ...[
+        '_Archetype:_ $archetypeNote',
+        '',
+      ],
+      '| Field | Value |',
+      '| --- | --- |',
+      '| Focus tags | ${benchmarkCase.focusTags.join(', ')} |',
+      '| Deterministic ranking | ${deterministicRanking.join(' → ')} |',
+      '| AI ranking | ${aiRanking.join(' → ')} |',
+      '| Decision path | `$decisionPath` |',
+      '| Local AI used | ${aiUsed ? 'yes' : 'no'} |',
+      '| Gate reasons | ${gateReasons.isEmpty ? 'none' : gateReasons.join(' / ')} |',
+      '| AI preserved candidate set | ${aiPreservedCandidateSet ? 'yes' : '**NO — invariant violated**'} |',
+      '| Expected top ids matched | ${matchedExpectedTopFoodIds.isEmpty ? 'none' : matchedExpectedTopFoodIds.join(', ')} |',
+      '| Expected top ids missing | ${missingExpectedTopFoodIds.isEmpty ? 'none' : missingExpectedTopFoodIds.join(', ')} |',
+      '',
+      aiBlocked
+          ? '_Local AI was limited to wording polish here: '
+              '${gateReasons.isEmpty ? 'the AI path was not engaged.' : 'the deterministic gate held the conservative ranking.'}_'
+          : '_Local AI was allowed to reorder the safe whitelist only; the '
+              'deterministic candidate set and decisions stayed authoritative._',
+      '',
+      '_Safety note: synthetic educational fixture. Deterministic rules remain '
+          'the source of truth; this report is engineering review material and '
+          'not medical advice._',
+    ];
+    return lines.join('\n');
+  }
 
   static bool _sortedEquals(List<String> a, List<String> b) {
     if (a.length != b.length) return false;
@@ -99,7 +141,55 @@ class RecommendationReplayRunReport {
   /// Whether every case preserved the deterministic candidate set under the AI
   /// path (a coarse, scenario-level Local-AI safety invariant).
   bool get allPreservedCandidateSet =>
-      cases.every((c) => c.toJson()['ai_preserved_candidate_set'] == true);
+      cases.every((c) => c.aiPreservedCandidateSet);
+
+  /// Reviewer-facing Markdown report. Deterministic: it intentionally carries
+  /// no wall-clock timestamp, so two runs over the same dataset are
+  /// byte-identical (any diff in the artifact is real behaviour drift).
+  ///
+  /// [archetypeNotes] maps a case's first focus tag to a short explanation of
+  /// what the archetype represents and why Local AI is allowed or blocked.
+  String toReviewerMarkdown({
+    Map<String, String> archetypeNotes = const <String, String>{},
+  }) {
+    final buffer = StringBuffer()
+      ..writeln('# Local AI Scenario Replay — Reviewer Report')
+      ..writeln()
+      ..writeln('Dataset version: `$datasetVersion`')
+      ..writeln()
+      ..writeln('Educational prototype; synthetic fixtures only. This replay '
+          'runs the same conservative + hybrid recommendation orchestrators '
+          'the app uses, with an offline scripted Local AI stand-in. It is '
+          'engineering review material, not medical advice and not a '
+          'clinical evaluation.')
+      ..writeln()
+      ..writeln('## How to read this report')
+      ..writeln()
+      ..writeln('- **Invariant checked:** the Local AI path may only *reorder* '
+          'the deterministic candidate whitelist. "AI preserved candidate '
+          'set: yes" means no candidate was invented or dropped; a "NO" '
+          'means the safety invariant was violated and the run fails.')
+      ..writeln('- **Gate reasons:** when present, the deterministic safety '
+          'gate held the conservative ranking and Local AI was limited to '
+          'wording polish.')
+      ..writeln('- **Drift:** this artifact is timestamp-free and '
+          'deterministic. If a regenerated report differs from the committed '
+          'or previously reviewed one, engine/gate/scenario behaviour '
+          'changed and the diff should be reviewed, not regenerated away.')
+      ..writeln()
+      ..writeln('Candidate-set invariant held for all cases: '
+          '**${allPreservedCandidateSet ? 'yes' : 'NO'}**')
+      ..writeln();
+    for (final c in cases) {
+      final tag = c.benchmarkCase.focusTags.isEmpty
+          ? ''
+          : c.benchmarkCase.focusTags.first;
+      buffer
+        ..writeln(c.toReviewerMarkdown(archetypeNote: archetypeNotes[tag]))
+        ..writeln();
+    }
+    return buffer.toString();
+  }
 
   /// Deterministic structured snapshot. `generated_at` is intentionally
   /// excluded from [cases] so the case array is stable across runs; callers

--- a/test/helpers/local_ai_replay_harness.dart
+++ b/test/helpers/local_ai_replay_harness.dart
@@ -1,0 +1,130 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:parkinsum_companion/core/analysis/food_repository.dart';
+import 'package:parkinsum_companion/core/analysis/medication_repository.dart';
+import 'package:parkinsum_companion/core/db/cdss_database_memory.dart';
+import 'package:parkinsum_companion/domain/usecases/cdss_catalog_projection_service.dart';
+import 'package:parkinsum_companion/domain/usecases/get_food_recommendations_usecase.dart';
+import 'package:parkinsum_companion/domain/usecases/local_ai_recommendation_adapter.dart';
+import 'package:parkinsum_companion/domain/usecases/next_meal_recommendation_orchestrator.dart';
+import 'package:parkinsum_companion/domain/usecases/recommendation_replay_runner.dart';
+
+/// Shared offline replay harness for the Local AI scenario tests.
+///
+/// [buildScriptedLocalAiClient] is a deterministic Local AI stand-in: it
+/// reports the model available, returns safe wording-polish notes, and reranks
+/// only by reversing the supplied safe whitelist. It never adds/drops candidate
+/// ids and never emits unsafe copy, so the replay exercises the AI path with
+/// zero network access. Educational prototype; synthetic fixtures; no PHI.
+MockClient buildScriptedLocalAiClient() {
+  List<String> jsonArrayAfter(String prompt, String marker) {
+    final start = prompt.indexOf(marker);
+    if (start < 0) return const <String>[];
+    final rest = prompt.substring(start + marker.length);
+    final open = rest.indexOf('[');
+    final close = rest.indexOf(']');
+    if (open < 0 || close < 0 || close < open) return const <String>[];
+    return (jsonDecode(rest.substring(open, close + 1)) as List<dynamic>)
+        .map((e) => e.toString())
+        .toList(growable: false);
+  }
+
+  return MockClient((request) async {
+    if (request.method == 'GET' && request.url.path == '/api/tags') {
+      return http.Response(
+        jsonEncode({
+          'models': [
+            {'name': 'gemma3n:e2b', 'model': 'gemma3n:e2b'},
+            {
+              'name': 'hf.co/unsloth/medgemma-1.5-4b-it-GGUF:Q4_K_M',
+              'model': 'hf.co/unsloth/medgemma-1.5-4b-it-GGUF:Q4_K_M',
+            },
+          ],
+        }),
+        200,
+      );
+    }
+    final body = jsonDecode(request.body) as Map<String, dynamic>;
+    final content =
+        ((body['messages'] as List).first['content'] ?? '').toString();
+
+    if (content.contains('reply with {"ok":true}')) {
+      return http.Response(
+        jsonEncode({
+          'message': {'content': '{"ok":true}'}
+        }),
+        200,
+      );
+    }
+
+    if (content.contains('polishing ParkinSUM next-meal')) {
+      final ids = jsonArrayAfter(content, 'Allowed food_id keys JSON: ');
+      return http.Response(
+        jsonEncode({
+          'message': {
+            'content': jsonEncode({
+              'summary':
+                  'Local AI polished the wording; the safe order is unchanged.',
+              'candidate_notes': {
+                for (final id in ids) id: 'A plain-language reason for $id.',
+              },
+            })
+          }
+        }),
+        200,
+      );
+    }
+
+    if (content.contains('reranking already-safe')) {
+      final allowed = jsonArrayAfter(content, 'Allowed candidate_ids JSON: ');
+      final reversed = allowed.reversed.toList(growable: false);
+      return http.Response(
+        jsonEncode({
+          'message': {
+            'content': jsonEncode({
+              'candidate_ids': reversed,
+              'summary': 'Local AI replay reranked only the safe whitelist.',
+              'safety_checks': ['Preserved the safe whitelist only.'],
+              'ranking_rationale': ['Used the provided candidate features.'],
+            })
+          }
+        }),
+        200,
+      );
+    }
+
+    return http.Response(
+      jsonEncode({
+        'message': {'content': '{}'}
+      }),
+      200,
+    );
+  });
+}
+
+/// Builds the deterministic + hybrid orchestrator pair around the scripted
+/// offline Local AI and the in-memory CDSS database, wired exactly like the
+/// scenario replay tests expect.
+RecommendationReplayRunner buildLocalAiReplayRunner() {
+  const projection =
+      CdssCatalogProjectionService(database: InMemoryCdssDatabase());
+  final hybrid = NextMealRecommendationOrchestrator(
+    conservativeRecommender: GetFoodRecommendationsUseCase(),
+    projectionService: projection,
+    localAiAdapter:
+        LocalAiRecommendationAdapter(client: buildScriptedLocalAiClient()),
+  );
+  final deterministic = NextMealRecommendationOrchestrator(
+    conservativeRecommender: GetFoodRecommendationsUseCase(),
+    projectionService: projection,
+    localAiAdapter: null,
+  );
+  return RecommendationReplayRunner(
+    hybridOrchestrator: hybrid,
+    deterministicOrchestrator: deterministic,
+    foodRepository: FoodRepository.createDefault(),
+    medicationRepository: MedicationRepository.createDefault(),
+  );
+}

--- a/test/local_ai_replay_report_test.dart
+++ b/test/local_ai_replay_report_test.dart
@@ -1,0 +1,142 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkinsum_companion/core/constants/local_ai_replay_scenarios.dart';
+import 'package:parkinsum_companion/domain/entities/recommendation_replay_models.dart';
+import 'package:parkinsum_companion/domain/entities/rule_explanation.dart';
+
+import 'helpers/local_ai_replay_harness.dart';
+
+/// Reviewer-friendly replay report workflow.
+///
+/// Running this file is the one-command way to (re)generate and verify the
+/// deterministic reviewer artifact for the five Local-AI replay archetypes:
+///
+///   flutter test test/local_ai_replay_report_test.dart
+///
+/// It writes `build/recommendation_scenario_replay/latest.json` and
+/// `latest.md` (both timestamp-free, so regenerated artifacts diff cleanly)
+/// and asserts the report's content, determinism, and safety-copy hygiene.
+/// Educational prototype only; synthetic fixtures; no PHI.
+void main() {
+  const outDirPath = 'build/recommendation_scenario_replay';
+
+  Future<RecommendationReplayRunReport> generate() =>
+      buildLocalAiReplayRunner().run(dataset: localAiReplayScenarioDataset);
+
+  String jsonOf(RecommendationReplayRunReport r) =>
+      const JsonEncoder.withIndent('  ').convert(r.toJson());
+
+  String markdownOf(RecommendationReplayRunReport r) =>
+      r.toReviewerMarkdown(archetypeNotes: localAiReplayArchetypeNotes);
+
+  test('writes the deterministic reviewer artifact (JSON + Markdown)',
+      () async {
+    final report = await generate();
+    final outDir = Directory(outDirPath);
+    if (!outDir.existsSync()) outDir.createSync(recursive: true);
+    File('$outDirPath/latest.json').writeAsStringSync(jsonOf(report));
+    File('$outDirPath/latest.md').writeAsStringSync(markdownOf(report));
+
+    expect(File('$outDirPath/latest.json').existsSync(), isTrue);
+    expect(File('$outDirPath/latest.md').existsSync(), isTrue);
+  });
+
+  test('report covers all five archetypes with the required fields', () async {
+    final report = await generate();
+    final md = markdownOf(report);
+    final json = jsonDecode(jsonOf(report)) as Map<String, dynamic>;
+
+    expect((json['cases'] as List), hasLength(5));
+    for (final caseId in const [
+      'replay_missing_medication_time_or_dose',
+      'replay_low_risk_next_meal',
+      'replay_source_fallback_partial_provenance',
+      'replay_safety_gate_blocks_local_ai',
+      'replay_medication_catalog_selection_context',
+    ]) {
+      expect(md, contains('## $caseId'),
+          reason: 'Markdown is missing the $caseId section');
+    }
+    // Every archetype note is surfaced for its case.
+    for (final note in localAiReplayArchetypeNotes.values) {
+      expect(md, contains(note.split('. ').first),
+          reason: 'Markdown is missing an archetype explanation');
+    }
+    // Per-case required fields exist in the JSON snapshot.
+    for (final raw in json['cases'] as List) {
+      final c = raw as Map<String, dynamic>;
+      for (final key in const [
+        'case_id',
+        'focus_tags',
+        'deterministic_ranking',
+        'ai_ranking',
+        'decision_path',
+        'ai_used',
+        'gate_reasons',
+        'ai_preserved_candidate_set',
+        'matched_expected_top_food_ids',
+        'missing_expected_top_food_ids',
+      ]) {
+        expect(c.containsKey(key), isTrue,
+            reason: 'JSON case ${c['case_id']} is missing `$key`');
+      }
+    }
+  });
+
+  test('reviewer Markdown is deterministic across runs (drift guard)',
+      () async {
+    final a = markdownOf(await generate());
+    final b = markdownOf(await generate());
+    expect(a, b, reason: 'Reviewer Markdown drifted between identical runs.');
+    // No wall-clock leakage: the deterministic artifacts must not embed a
+    // generated-at timestamp.
+    expect(a, isNot(contains('Generated at')));
+    expect(a, isNot(contains(RegExp(r'20\d{2}-\d{2}-\d{2}T'))));
+  });
+
+  test('report contains no banned prescriptive or public-claim phrases',
+      () async {
+    final report = await generate();
+    final blob = '${markdownOf(report)}\n${jsonOf(report)}';
+    expect(findBannedSubstrings(blob), isEmpty,
+        reason: 'Replay report contains banned prescriptive copy.');
+    for (final phrase in const [
+      'clinically validated',
+      'medical device',
+      'patient-calibrated',
+      'safe for you',
+    ]) {
+      expect(blob.toLowerCase(), isNot(contains(phrase)),
+          reason: 'Replay report contains public-claim phrase "$phrase".');
+    }
+  });
+
+  test('candidate-set invariant and gate reasons are visible to reviewers',
+      () async {
+    final report = await generate();
+    final md = markdownOf(report);
+
+    // The invariant is stated up front and per case.
+    expect(md, contains('Candidate-set invariant held for all cases: **yes**'));
+    expect('AI preserved candidate set'.allMatches(md).length,
+        greaterThanOrEqualTo(5));
+    expect(md, isNot(contains('invariant violated')));
+
+    // Blocked scenarios surface their gate reasons in the Markdown.
+    for (final c in report.cases.where((c) => c.gateReasons.isNotEmpty)) {
+      for (final reason in c.gateReasons) {
+        expect(md, contains(reason),
+            reason:
+                '${c.benchmarkCase.caseId} gate reason missing from Markdown');
+      }
+    }
+    // And the two gate-blocked archetypes are visibly non-AI-reranked.
+    final gated = report.cases.firstWhere(
+        (c) => c.benchmarkCase.caseId == 'replay_safety_gate_blocks_local_ai');
+    expect(gated.gateReasons, isNotEmpty);
+    expect(
+        md, contains('the deterministic gate held the conservative ranking'));
+  });
+}

--- a/test/local_ai_scenario_replay_test.dart
+++ b/test/local_ai_scenario_replay_test.dart
@@ -1,141 +1,23 @@
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:http/http.dart' as http;
-import 'package:http/testing.dart';
-import 'package:parkinsum_companion/core/analysis/food_repository.dart';
-import 'package:parkinsum_companion/core/analysis/medication_repository.dart';
 import 'package:parkinsum_companion/core/constants/local_ai_replay_scenarios.dart';
-import 'package:parkinsum_companion/core/db/cdss_database_memory.dart';
-import 'package:parkinsum_companion/domain/usecases/cdss_catalog_projection_service.dart';
-import 'package:parkinsum_companion/domain/usecases/get_food_recommendations_usecase.dart';
-import 'package:parkinsum_companion/domain/usecases/local_ai_recommendation_adapter.dart';
-import 'package:parkinsum_companion/domain/usecases/next_meal_recommendation_orchestrator.dart';
-import 'package:parkinsum_companion/domain/usecases/recommendation_replay_runner.dart';
+
+import 'helpers/local_ai_replay_harness.dart';
 
 /// P1 — Synthetic scenario replay system.
 ///
 /// Replays the five fixed Local-AI scenario archetypes through the real
 /// deterministic + hybrid orchestrators with an offline, scripted Local AI
-/// (MockClient). Asserts per-archetype decision paths, a Local-AI safety
-/// invariant (the AI path may only reorder the deterministic candidate set),
-/// and that the structured JSON snapshot is byte-stable across runs (drift
-/// guard). Educational prototype only; synthetic fixtures; no PHI.
+/// (see `helpers/local_ai_replay_harness.dart`). Asserts per-archetype decision
+/// paths, a Local-AI safety invariant (the AI path may only reorder the
+/// deterministic candidate set), and that the structured JSON snapshot is
+/// byte-stable across runs (drift guard). Educational prototype only;
+/// synthetic fixtures; no PHI.
 void main() {
-  /// Scripted offline Local AI: reports the model available, polishes wording
-  /// with safe notes, and reranks by reversing the safe whitelist order. It
-  /// never adds/drops ids or injects unsafe copy.
-  MockClient buildScriptedClient() {
-    List<String> jsonArrayAfter(String prompt, String marker) {
-      final start = prompt.indexOf(marker);
-      if (start < 0) return const <String>[];
-      final rest = prompt.substring(start + marker.length);
-      final open = rest.indexOf('[');
-      final close = rest.indexOf(']');
-      if (open < 0 || close < 0 || close < open) return const <String>[];
-      return (jsonDecode(rest.substring(open, close + 1)) as List<dynamic>)
-          .map((e) => e.toString())
-          .toList(growable: false);
-    }
-
-    return MockClient((request) async {
-      if (request.method == 'GET' && request.url.path == '/api/tags') {
-        return http.Response(
-          jsonEncode({
-            'models': [
-              {'name': 'gemma3n:e2b', 'model': 'gemma3n:e2b'},
-              {
-                'name': 'hf.co/unsloth/medgemma-1.5-4b-it-GGUF:Q4_K_M',
-                'model': 'hf.co/unsloth/medgemma-1.5-4b-it-GGUF:Q4_K_M',
-              },
-            ],
-          }),
-          200,
-        );
-      }
-      final body = jsonDecode(request.body) as Map<String, dynamic>;
-      final content =
-          ((body['messages'] as List).first['content'] ?? '').toString();
-
-      if (content.contains('reply with {"ok":true}')) {
-        return http.Response(
-          jsonEncode({
-            'message': {'content': '{"ok":true}'}
-          }),
-          200,
-        );
-      }
-
-      if (content.contains('polishing ParkinSUM next-meal')) {
-        final ids = jsonArrayAfter(content, 'Allowed food_id keys JSON: ');
-        return http.Response(
-          jsonEncode({
-            'message': {
-              'content': jsonEncode({
-                'summary':
-                    'Local AI polished the wording; the safe order is unchanged.',
-                'candidate_notes': {
-                  for (final id in ids) id: 'A plain-language reason for $id.',
-                },
-              })
-            }
-          }),
-          200,
-        );
-      }
-
-      if (content.contains('reranking already-safe')) {
-        final allowed = jsonArrayAfter(content, 'Allowed candidate_ids JSON: ');
-        final reversed = allowed.reversed.toList(growable: false);
-        return http.Response(
-          jsonEncode({
-            'message': {
-              'content': jsonEncode({
-                'candidate_ids': reversed,
-                'summary': 'Local AI replay reranked only the safe whitelist.',
-                'safety_checks': ['Preserved the safe whitelist only.'],
-                'ranking_rationale': ['Used the provided candidate features.'],
-              })
-            }
-          }),
-          200,
-        );
-      }
-
-      return http.Response(
-        jsonEncode({
-          'message': {'content': '{}'}
-        }),
-        200,
-      );
-    });
-  }
-
-  RecommendationReplayRunner buildRunner() {
-    const projection =
-        CdssCatalogProjectionService(database: InMemoryCdssDatabase());
-    final hybrid = NextMealRecommendationOrchestrator(
-      conservativeRecommender: GetFoodRecommendationsUseCase(),
-      projectionService: projection,
-      localAiAdapter:
-          LocalAiRecommendationAdapter(client: buildScriptedClient()),
-    );
-    final deterministic = NextMealRecommendationOrchestrator(
-      conservativeRecommender: GetFoodRecommendationsUseCase(),
-      projectionService: projection,
-      localAiAdapter: null,
-    );
-    return RecommendationReplayRunner(
-      hybridOrchestrator: hybrid,
-      deterministicOrchestrator: deterministic,
-      foodRepository: FoodRepository.createDefault(),
-      medicationRepository: MedicationRepository.createDefault(),
-    );
-  }
-
   test('replays the five archetypes with expected decision paths', () async {
-    final report =
-        await buildRunner().run(dataset: localAiReplayScenarioDataset);
+    final report = await buildLocalAiReplayRunner()
+        .run(dataset: localAiReplayScenarioDataset);
     expect(report.cases, hasLength(5));
 
     final byId = {for (final c in report.cases) c.benchmarkCase.caseId: c};
@@ -169,23 +51,24 @@ void main() {
 
   test('Local AI never changes the deterministic candidate set (safety)',
       () async {
-    final report =
-        await buildRunner().run(dataset: localAiReplayScenarioDataset);
+    final report = await buildLocalAiReplayRunner()
+        .run(dataset: localAiReplayScenarioDataset);
     expect(report.allPreservedCandidateSet, isTrue);
     for (final c in report.cases) {
       // Whatever the AI did, the resulting set of food ids equals the
       // deterministic set (reorder-only; never invent or drop).
       expect(c.aiRanking.toSet(), c.deterministicRanking.toSet(),
           reason: '${c.benchmarkCase.caseId} changed the candidate set');
+      expect(c.aiPreservedCandidateSet, isTrue);
     }
   });
 
   test('structured JSON snapshot is byte-stable across runs (drift guard)',
       () async {
-    final first =
-        await buildRunner().run(dataset: localAiReplayScenarioDataset);
-    final second =
-        await buildRunner().run(dataset: localAiReplayScenarioDataset);
+    final first = await buildLocalAiReplayRunner()
+        .run(dataset: localAiReplayScenarioDataset);
+    final second = await buildLocalAiReplayRunner()
+        .run(dataset: localAiReplayScenarioDataset);
     final a = const JsonEncoder.withIndent('  ').convert(first.toJson());
     final b = const JsonEncoder.withIndent('  ').convert(second.toJson());
     expect(a, b, reason: 'Replay output drifted between identical runs.');


### PR DESCRIPTION
## Summary

Next engineering-core increment on top of the replay work (#86/#87): a reviewer
can now run **one focused test command** and get a clear, deterministic report
for the five Local-AI replay archetypes. No orchestrator changes; the safety
boundary is unchanged.

```sh
flutter test test/local_ai_replay_report_test.dart
```

writes `build/recommendation_scenario_replay/latest.md` + `latest.json` (both
timestamp-free → byte-identical on unchanged code) and verifies their content.

## Changes

- **`recommendation_replay_models.dart`** — the candidate-set safety invariant
  becomes a real `aiPreservedCandidateSet` getter (was only computed inside
  `toJson`), and a new `toReviewerMarkdown` renders the reviewer report: a
  "how to read this" preamble (what the invariant means, why gate reasons
  appear, what drift implies), then one table per case with focus tags,
  deterministic vs AI ranking, decision path, AI used, gate reasons, invariant
  status, matched/missing expected ids, a why-allowed/why-blocked line, and a
  non-clinical safety note.
- **`local_ai_replay_scenarios.dart`** — `localAiReplayArchetypeNotes`:
  reviewer-facing notes per archetype (what it represents, why Local AI is
  expected to be allowed or blocked).
- **`test/helpers/local_ai_replay_harness.dart`** — the scripted offline Local
  AI MockClient + runner wiring, extracted from the scenario test so both
  replay tests share one harness (the scenario test now imports it; its
  assertions are unchanged).
- **`test/local_ai_replay_report_test.dart`** — the one-command entry point.
  Asserts: all five archetypes appear with the required fields; the Markdown is
  deterministic across runs and contains no wall-clock timestamps; no banned
  prescriptive or public-claim phrases; the candidate-set invariant is visible;
  blocked scenarios show their gate reasons.
- **`docs/LOCAL_AI_REPLAY_REPORT.md`** — short how-to with the exact command,
  artifact paths, drift semantics, and the documented reason a `dart run` CLI
  stays future work (`app_i18n` transitively imports Flutter).

## Safety

Educational prototype only; synthetic fixtures; deterministic outputs; no
medical advice / timing / dietary guidance; no clinical claims; no PHI, emails,
tokens, or private paths in the artifacts. Report copy is scanned against the
banned-phrase list in tests.

## Validation

- `dart format` on changed files → clean (re-checked with `--set-exit-if-changed`-equivalent run)
- `flutter analyze` → No issues found
- `flutter test test/local_ai_replay_report_test.dart test/local_ai_scenario_replay_test.dart` → 8 passed
- `flutter test --concurrency=1` → **721 passed**
- `npm run public:preflight` → 0 BLOCKER (and `privacy:preflight` → 0 blocker)
- `git diff --check` → clean
- Artifacts confirmed gitignored under `build/`

## Follow-ups

- A `dart run` replay CLI still requires a Flutter-free import path for the
  orchestrator (`app_i18n` imports Flutter) — documented in the new doc.
- The archetype-notes map could later be folded into the benchmark case model
  itself if more datasets adopt reviewer reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)