### PR TITLE
Security hardening pass: credential hygiene, identifier sinks, secure RNG

### DIFF
--- a/lib/core/db/cdss_database.dart
+++ b/lib/core/db/cdss_database.dart
@@ -1,5 +1,19 @@
 import '../../domain/entities/cdss_records.dart';
 
+/// CDSS table identifiers are internal constants, but they end up in dynamic
+/// identifier sinks (SQL table names, Firestore path segments, storage keys),
+/// which cannot use parameter binding. This guard rejects anything that is not
+/// a plain snake_case identifier so a malformed value can never reshape a
+/// query or a collection path.
+final RegExp _cdssTableNamePattern = RegExp(r'^[a-z][a-z0-9_]{0,63}$');
+
+String requireValidCdssTableName(String table) {
+  if (!_cdssTableNamePattern.hasMatch(table)) {
+    throw ArgumentError.value(table, 'table', 'Invalid CDSS table identifier');
+  }
+  return table;
+}
+
 abstract class CdssDatabase {
   Future<void> initialize();
 

--- a/lib/core/db/cdss_database_firestore.dart
+++ b/lib/core/db/cdss_database_firestore.dart
@@ -31,6 +31,7 @@ class FirestoreCdssDatabase implements CdssDatabase {
       _providedFirestore ?? FirebaseFirestore.instance;
 
   Future<CollectionReference<Map<String, dynamic>>> _rows(String table) async {
+    requireValidCdssTableName(table);
     await FirebaseBackend.ensureInitialized();
     final uid = authService.currentUserId;
     if (uid == null) {
@@ -511,6 +512,13 @@ class FirestoreCdssDatabase implements CdssDatabase {
         row['rule_id'] ??
         row['event_id'] ??
         row['ticket_id'];
+    if (id == null || '$id'.trim().isEmpty) {
+      // Without an identifier every row would upsert into the same "null"
+      // document and silently overwrite earlier rows — fail loudly instead.
+      throw StateError(
+          'Staging row for "$table" has no identifier key; refusing to '
+          'upsert under a shared document id.');
+    }
     return _upsert(table, '$id', row);
   }
 

--- a/lib/core/db/cdss_database_native.dart
+++ b/lib/core/db/cdss_database_native.dart
@@ -767,6 +767,7 @@ class NativeCdssDatabase implements CdssDatabase {
 
   @override
   Future<void> insertStagingRow(String table, Map<String, Object?> row) async {
+    requireValidCdssTableName(table);
     final db = await _open();
     await db.insert(
       table,
@@ -798,6 +799,7 @@ class NativeCdssDatabase implements CdssDatabase {
 
   @override
   Future<List<Map<String, Object?>>> queryTable(String table) async {
+    requireValidCdssTableName(table);
     final db = await _open();
     return db.query(table);
   }

--- a/lib/core/db/cdss_database_web.dart
+++ b/lib/core/db/cdss_database_web.dart
@@ -613,6 +613,7 @@ class WebCdssDatabase implements CdssDatabase {
 
   @override
   Future<void> insertStagingRow(String table, Map<String, Object?> row) async {
+    requireValidCdssTableName(table);
     final rows = await _load(table);
     final idKey = row.keys.firstWhere(
       (key) => key.endsWith('_id'),
@@ -643,6 +644,7 @@ class WebCdssDatabase implements CdssDatabase {
 
   @override
   Future<List<Map<String, Object?>>> queryTable(String table) async {
+    requireValidCdssTableName(table);
     final rows = await _load(table);
     return rows.cast<Map<String, Object?>>();
   }

--- a/lib/core/state/app_state.dart
+++ b/lib/core/state/app_state.dart
@@ -640,10 +640,21 @@ class AppState extends ChangeNotifier {
     return services.getProteinTrendUseCase.averageProtein(_meals);
   }
 
+  // Cryptographically secure RNG for record ids (falls back to a seeded RNG
+  // only on platforms without an entropy source). A static instance avoids
+  // re-seeding per call.
+  static final Random _idRandom = () {
+    try {
+      return Random.secure();
+    } on UnsupportedError {
+      return Random();
+    }
+  }();
+
   String newId(String prefix) {
     // Web/JS 下 `1 << 32` 会溢出成 0，导致 nextInt(0) 抛 RangeError。
     // 这里改用跨平台安全的随机范围。
-    final r = Random().nextInt(1 << 31);
+    final r = _idRandom.nextInt(1 << 31);
     final now = DateTime.now().microsecondsSinceEpoch;
     final id = '${prefix}_${now}_$r';
     _debugLog('[AppState] newId prefix=$prefix');

--- a/lib/data/datasources/remote/dailymed_p0_importer.dart
+++ b/lib/data/datasources/remote/dailymed_p0_importer.dart
@@ -30,7 +30,10 @@ class DailyMedP0Importer {
 
   Future<P0ImportBundle> fetchBySetIds(List<String> setIds) async {
     P0ImportBundle bundle = const P0ImportBundle();
-    for (final setId in setIds) {
+    for (final rawSetId in setIds) {
+      // Set ids come from config/upstream indexes; encode them so a malformed
+      // value cannot alter the request path.
+      final setId = Uri.encodeComponent(rawSetId);
       final xml = await fetchClient
           .getText('${P0SourceUrls.dailymedSplXmlBase}/$setId.xml');
       final ndcs = await _safeFetchJsonList(

--- a/lib/data/datasources/remote/fdc_p0_importer.dart
+++ b/lib/data/datasources/remote/fdc_p0_importer.dart
@@ -29,8 +29,14 @@ class FdcP0Importer {
     required String apiKey,
     required int fdcId,
   }) async {
-    final url = '${P0SourceUrls.fdcFoodDetail}/$fdcId?api_key=$apiKey';
-    final json = await fetchClient.getJsonMap(url);
+    // The key is sent as an X-Api-Key header (supported by api.data.gov /
+    // FDC) instead of a query parameter, so it can never leak through URLs in
+    // error messages, logs, or cache-metadata keys.
+    final url = '${P0SourceUrls.fdcFoodDetail}/$fdcId';
+    final json = await fetchClient.getJsonMap(
+      url,
+      headers: {'X-Api-Key': apiKey},
+    );
     return importFoods([json], sourceLabel: 'fdc_api_food_detail');
   }
 

--- a/lib/data/datasources/remote/health_canada_dpd_p0_importer.dart
+++ b/lib/data/datasources/remote/health_canada_dpd_p0_importer.dart
@@ -334,8 +334,10 @@ class HealthCanadaDpdP0Importer {
       final productCode = variant.externalProductCode;
       final drugCode =
           productCode.contains('-') ? productCode.split('-').last : productCode;
+      // The code is parsed from upstream data; encode it so it cannot inject
+      // additional query parameters.
       final infoUrl =
-          'https://health-products.canada.ca/dpd-bdpp/info?code=$drugCode&lang=eng';
+          'https://health-products.canada.ca/dpd-bdpp/info?code=${Uri.encodeQueryComponent(drugCode)}&lang=eng';
       try {
         final html = await fetchClient.getText(infoUrl);
         final summaryText = _summarizeHtmlDetail(html);

--- a/lib/data/datasources/remote/source_fetch_client.dart
+++ b/lib/data/datasources/remote/source_fetch_client.dart
@@ -59,8 +59,10 @@ class HttpSourceFetchClient implements SourceFetchClient {
     Map<String, String>? headers,
   }) async {
     final uri = Uri.parse(url);
+    // Query strings may carry credentials; never echo them into errors.
+    final safeUrl = '${uri.scheme}://${uri.host}${uri.path}';
     if (uri.scheme != 'https' || uri.host.isEmpty || uri.userInfo.isNotEmpty) {
-      throw StateError('Refusing non-HTTPS or malformed source URL: $url');
+      throw StateError('Refusing non-HTTPS or malformed source URL: $safeUrl');
     }
     final request = http.Request('GET', uri)
       ..followRedirects = false
@@ -70,21 +72,21 @@ class HttpSourceFetchClient implements SourceFetchClient {
     if (streamed.statusCode < 200 || streamed.statusCode >= 300) {
       await streamed.stream.drain<void>();
       throw StateError(
-        'Failed to fetch $url: HTTP ${streamed.statusCode}',
+        'Failed to fetch $safeUrl: HTTP ${streamed.statusCode}',
       );
     }
     final declaredLength = streamed.contentLength;
     if (declaredLength != null && declaredLength > responseByteLimit) {
       await streamed.stream.drain<void>();
       throw StateError(
-        'Failed to fetch $url: response exceeds $responseByteLimit bytes.',
+        'Failed to fetch $safeUrl: response exceeds $responseByteLimit bytes.',
       );
     }
     final bytes = BytesBuilder(copy: false);
     await for (final chunk in streamed.stream) {
       if (bytes.length + chunk.length > responseByteLimit) {
         throw StateError(
-          'Failed to fetch $url: response exceeds $responseByteLimit bytes.',
+          'Failed to fetch $safeUrl: response exceeds $responseByteLimit bytes.',
         );
       }
       bytes.add(chunk);

--- a/test/security_hardening_test.dart
+++ b/test/security_hardening_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:parkinsum_companion/core/db/cdss_database.dart';
+import 'package:parkinsum_companion/data/datasources/remote/fdc_p0_importer.dart';
+import 'package:parkinsum_companion/data/datasources/remote/source_fetch_client.dart';
+
+/// Security-hardening regression tests.
+///
+/// Pins the fixes from the security scan:
+///  - CDSS table identifiers are validated before reaching dynamic identifier
+///    sinks (SQL table names, Firestore path segments, storage keys).
+///  - Fetch-client error messages never echo URL query strings (which may
+///    carry credentials).
+///  - The FDC API key travels in the `X-Api-Key` header, never in the URL.
+///
+/// Educational prototype only; synthetic fixtures; no real credentials.
+void main() {
+  group('CDSS table-name guard', () {
+    test('accepts plain snake_case identifiers', () {
+      for (final ok in ['ingestion_run', 'staging_resolved_fact', 'a1_b2']) {
+        expect(requireValidCdssTableName(ok), ok);
+      }
+    });
+
+    test('rejects path/SQL-shaping values', () {
+      for (final bad in [
+        '',
+        'users/other_uid',
+        'a b',
+        'A_Upper',
+        'rows; DROP TABLE x',
+        '../escape',
+        'name#frag',
+      ]) {
+        expect(() => requireValidCdssTableName(bad), throwsArgumentError,
+            reason: '"$bad" must be rejected');
+      }
+    });
+  });
+
+  group('fetch-client URL hygiene', () {
+    test('HTTP error messages omit the query string', () async {
+      final client = HttpSourceFetchClient(
+        client: MockClient((_) async => http.Response('nope', 500)),
+      );
+      try {
+        await client.getText('https://example.org/data?api_key=SECRET123&x=1');
+        fail('expected a StateError');
+      } on StateError catch (e) {
+        expect(e.message, isNot(contains('SECRET123')));
+        expect(e.message, contains('https://example.org/data'));
+      }
+    });
+
+    test('non-HTTPS rejection message omits the query string', () async {
+      final client = HttpSourceFetchClient(
+        client: MockClient((_) async => http.Response('ok', 200)),
+      );
+      try {
+        await client.getText('http://example.org/data?token=SECRET456');
+        fail('expected a StateError');
+      } on StateError catch (e) {
+        expect(e.message, isNot(contains('SECRET456')));
+      }
+    });
+
+    test('oversized responses fail without echoing the query', () async {
+      final client = HttpSourceFetchClient(
+        client: MockClient((_) async => http.Response('x' * 64, 200)),
+        responseByteLimit: 16,
+      );
+      try {
+        await client.getText('https://example.org/big?api_key=SECRET789');
+        fail('expected a StateError');
+      } on StateError catch (e) {
+        expect(e.message, isNot(contains('SECRET789')));
+      }
+    });
+  });
+
+  group('FDC API key handling', () {
+    test('key is sent as X-Api-Key header, never in the URL', () async {
+      Uri? seenUri;
+      Map<String, String>? seenHeaders;
+      final client = HttpSourceFetchClient(
+        client: MockClient((request) async {
+          seenUri = request.url;
+          seenHeaders = request.headers;
+          return http.Response('{"fdcId": 1, "description": "demo"}', 200);
+        }),
+      );
+      final importer = FdcP0Importer(fetchClient: client);
+      await importer.fetchFoodDetail(apiKey: 'DEMO_KEY_NOT_REAL', fdcId: 12345);
+
+      expect(seenUri, isNotNull);
+      expect(seenUri!.toString(), isNot(contains('DEMO_KEY_NOT_REAL')));
+      expect(seenUri!.query, isEmpty);
+      expect(seenHeaders!['X-Api-Key'], 'DEMO_KEY_NOT_REAL');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Project-wide bug/security scan of the high-risk surfaces — network clients,
importers, local/Firestore/web databases, auth services, operator tooling, and
Firestore rules — with **six fixes** applied. No behaviour change for
well-formed inputs; the educational safety boundary is untouched.

## Fixes

| # | File(s) | Defect | Fix |
| --- | --- | --- | --- |
| F1 | `lib/core/state/app_state.dart` | Record ids generated with a per-call, non-cryptographic `Random()` | Static `Random.secure()` (seeded fallback only where no entropy source exists) |
| F2 | `lib/data/datasources/remote/fdc_p0_importer.dart` | FDC API key embedded in the URL query string → leaked into error messages, logs, and cache-metadata keys | Key sent as the `X-Api-Key` header (supported by api.data.gov/FDC); URL carries no query |
| F3 | `lib/data/datasources/remote/source_fetch_client.dart` | Fetch error messages echoed full URLs, including query strings that may carry credentials | All three error paths (non-HTTPS rejection, HTTP failure, byte-limit) now echo only `scheme://host/path` |
| F4 | `dailymed_p0_importer.dart`, `health_canada_dpd_p0_importer.dart` | Upstream-derived values (SPL set ids, DPD drug codes) interpolated unencoded into request paths/queries | `Uri.encodeComponent` / `Uri.encodeQueryComponent` before interpolation |
| F5 | `lib/core/db/cdss_database*.dart` | Table names flowed unvalidated into dynamic identifier sinks that cannot use parameter binding: SQL identifiers (native), Firestore path segments (`users/{uid}/cdss_tables/{table}/rows`), web storage keys | New `requireValidCdssTableName` guard (strict snake_case) enforced in all three implementations |
| F6 | `lib/core/db/cdss_database_firestore.dart` | A staging row with no identifier key upserted into a shared `"null"` document — every such row silently overwrote the previous one (data loss) | Fails loudly with a `StateError` |

## Audited and found already sound (no change needed)

- `HttpSourceFetchClient`: HTTPS-only, redirects disabled, userInfo rejected, streaming byte cap enforced even without Content-Length.
- Local AI adapter: localhost-only endpoint enforcement (scheme/host/userInfo/query/fragment checks), redirects disabled, banned-phrase scrubbing.
- Firestore rules: deny-all fallback, owner scoping, `safeId` pattern on ids, admin/importer claims gating.
- Operator token tooling: token files written `0600` under `build/`; no token values logged.
- Tool scripts: `spawnSync` only with fixed argv arrays (no shell interpolation).
- Local SQL: row queries use `?` parameter binding throughout.
- No credential/email logging in auth or backend services.

## Tests

New [`test/security_hardening_test.dart`](test/security_hardening_test.dart) (6 cases) pins:
- the table-name guard (valid identifiers pass; path/SQL-shaping values throw),
- query-string redaction on all three fetch-client error paths,
- the FDC key travelling only in the `X-Api-Key` header (captured request asserted).

## Validation (all run, all green)

- `dart format --set-exit-if-changed .` clean; `flutter analyze` no issues
- `flutter test --concurrency=1` → **751 passed**
- `npm run public:preflight` → 0 BLOCKER; `npm run privacy:preflight` → 0 blocker
- `git diff --check` clean

Educational prototype only; synthetic fixtures; no real credentials, PHI, or
medical-meaning changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)