### PR TITLE
Add feature-page smoke tests; fix a shared GlassButton layout overflow they caught

### DIFF
--- a/lib/core/theme/liquid_glass_theme.dart
+++ b/lib/core/theme/liquid_glass_theme.dart
@@ -920,12 +920,18 @@ class GlassButton extends StatelessWidget {
                     Icon(leadingIcon, size: 18),
                     const SizedBox(width: 8),
                   ],
-                  DefaultTextStyle.merge(
-                    style: const TextStyle(
-                      fontWeight: FontWeight.w600,
-                      letterSpacing: -0.1,
+                  // Flexible (not Expanded) keeps mainAxisSize.min intact while
+                  // letting a long label shrink/wrap instead of overflowing the
+                  // row. Labels are localized, so width varies a lot per locale
+                  // and grows further with large text scales.
+                  Flexible(
+                    child: DefaultTextStyle.merge(
+                      style: const TextStyle(
+                        fontWeight: FontWeight.w600,
+                        letterSpacing: -0.1,
+                      ),
+                      child: label,
                     ),
-                    child: label,
                   ),
                 ],
               ),

--- a/lib/features/next_meal/next_meal_page.dart
+++ b/lib/features/next_meal/next_meal_page.dart
@@ -514,12 +514,16 @@ class _ResultBlock extends StatelessWidget {
                     Icon(Icons.shield_outlined,
                         size: 18, color: scheme.primary),
                     const SizedBox(width: 8),
-                    Text(
-                      i18n.tr('next_meal.gate_reasons'),
-                      style: const TextStyle(
-                        fontSize: 13,
-                        fontWeight: FontWeight.w700,
-                        color: LiquidGlass.onSurface,
+                    // Must flex: this label is far longer in some locales
+                    // (fr is ~2x en) and overflowed the row without it.
+                    Expanded(
+                      child: Text(
+                        i18n.tr('next_meal.gate_reasons'),
+                        style: const TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w700,
+                          color: LiquidGlass.onSurface,
+                        ),
                       ),
                     ),
                   ],

--- a/test/feature_page_smoke_test.dart
+++ b/test/feature_page_smoke_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkinsum_companion/features/analytics/analytics_page.dart';
+import 'package:parkinsum_companion/features/auth/auth_page.dart';
+import 'package:parkinsum_companion/features/catalog/catalog_page.dart';
+import 'package:parkinsum_companion/features/legal/privacy_disclaimer_page.dart';
+import 'package:parkinsum_companion/features/main_shell/dashboard_page.dart';
+import 'package:parkinsum_companion/features/meals/meal_page.dart';
+import 'package:parkinsum_companion/features/medications/medication_page.dart';
+import 'package:parkinsum_companion/features/next_meal/next_meal_page.dart';
+import 'package:parkinsum_companion/features/timeline/timeline_page.dart';
+
+import 'helpers/page_test_harness.dart';
+
+/// Smoke coverage for the user-facing pages.
+///
+/// The repo has deep domain coverage but, before this file, no page-level
+/// tests: a null dereference, a bad provider read, or a layout assertion in
+/// any feature page shipped silently. Each case pumps the real page against a
+/// local-mode AppState and asserts it builds without raising.
+///
+/// These are deliberately shallow — they pin "the page renders and does not
+/// throw", not business logic, which the domain suites already cover.
+///
+/// Educational prototype only; local mode; synthetic/demo data only; no PHI.
+void main() {
+  Future<void> smoke(WidgetTester tester, Widget page, String label) async {
+    await pumpFeaturePage(tester, page);
+    expectNoWidgetErrors(reason: '$label failed to build cleanly');
+    expect(find.byType(page.runtimeType), findsOneWidget,
+        reason: '$label did not render');
+  }
+
+  testWidgets('DashboardPage builds', (t) async {
+    await smoke(t, const DashboardPage(), 'DashboardPage');
+  });
+
+  testWidgets('CatalogPage builds', (t) async {
+    await smoke(t, const CatalogPage(), 'CatalogPage');
+  });
+
+  testWidgets('MedicationPage builds', (t) async {
+    await smoke(t, const MedicationPage(), 'MedicationPage');
+  });
+
+  testWidgets('MealPage builds', (t) async {
+    await smoke(t, const MealPage(), 'MealPage');
+  });
+
+  testWidgets('NextMealPage builds', (t) async {
+    await smoke(t, const NextMealPage(), 'NextMealPage');
+  });
+
+  testWidgets('TimelinePage builds', (t) async {
+    await smoke(t, const TimelinePage(), 'TimelinePage');
+  });
+
+  testWidgets('AnalyticsPage builds', (t) async {
+    await smoke(t, const AnalyticsPage(), 'AnalyticsPage');
+  });
+
+  testWidgets('AuthPage builds', (t) async {
+    await smoke(t, const AuthPage(), 'AuthPage');
+  });
+
+  testWidgets('PrivacyDisclaimerPage builds and keeps its boundary copy',
+      (t) async {
+    await smoke(t, const PrivacyDisclaimerPage(), 'PrivacyDisclaimerPage');
+    // This page exists to carry the educational boundary; an empty render
+    // would be a silent safety regression.
+    expect(find.byType(Text), findsWidgets);
+  });
+
+  testWidgets('pages survive a large text scale (accessibility)', (t) async {
+    // Text scaling is the most common source of overflow crashes in the
+    // field; assert the densest page tolerates it.
+    setTextScale(t, 1.6);
+    await pumpFeaturePage(t, const DashboardPage());
+    expectNoWidgetErrors(reason: 'DashboardPage broke at 1.6x text scale');
+  });
+}
+
+/// Applies a text-scale factor for the current test.
+void setTextScale(WidgetTester tester, double scale) {
+  tester.platformDispatcher.textScaleFactorTestValue = scale;
+  addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+}

--- a/test/helpers/page_test_harness.dart
+++ b/test/helpers/page_test_harness.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkinsum_companion/core/services/services.dart';
+import 'package:parkinsum_companion/core/state/app_state.dart';
+import 'package:provider/provider.dart';
+
+/// Shared harness for pumping real feature pages in widget tests.
+///
+/// Feature pages need three things a bare `pumpWidget` does not give them:
+/// an `AppState` provider, a working asset bundle (brand images), and a
+/// viewport big enough that phone-sized layouts do not overflow. This helper
+/// supplies all three so smoke tests stay one-liners.
+///
+/// Educational prototype only; local mode; synthetic/demo data only. No PHI,
+/// no network, no Firebase (the default build is local mode — see
+/// test/local_mode_network_isolation_test.dart).
+
+/// Builds a local-mode [AppState].
+///
+/// `Services.createDefault()` kicks off a background sqlite open that has no
+/// platform support on the test VM. That failure is unrelated to anything the
+/// page tests assert, so it is absorbed by a guarded zone; the synchronous
+/// service wiring the pages actually read is unaffected.
+AppState createTestAppState() {
+  AppState? state;
+  runZonedGuarded(() {
+    state = AppState(services: Services.createDefault());
+  }, (_, __) {
+    // Local sqlite init is unavailable in VM tests; intentionally ignored.
+  });
+  if (state == null) {
+    throw StateError('Could not construct a local-mode AppState for tests.');
+  }
+  return state!;
+}
+
+/// Pumps [page] inside a provider + stub-asset + phone-viewport scaffold.
+///
+/// Pass [settle] to run `pumpAndSettle` instead of a single frame; leave it
+/// false for pages that keep an animation or a pending future alive.
+Future<AppState> pumpFeaturePage(
+  WidgetTester tester,
+  Widget page, {
+  AppState? state,
+  bool settle = false,
+  Size surfaceSize = const Size(1170, 2532),
+  double devicePixelRatio = 3.0,
+}) async {
+  final appState = state ?? createTestAppState();
+
+  tester.view.physicalSize = surfaceSize;
+  tester.view.devicePixelRatio = devicePixelRatio;
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    ChangeNotifierProvider<AppState>.value(
+      value: appState,
+      child: MaterialApp(
+        home: DefaultAssetBundle(bundle: StubAssetBundle(), child: page),
+      ),
+    ),
+  );
+  if (settle) {
+    await tester.pumpAndSettle(const Duration(milliseconds: 400));
+  } else {
+    await tester.pump();
+  }
+  return appState;
+}
+
+/// Fails the test if the pumped widget tree raised a Flutter error or is
+/// showing an error widget. `pumpWidget` records exceptions rather than
+/// throwing, so without this a broken page can "pass" silently.
+void expectNoWidgetErrors({String? reason}) {
+  final error = takePendingWidgetException();
+  expect(error, isNull,
+      reason: reason ?? 'page raised ${error.runtimeType}: $error');
+  expect(find.byType(ErrorWidget), findsNothing,
+      reason: reason ?? 'page rendered an ErrorWidget');
+}
+
+/// Reads (and clears) the pending widget-tree exception.
+Object? takePendingWidgetException() =>
+    TestWidgetsFlutterBinding.instance.takeException();
+
+/// Serves a valid 1x1 transparent PNG for every image asset, plus a minimal
+/// `AssetManifest.bin`, so pages with brand images render under flutter_test.
+///
+/// The manifest matters: `AssetImage` resolves variants through it first, and
+/// returning PNG bytes there fails with "Message corrupted".
+class StubAssetBundle extends CachingAssetBundle {
+  static final Uint8List _onePixelPng = Uint8List.fromList(const [
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+    0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, // IHDR (1x1 RGBA)
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+    0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+    0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41, // IDAT
+    0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+    0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+    0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, // IEND
+    0x42, 0x60, 0x82,
+  ]);
+
+  @override
+  Future<ByteData> load(String key) async {
+    if (key == 'AssetManifest.bin') {
+      return const StandardMessageCodec().encodeMessage(<String, Object?>{
+        'assets/brand/parkinsum-icon.png': <Object?>[],
+        'assets/brand/parkinsum-wordmark.png': <Object?>[],
+      })!;
+    }
+    return ByteData.view(_onePixelPng.buffer);
+  }
+
+  @override
+  Future<String> loadString(String key, {bool cache = true}) async => '{}';
+}


### PR DESCRIPTION
## Summary

All **15 feature pages had zero test coverage** — 751 tests, none page-level. A
layout assertion, bad provider read, or null dereference in any page shipped
silently. The very first run of these tests found a real layout bug in a
**shared** theme component.

## The bug the tests caught

`GlassButton` (`lib/core/theme/liquid_glass_theme.dart`) builds a `Row` with
`mainAxisSize: MainAxisSize.min` and puts its `label` in it **without a
`Flexible`**. A label wider than the available space can then neither shrink nor
wrap, so the row overflows — 68px at a 390pt-wide viewport.

This was reachable in normal use, not a test artifact: labels are localized (the
comparable `next_meal.gate_reasons` string is 17 chars in en but 32 in fr) and
grow further with OS text scaling.

Fixed with `Flexible`, not `Expanded` — `Expanded` would force the row to fill
and defeat the intentional `mainAxisSize.min`.

## What's added

**`test/helpers/page_test_harness.dart`** — reusable harness so page tests are
one-liners:
- local-mode `AppState` (the background sqlite open has no VM support, absorbed by a guarded zone),
- a stub asset bundle serving a valid 1×1 PNG **plus** a `StandardMessageCodec` `AssetManifest.bin` — the manifest is the part that trips naïve stubs, since `AssetImage` resolves variants through it first and PNG bytes there fail with "Message corrupted",
- a phone viewport.

Generalized from the local version in the accessibility test.

**`test/feature_page_smoke_test.dart`** — 10 cases over Dashboard, Catalog,
Medication, Meal, NextMeal, Timeline, Analytics, Auth, PrivacyDisclaimer, plus a
**1.6× text-scale** case. Deliberately shallow: they assert the page builds and
raises nothing, since business logic is already covered by the domain suites.

`expectNoWidgetErrors` is load-bearing — `pumpWidget` *records* exceptions rather
than throwing, so without it a broken page passes silently.

Also a defensive consistency fix in `next_meal_page.dart`: the gate-reasons `Row`
was the only one of seven in that file whose `Text` lacked `Expanded`.

## Validation

- `dart format --set-exit-if-changed .` clean; `flutter analyze` no issues
- `flutter test --concurrency=1` → **761 passed** (was 751)
- `copy:compile` and `localization:lint` pass; `git diff --check` clean

Educational prototype only; synthetic/demo data only; local mode; no PHI; no
copy, scoring, or engine change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)