### PR TITLE
Resolve 5 dependency vulnerabilities (1 critical, 1 high, 3 moderate)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -348,9 +348,9 @@
       "optional": true
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause",
       "optional": true
     },
@@ -368,13 +368,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause",
       "optional": true
     },
@@ -1690,9 +1683,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
-      "integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "optional": true,
@@ -1700,10 +1693,9 @@
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
@@ -1972,9 +1964,9 @@
       "optional": true
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",


### PR DESCRIPTION
## Summary

GitHub reports **5 open advisories on the default branch**. All of them reach
the repo transitively through its single production dependency, `firebase-admin`.

| Package | Bump | Severity | Advisory |
| --- | --- | --- | --- |
| `websocket-driver` | 0.7.4 → 0.7.5 | **CRITICAL** | Resource-limit bypass via message compression ([GHSA-mp7j-qc5w-4988](https://github.com/advisories/GHSA-mp7j-qc5w-4988)) |
| `websocket-driver` | ″ | **HIGH** | Message corruption via protocol length headers ([GHSA-xv26-6w52-cph6](https://github.com/advisories/GHSA-xv26-6w52-cph6)) |
| `protobufjs` | 7.6.0 → 7.6.5 | Moderate | DoS via infinite loop in `.proto` parsing |
| `protobufjs` | ″ | Moderate | DoS via unbounded `Any` expansion |
| `protobufjs` | ″ | Moderate | Schema-derived names shadowing runtime-significant properties |

Paths: `firebase-admin → @firebase/database → faye-websocket → websocket-driver`
and `firebase-admin → @google-cloud/firestore → google-gax → protobufjs`.

## Fix

`npm audit fix` — **lockfile only**. No `package.json` range changes, no major
bumps. `npm audit` now reports **0 vulnerabilities**.

## Scope note

These are **operator-tooling** dependencies, not shipped app code — the Flutter
app doesn't use them. But they execute in CI and on maintainer machines, so the
critical one is worth closing rather than deferring.

Supersedes the standalone Dependabot PR #94, which covered only the
`websocket-driver` half. Once the `.github/dependabot.yml` from #95 lands, this
class of update gets picked up weekly across `pub`, `npm`, and `github-actions`
instead of relying on default security alerts alone.

## Validation

Re-ran the Node-based tooling after the bump:
- `public:preflight` → 0 BLOCKER
- `rules:contract` → 14/14
- `contribution:route` → pass
- `npm audit` → 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)