### PR TITLE
[codex] Clean up reviewer safety wording after #89

### DIFF
--- a/lib/domain/usecases/evidence_graph_builder.dart
+++ b/lib/domain/usecases/evidence_graph_builder.dart
@@ -3,7 +3,7 @@
 /// Educational/research prototype only. Synthetic/demo artifacts only. Builds a
 /// deterministic **local** evidence/provenance graph from already-produced
 /// ParkinSUM artifacts. It is NOT a FHIR Provenance resource, NOT a W3C PROV
-/// export, NOT a patient record, not clinically calibrated, and not medical
+/// export, NOT a patient record, not calibrated for real care, and not medical
 /// advice. Inputs are parsed artifact maps (file I/O stays in the tool wrapper);
 /// a missing input becomes a `missing_artifact` node, never a fabricated success.
 library;
@@ -50,7 +50,7 @@ class EvidenceGraphBuilder {
     'Local educational traceability artifact composed from synthetic/demo artifacts only.',
     'Not a FHIR Provenance resource and not a W3C PROV export.',
     'Not a patient record; no patient/subject/encounter linkage.',
-    'Not clinical validation; the model is not clinically calibrated.',
+    'Not clinical validation; the model is not calibrated for real care.',
     'Missing inputs are represented as missing_artifact nodes, never fabricated.',
   ];
 
@@ -76,7 +76,7 @@ class EvidenceGraphBuilder {
       type: 'mechanistic_layer',
       label: 'Mechanistic layer',
       summary: 'Deterministic, literature-informed educational conflict '
-          'simulation (not clinically calibrated; no PK/PD prediction).',
+          'simulation (not calibrated for real care; no PK/PD prediction).',
       status: 'present',
     );
     const metadataGate = EvidenceGraphNode(
@@ -108,7 +108,7 @@ class EvidenceGraphBuilder {
       type: 'limitation',
       label: 'Limitations',
       summary: 'Local evidence graph; synthetic/demo only; not FHIR/PROV '
-          'conformant; not clinical validation; not clinically calibrated.',
+          'conformant; not clinical validation; not calibrated for real care.',
       status: 'present',
     );
 

--- a/lib/domain/usecases/release_snapshot_generator.dart
+++ b/lib/domain/usecases/release_snapshot_generator.dart
@@ -1,7 +1,8 @@
 /// P12 — ReleaseSnapshotGenerator.
 ///
 /// Educational/research prototype only. Synthetic/demo data only. Not medical
-/// advice, not clinically calibrated, and carries no clinical-validation claim.
+/// advice, not calibrated for real care, and carries no clinical-validation
+/// claim.
 ///
 /// Composes **existing** verification artifacts into one reproducible release
 /// evidence snapshot. It is a **pure** transform: it parses already-produced
@@ -111,7 +112,7 @@ class ReleaseSnapshot {
 
   static const List<String> knownLimitations = [
     'Deterministic synthetic-data regression + governance evidence only.',
-    'Not clinical validation; the model is not clinically calibrated.',
+    'Not clinical validation; the model is not calibrated for real care.',
     'Importer adapters are fixture-validated, not live production ingestion.',
     'Counts are composed from existing artifacts; missing inputs are recorded '
         'as missing_artifact, never fabricated.',
@@ -146,7 +147,7 @@ class ReleaseSnapshot {
       ..writeln('# ParkinSUM Release Snapshot')
       ..writeln()
       ..writeln('Educational/research prototype. Synthetic/demo data only. '
-          '**Not medical advice, not clinically calibrated, and carries no '
+          '**Not medical advice, not calibrated for real care, and carries no '
           'clinical-validation claim.**')
       ..writeln()
       ..writeln('Composed from existing verification artifacts. Missing inputs '

--- a/test/evidence_graph_builder_test.dart
+++ b/test/evidence_graph_builder_test.dart
@@ -173,6 +173,18 @@ void main() {
     expect(g.limitations, isNotEmpty);
   });
 
+  test('human-facing summaries use real-care calibration wording', () {
+    final g = builder.build(fullInputs());
+    final humanText = [
+      for (final node in g.nodes) node.summary,
+      ...g.limitations,
+    ].join('\n').toLowerCase();
+    expect(humanText, contains('not calibrated for real care'));
+    expect(humanText, isNot(contains('not clinically calibrated')));
+    // The machine-readable compatibility field remains in JSON.
+    expect(g.toJson()['not_clinically_calibrated'], isTrue);
+  });
+
   test('7. no patient / subject / encounter / clinical-workflow KEYS', () {
     // Recursive key-level scan (phi_policy VALUE may name what is omitted).
     scanNoPhiKeys(builder.build(fullInputs()).toJson());

--- a/test/release_snapshot_generator_test.dart
+++ b/test/release_snapshot_generator_test.dart
@@ -82,6 +82,15 @@ void main() {
     expect(json['complete'], isTrue);
   });
 
+  test('reviewer-facing Markdown uses real-care calibration wording', () {
+    final md = gen.build(fullInputs()).toMarkdown();
+    expect(md, contains('not calibrated for real care'));
+    expect(md.toLowerCase(), isNot(contains('not clinically calibrated')));
+    // The machine-readable compatibility key remains in JSON.
+    expect(
+        gen.build(fullInputs()).toJson()['not_clinically_calibrated'], isTrue);
+  });
+
   test('missing artifacts produce missing_artifact, not fabricated success',
       () {
     const empty = ReleaseSnapshotInputs();


### PR DESCRIPTION
## Summary

Follow-up to already-merged PR #89. This keeps the scope narrow and only cleans up reviewer-facing safety wording.

- Replaces human-facing release snapshot wording with `not calibrated for real care`.
- Replaces human-facing evidence graph summaries/limitations with the same wording.
- Preserves the existing machine-readable `not_clinically_calibrated` compatibility key in JSON.
- Adds regression tests so human-facing release snapshot/evidence graph text does not drift back to `not clinically calibrated` while schema guardrails remain intact.

## Validation

- `dart format --set-exit-if-changed .`
- `flutter analyze`
- `flutter test test/release_snapshot_generator_test.dart test/evidence_graph_builder_test.dart test/local_ai_replay_report_test.dart`
- `flutter test --concurrency=1` (744 passed)
- `npm run public:preflight` (0 BLOCKER)
- `npm run privacy:preflight` (0 blocker)
- `git diff --check`

## Notes

`pubspec.lock` was touched by Flutter dependency resolution during validation and was restored; it is intentionally not part of this PR.
