### PR TITLE
Follow-ups: dart-run replay CLI via pure-Dart i18n split + page-level a11y audit

### DIFF
--- a/docs/LOCAL_AI_REPLAY_REPORT.md
+++ b/docs/LOCAL_AI_REPLAY_REPORT.md
@@ -25,10 +25,13 @@ candidate, and it never overrides gate decisions.
 ## How to run
 
 ```sh
+npm run recommend:replay
+# or, equivalently (also verifies the report content):
 flutter test test/local_ai_replay_report_test.dart
 ```
 
-This one command regenerates and verifies the reviewer artifact:
+Either command regenerates the reviewer artifact (both entry points produce
+byte-identical files; the focused test additionally asserts the content):
 
 - `build/recommendation_scenario_replay/latest.md` — reviewer Markdown (per
   archetype: rankings, decision path, gate reasons, invariant status,
@@ -54,9 +57,12 @@ byte-stability) live in:
 flutter test test/local_ai_scenario_replay_test.dart
 ```
 
-## Why there is no `dart run` CLI
+## CLI notes
 
-The orchestrator transitively imports Flutter via `app_i18n`, so a plain-Dart
-CLI cannot compile without a larger i18n refactor. The focused test above is
-the supported one-command entry point; a Flutter-free import path for the
-orchestrator remains documented future work.
+`npm run recommend:replay` runs `tool/run_recommendation_scenario_replay.dart`
+under plain `dart run` (no device, no network, no real model). This became
+possible after the Flutter-facing i18n members (`BuildContext` access and
+`Locale` mapping) were split into `lib/core/i18n/app_i18n_context.dart`,
+leaving `app_i18n.dart` — and therefore the whole recommendation stack — pure
+Dart. The CLI exits non-zero iff the Local-AI candidate-set invariant is
+violated.

--- a/docs/PUBLIC_VERIFICATION.md
+++ b/docs/PUBLIC_VERIFICATION.md
@@ -76,10 +76,11 @@ results.
 
 ### Recommended reviewer order
 
-1. `flutter test test/local_ai_replay_report_test.dart` — regenerates the
-   deterministic Local-AI scenario replay artifact. Proves the Local-AI
-   candidate-set invariant held over the five synthetic archetypes; does NOT
-   prove model quality or real-care behaviour.
+1. `npm run recommend:replay` (or `flutter test
+   test/local_ai_replay_report_test.dart`) — regenerates the deterministic
+   Local-AI scenario replay artifact; both entry points produce byte-identical
+   files. Proves the Local-AI candidate-set invariant held over the five
+   synthetic archetypes; does NOT prove model quality or real-care behaviour.
 2. `npm run release:snapshot` — composes all artifacts into one evidence
    summary. Proves which artifacts exist and what they reported; does NOT
    re-run any check.
@@ -100,7 +101,7 @@ calibrated for real care.
   `build/source_quality_perturbation/latest.json`,
   `build/public_release_preflight/latest.json`, and
   `build/recommendation_scenario_replay/latest.json` (generate the last one with
-  `flutter test test/local_ai_replay_report_test.dart`); analyze/test/firestore
+  `npm run recommend:replay`); analyze/test/firestore
   results may be injected via flags (e.g. `--analyze=clean --test-count=460
   --firestore=13/13`).
 - **Expected:** `build/release_snapshot/latest.{json,md}` with a per-check table;

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
 
-import '../core/i18n/app_i18n.dart';
+import '../core/i18n/app_i18n_context.dart';
 import '../core/services/services.dart';
 import '../core/state/app_state.dart';
 import '../core/theme/liquid_glass_theme.dart';
@@ -32,7 +32,7 @@ class ParkinSUMApp extends StatelessWidget {
         builder: (context, state, _) => MaterialApp(
           key: ValueKey<String>(state.userProfile.displayLocale),
           debugShowCheckedModeBanner: false,
-          locale: AppI18n.toLocale(state.userProfile.displayLocale),
+          locale: appI18nLocaleFor(state.userProfile.displayLocale),
           supportedLocales: const [
             // Originally supported.
             Locale('zh', 'CN'),

--- a/lib/core/i18n/app_i18n.dart
+++ b/lib/core/i18n/app_i18n.dart
@@ -1,7 +1,3 @@
-import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-
-import '../state/app_state.dart';
 import 'app_i18n_full_translations.dart';
 
 /// Lightweight in-app localization layer.
@@ -16,25 +12,6 @@ class AppI18n {
 
   factory AppI18n.fromLocaleTag(String localeTag) {
     return AppI18n._(localeTag);
-  }
-
-  static AppI18n of(BuildContext context) {
-    // 这里不能再用 context.select/watch：
-    // EntryPage 等页面会在 didChangeDependencies、保存回调、弹窗动作里读取 i18n，
-    // 若继续依赖 provider 的 build-phase API，会触发
-    // “Tried to use context.select outside of the build method” 断言。
-    // 因此统一改成 listen:false 的只读访问，让 build 内外都能安全取当前 locale。
-    final localeTag =
-        Provider.of<AppState>(context, listen: false).userProfile.displayLocale;
-    return AppI18n.fromLocaleTag(localeTag);
-  }
-
-  static Locale toLocale(String localeTag) {
-    final parts = localeTag.split('-');
-    if (parts.length >= 2) {
-      return Locale(parts[0], parts[1]);
-    }
-    return Locale(parts.first);
   }
 
   String get languageFamily {
@@ -455,10 +432,6 @@ class AppI18n {
     final familyMap = _strings[languageFamily] ?? _strings['en']!;
     return familyMap[key] ?? value;
   }
-}
-
-extension AppI18nBuildContext on BuildContext {
-  AppI18n get appI18n => AppI18n.of(this);
 }
 
 /// Family → flatKey → translatedString.

--- a/lib/core/i18n/app_i18n_context.dart
+++ b/lib/core/i18n/app_i18n_context.dart
@@ -1,0 +1,40 @@
+/// Flutter-facing access to [AppI18n].
+///
+/// [AppI18n] itself is pure Dart (so non-Flutter tools — e.g. the Local-AI
+/// scenario replay CLI — can compile the recommendation stack with `dart run`).
+/// Everything that needs `BuildContext`, `Locale`, or the `AppState` provider
+/// lives here instead. UI code imports THIS file; pure-Dart code imports
+/// `app_i18n.dart` directly.
+library;
+
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+
+import '../state/app_state.dart';
+import 'app_i18n.dart';
+
+export 'app_i18n.dart';
+
+/// Maps a BCP-47-ish tag (e.g. `en-US`) to a Flutter [Locale].
+Locale appI18nLocaleFor(String localeTag) {
+  final parts = localeTag.split('-');
+  if (parts.length >= 2) {
+    return Locale(parts[0], parts[1]);
+  }
+  return Locale(parts.first);
+}
+
+extension AppI18nBuildContext on BuildContext {
+  /// Resolves the current [AppI18n] from the user profile's display locale.
+  ///
+  /// 这里不能再用 context.select/watch：
+  /// EntryPage 等页面会在 didChangeDependencies、保存回调、弹窗动作里读取 i18n，
+  /// 若继续依赖 provider 的 build-phase API，会触发
+  /// “Tried to use context.select outside of the build method” 断言。
+  /// 因此统一改成 listen:false 的只读访问，让 build 内外都能安全取当前 locale。
+  AppI18n get appI18n {
+    final localeTag =
+        Provider.of<AppState>(this, listen: false).userProfile.displayLocale;
+    return AppI18n.fromLocaleTag(localeTag);
+  }
+}

--- a/lib/features/analytics/analytics_page.dart
+++ b/lib/features/analytics/analytics_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../core/copy/response_copy_service.dart';
-import '../../core/i18n/app_i18n.dart';
+import '../../core/i18n/app_i18n_context.dart';
 import '../../core/state/app_state.dart';
 import '../../core/theme/liquid_glass_theme.dart';
 import '../../domain/usecases/local_ai_recommendation_adapter.dart';

--- a/lib/features/catalog/catalog_detail_pages.dart
+++ b/lib/features/catalog/catalog_detail_pages.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../../core/i18n/app_i18n.dart';
+import '../../core/i18n/app_i18n_context.dart';
 import '../../core/models/drug_definition.dart';
 import '../../core/models/food_item.dart';
 import '../../domain/usecases/cdss_catalog_projection_service.dart';

--- a/lib/features/catalog/catalog_page.dart
+++ b/lib/features/catalog/catalog_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../../core/i18n/app_i18n.dart';
+import '../../core/i18n/app_i18n_context.dart';
 import '../../core/models/food_item.dart';
 import '../../core/state/app_state.dart';
 import '../../core/theme/liquid_glass_theme.dart';

--- a/lib/features/entry/entry_page.dart
+++ b/lib/features/entry/entry_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../../core/i18n/app_i18n.dart';
+import '../../core/i18n/app_i18n_context.dart';
 import '../../core/models/food_item.dart';
 import '../../core/models/meal.dart';
 import '../../core/state/app_state.dart';

--- a/lib/features/import/import_page.dart
+++ b/lib/features/import/import_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../../core/i18n/app_i18n.dart';
+import '../../core/i18n/app_i18n_context.dart';
 import '../../core/state/app_state.dart';
 
 /// 本地 P0 导入页：

--- a/lib/features/main_shell/dashboard_page.dart
+++ b/lib/features/main_shell/dashboard_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../core/copy/response_copy_service.dart';
-import '../../core/i18n/app_i18n.dart';
+import '../../core/i18n/app_i18n_context.dart';
 import '../../core/models/meal.dart';
 import '../../core/state/app_state.dart';
 import '../../domain/entities/food_recommendation.dart';

--- a/lib/features/main_shell/main_shell.dart
+++ b/lib/features/main_shell/main_shell.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../core/services/firebase_backend.dart';
-import '../../core/i18n/app_i18n.dart';
+import '../../core/i18n/app_i18n_context.dart';
 import '../../core/state/app_state.dart';
 import '../../core/theme/liquid_glass_theme.dart';
 import 'dashboard_page.dart';

--- a/lib/features/meals/meal_page.dart
+++ b/lib/features/meals/meal_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../../core/i18n/app_i18n.dart';
+import '../../core/i18n/app_i18n_context.dart';
 import '../../core/models/meal.dart';
 import '../../core/state/app_state.dart';
 import '../entry/entry_page.dart';

--- a/lib/features/medications/medication_page.dart
+++ b/lib/features/medications/medication_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../../core/i18n/app_i18n.dart';
+import '../../core/i18n/app_i18n_context.dart';
 import '../../core/state/app_state.dart';
 import '../catalog/catalog_detail_pages.dart';
 

--- a/lib/features/next_meal/next_meal_page.dart
+++ b/lib/features/next_meal/next_meal_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../core/copy/response_copy_service.dart';
-import '../../core/i18n/app_i18n.dart';
+import '../../core/i18n/app_i18n_context.dart';
 import '../../core/state/app_state.dart';
 import '../../core/theme/liquid_glass_theme.dart';
 import '../../domain/entities/next_meal_recommendation_models.dart';

--- a/lib/features/shared/interaction_result_view.dart
+++ b/lib/features/shared/interaction_result_view.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../core/copy/response_copy_service.dart';
-import '../../core/i18n/app_i18n.dart';
+import '../../core/i18n/app_i18n_context.dart';
 import '../../core/models/interaction_result.dart';
 import 'mechanistic_trace_view.dart';
 

--- a/lib/features/timeline/timeline_page.dart
+++ b/lib/features/timeline/timeline_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../../core/i18n/app_i18n.dart';
+import '../../core/i18n/app_i18n_context.dart';
 import '../../core/models/drug_definition.dart';
 import '../../core/models/intake.dart';
 import '../../core/models/meal.dart';

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "operator:clinical-review": "node tool/clinical_review_report.mjs",
     "operator:gate": "node tool/operator_gate.mjs",
     "mechanistic:replay": "node tool/run_mechanistic_replay.mjs",
+    "recommend:replay": "node tool/run_recommendation_scenario_replay.mjs",
     "source:quality": "node tool/run_source_quality_perturbation_report.mjs",
     "release:snapshot": "node tool/run_release_snapshot.mjs",
     "demo:walkthrough": "node tool/generate_public_demo_walkthrough.mjs",

--- a/test/accessibility_semantics_test.dart
+++ b/test/accessibility_semantics_test.dart
@@ -1,17 +1,25 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:parkinsum_companion/core/i18n/app_i18n.dart';
+import 'package:parkinsum_companion/core/state/app_state.dart';
+import 'package:parkinsum_companion/core/services/services.dart';
 import 'package:parkinsum_companion/domain/entities/rule_explanation.dart';
+import 'package:parkinsum_companion/features/catalog/catalog_page.dart';
+import 'package:provider/provider.dart';
 
 /// Accessibility — semantic labels for meaning-bearing icons.
 ///
 /// The catalog list rows (chevron "view details", check-circle "selected as
 /// active medication") and the next-meal decision-path icon now carry
-/// `semanticLabel`s sourced from i18n. Full page-level semantics audits need
-/// an asset-bundle test harness (brand images) and stay follow-up work; these
-/// tests pin (a) the i18n label coverage across the four inlined locales and
-/// (b) that the exact icon construct used by the pages exposes the label to
-/// the semantics tree. Educational prototype only; synthetic data only.
+/// `semanticLabel`s sourced from i18n. These tests pin (a) the i18n label
+/// coverage across the four inlined locales, (b) that the exact icon construct
+/// used by the pages exposes the label to the semantics tree, and (c) a
+/// page-level audit of the real CatalogPage rendered with a stub asset bundle
+/// (brand images become a 1x1 png) and a local-mode AppState.
+/// Educational prototype only; synthetic data only.
 void main() {
   const labelKeys = ['catalog.view_detail', 'catalog.selected_active'];
   const localeTags = ['en-US', 'zh-CN', 'fr-FR', 'ja-JP'];
@@ -74,4 +82,69 @@ void main() {
           reason: 'decision-path icon (aiUsed=$aiUsed) must expose "$label"');
     }
   });
+
+  testWidgets('CatalogPage exposes the view-details labels (page-level audit)',
+      (tester) async {
+    // Local-mode services + AppState; the background sqlite init has no VM
+    // support and is irrelevant here, so it is captured by a guarded zone.
+    AppState? state;
+    runZonedGuarded(() {
+      state = AppState(services: Services.createDefault());
+    }, (_, __) {});
+    expect(state, isNotNull);
+
+    // The page is laid out for a phone viewport; widen the test surface so the
+    // showcase card + list render without overflow at the default 800x600.
+    tester.view.physicalSize = const Size(1170, 2532);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AppState>.value(
+        value: state!,
+        child: MaterialApp(
+          home: DefaultAssetBundle(
+            bundle: _StubAssetBundle(),
+            child: const CatalogPage(),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    // Food rows render with the accessible "view details" trailing label.
+    expect(find.bySemanticsLabel(RegExp('View details')), findsWidgets);
+  });
+}
+
+/// Serves a valid 1x1 transparent PNG for every image asset so page-level
+/// widget tests can render brand images without the real asset bundle.
+class _StubAssetBundle extends CachingAssetBundle {
+  static final Uint8List _onePixelPng = Uint8List.fromList(const [
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+    0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, // IHDR (1x1 RGBA)
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+    0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+    0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41, // IDAT
+    0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+    0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+    0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, // IEND
+    0x42, 0x60, 0x82,
+  ]);
+
+  @override
+  Future<ByteData> load(String key) async {
+    if (key == 'AssetManifest.bin') {
+      // AssetImage resolves variants through the manifest first; serve a
+      // minimal StandardMessageCodec-encoded manifest for the brand assets.
+      return const StandardMessageCodec().encodeMessage(<String, Object?>{
+        'assets/brand/parkinsum-icon.png': <Object?>[],
+        'assets/brand/parkinsum-wordmark.png': <Object?>[],
+      })!;
+    }
+    return ByteData.view(_onePixelPng.buffer);
+  }
+
+  @override
+  Future<String> loadString(String key, {bool cache = true}) async => '{}';
 }

--- a/tool/run_recommendation_scenario_replay.dart
+++ b/tool/run_recommendation_scenario_replay.dart
@@ -1,0 +1,153 @@
+// Replays the fixed Local-AI recommendation scenarios (the five archetypes) and
+// writes the deterministic reviewer artifact under
+// build/recommendation_scenario_replay/.
+//
+// Usage:
+//   dart run tool/run_recommendation_scenario_replay.dart
+//   (or: npm run recommend:replay)
+//
+// Educational/research prototype. Deterministic replay only. It runs the same
+// conservative + hybrid orchestrators the app uses, with an OFFLINE scripted
+// Local AI stand-in (no network) that may only reorder the safe whitelist. It
+// adds no medical advice, no dose/timing/diet guidance, is not calibrated for
+// real care, and uses synthetic/demo data only. No PHI. Exits non-zero iff the
+// Local-AI candidate-set safety invariant is violated.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:parkinsum_companion/core/analysis/food_repository.dart';
+import 'package:parkinsum_companion/core/analysis/medication_repository.dart';
+import 'package:parkinsum_companion/core/constants/local_ai_replay_scenarios.dart';
+import 'package:parkinsum_companion/core/db/cdss_database_memory.dart';
+import 'package:parkinsum_companion/domain/usecases/cdss_catalog_projection_service.dart';
+import 'package:parkinsum_companion/domain/usecases/get_food_recommendations_usecase.dart';
+import 'package:parkinsum_companion/domain/usecases/local_ai_recommendation_adapter.dart';
+import 'package:parkinsum_companion/domain/usecases/next_meal_recommendation_orchestrator.dart';
+import 'package:parkinsum_companion/domain/usecases/recommendation_replay_runner.dart';
+
+Future<void> main() async {
+  const projection =
+      CdssCatalogProjectionService(database: InMemoryCdssDatabase());
+  final hybrid = NextMealRecommendationOrchestrator(
+    conservativeRecommender: GetFoodRecommendationsUseCase(),
+    projectionService: projection,
+    localAiAdapter:
+        LocalAiRecommendationAdapter(client: _ScriptedLocalAiClient()),
+  );
+  final deterministic = NextMealRecommendationOrchestrator(
+    conservativeRecommender: GetFoodRecommendationsUseCase(),
+    projectionService: projection,
+    localAiAdapter: null,
+  );
+  final runner = RecommendationReplayRunner(
+    hybridOrchestrator: hybrid,
+    deterministicOrchestrator: deterministic,
+    foodRepository: FoodRepository.createDefault(),
+    medicationRepository: MedicationRepository.createDefault(),
+  );
+
+  final report = await runner.run(dataset: localAiReplayScenarioDataset);
+
+  final outDir = Directory('build/recommendation_scenario_replay');
+  if (!outDir.existsSync()) outDir.createSync(recursive: true);
+  File('${outDir.path}/latest.json').writeAsStringSync(
+      const JsonEncoder.withIndent('  ').convert(report.toJson()));
+  File('${outDir.path}/latest.md').writeAsStringSync(
+      report.toReviewerMarkdown(archetypeNotes: localAiReplayArchetypeNotes));
+
+  final safe = report.allPreservedCandidateSet;
+  stdout
+    ..writeln(
+        'Recommendation scenario replay: ${report.cases.length} scenarios '
+        '(dataset ${localAiReplayScenarioDataset.version}).')
+    ..writeln('Local-AI candidate-set safety invariant held: $safe.')
+    ..writeln('Report: ${outDir.path}/latest.json')
+    ..writeln('Report: ${outDir.path}/latest.md');
+  for (final c in report.cases) {
+    stdout.writeln('  - ${c.benchmarkCase.caseId}: ${c.decisionPath} '
+        '(ai_used=${c.aiUsed})');
+  }
+  if (!safe) {
+    stderr
+        .writeln('BLOCKER: Local AI changed the deterministic candidate set.');
+  }
+  exitCode = safe ? 0 : 1;
+}
+
+/// Offline, deterministic Local AI stand-in (mirrors the test harness in
+/// test/helpers/local_ai_replay_harness.dart). Reports the model available,
+/// returns safe copy-polish notes, and reranks only by reversing the supplied
+/// safe whitelist. It never adds/drops candidate ids or emits unsafe copy, so
+/// the replay exercises the AI path with zero network access.
+class _ScriptedLocalAiClient extends http.BaseClient {
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    if (request.method == 'GET' && request.url.path == '/api/tags') {
+      return _json(jsonEncode({
+        'models': [
+          {'name': 'gemma3n:e2b', 'model': 'gemma3n:e2b'},
+        ],
+      }));
+    }
+    final body = request is http.Request ? request.body : '';
+    final decoded = jsonDecode(body) as Map<String, dynamic>;
+    final content =
+        ((decoded['messages'] as List).first['content'] ?? '').toString();
+
+    if (content.contains('reply with {"ok":true}')) {
+      return _json(jsonEncode({
+        'message': {'content': '{"ok":true}'}
+      }));
+    }
+    if (content.contains('polishing ParkinSUM next-meal')) {
+      final ids = _jsonArrayAfter(content, 'Allowed food_id keys JSON: ');
+      return _json(jsonEncode({
+        'message': {
+          'content': jsonEncode({
+            'summary': 'Local AI polished the wording; safe order unchanged.',
+            'candidate_notes': {
+              for (final id in ids) id: 'A plain-language reason for $id.',
+            },
+          })
+        }
+      }));
+    }
+    if (content.contains('reranking already-safe')) {
+      final allowed = _jsonArrayAfter(content, 'Allowed candidate_ids JSON: ');
+      return _json(jsonEncode({
+        'message': {
+          'content': jsonEncode({
+            'candidate_ids': allowed.reversed.toList(growable: false),
+            'summary': 'Local AI replay reranked only the safe whitelist.',
+            'safety_checks': ['Preserved the safe whitelist only.'],
+            'ranking_rationale': ['Used the provided candidate features.'],
+          })
+        }
+      }));
+    }
+    return _json(jsonEncode({
+      'message': {'content': '{}'}
+    }));
+  }
+
+  List<String> _jsonArrayAfter(String prompt, String marker) {
+    final start = prompt.indexOf(marker);
+    if (start < 0) return const <String>[];
+    final rest = prompt.substring(start + marker.length);
+    final open = rest.indexOf('[');
+    final close = rest.indexOf(']');
+    if (open < 0 || close < 0 || close < open) return const <String>[];
+    return (jsonDecode(rest.substring(open, close + 1)) as List<dynamic>)
+        .map((e) => e.toString())
+        .toList(growable: false);
+  }
+
+  http.StreamedResponse _json(String payload) => http.StreamedResponse(
+        Stream.value(utf8.encode(payload)),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+}

--- a/tool/run_recommendation_scenario_replay.mjs
+++ b/tool/run_recommendation_scenario_replay.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+// Thin wrapper so `npm run recommend:replay` invokes the Dart runner.
+// Synthetic inputs only; offline scripted Local AI; not medical advice.
+
+import { spawnSync } from 'node:child_process';
+
+const result = spawnSync(
+  'dart',
+  ['run', 'tool/run_recommendation_scenario_replay.dart'],
+  { stdio: 'inherit' },
+);
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary

Closes the two concrete follow-ups documented in #89.

### 1. `dart run` Local-AI replay CLI — finally unblocked

The CLI had been documented as future work in three consecutive PRs because the
recommendation orchestrator transitively imported Flutter via `app_i18n.dart`.
The actual Flutter surface there turned out to be just three members, so this
PR splits them out instead of refactoring i18n broadly:

- **`lib/core/i18n/app_i18n_context.dart`** (new) — the `BuildContext.appI18n`
  extension (AppState provider lookup) and `appI18nLocaleFor` (tag → `Locale`),
  re-exporting `app_i18n.dart`. The 13 UI files + `app.dart` now import this;
  `app_i18n.dart` itself is **pure Dart**. No behaviour change (same logic,
  same `listen: false` semantics).
- **`tool/run_recommendation_scenario_replay.dart`** + `.mjs` wrapper +
  **`npm run recommend:replay`** — replays the five archetypes with the same
  offline scripted Local AI stand-in as the test harness, writes
  `build/recommendation_scenario_replay/latest.{json,md}`, and exits non-zero
  iff the candidate-set invariant is violated.
- **Verified byte-identical artifacts** between the CLI and
  `flutter test test/local_ai_replay_report_test.dart` (md5-compared), so the
  two entry points cannot drift from each other.
- Docs updated: the "Why there is no `dart run` CLI" section is replaced with
  CLI notes; the reviewer order in `PUBLIC_VERIFICATION.md` now starts with
  `npm run recommend:replay`.

### 2. Page-level accessibility audit (was blocked on asset loading)

`test/accessibility_semantics_test.dart` gains a real **`CatalogPage`** widget
test: a stub `CachingAssetBundle` serves a valid 1×1 PNG plus a
`StandardMessageCodec`-encoded `AssetManifest.bin`, so the brand images render
under `flutter_test`; a local-mode `AppState` is constructed in a guarded zone
(sqlite init is unavailable on the test VM and irrelevant); a phone-sized test
viewport avoids layout overflow. The test asserts the accessible "view details"
labels are exposed by the real page's semantics tree — upgrading the previous
construct-level checks to a page-level audit.

## Validation (all run, all green)
- `dart format --set-exit-if-changed .` clean; `flutter analyze` no issues
- `flutter test --concurrency=1` → **745 passed**
- `npm run recommend:replay` → 5 scenarios, invariant held, exit 0
- CLI vs test artifact: byte-identical (json + md)
- `npm run public:preflight` 0 BLOCKER; `npm run privacy:preflight` 0 blocker
- `git diff --check` clean

## Remaining follow-ups (intentionally untouched)
- Language-tagged alias model (`LocalizedAlias`) — only if per-locale alias
  filtering becomes a requirement; flat lists still suffice.
- Kana below the catalog engine's CJK threshold — widening `_hasCjk` would
  shift existing confidence assignments; deliberately left alone.

Educational prototype only; synthetic/demo data only; no medical advice; not
calibrated for real care.

🤖 Generated with [Claude Code](https://claude.com/claude-code)