### PR TITLE
Document the real minimum Dart SDK (3.11.0) in verification prerequisites

### DIFF
--- a/docs/PUBLIC_VERIFICATION.md
+++ b/docs/PUBLIC_VERIFICATION.md
@@ -14,6 +14,22 @@ Install Flutter, Dart, Node.js, and npm. From the repository root run
 `flutter pub get` and `npm ci` once. All checks below run on **synthetic/demo
 data** and, except where noted, require **no network**.
 
+**Minimum Dart SDK in practice: 3.11.0** (Flutter 3.47 or newer). The floor is
+set by the strictest dependency — currently `xml`, which requires Dart
+`^3.11.0`. On an older SDK `flutter pub get` fails during version solving before
+any check can run, and the error names `xml` rather than the SDK:
+
+```
+Because xml 7.0.1 requires SDK version ^3.11.0 ... version solving failed.
+```
+
+Note that `pubspec.yaml` still declares `sdk: ">=3.3.0 <4.0.0"`, which no longer
+matches this. Correcting it is a one-line change, but raising the declared floor
+also raises the package's **language version**, which switches `dart format` to
+the newer style and reformats ~269 files. That formatter migration should be its
+own commit rather than a side effect of a dependency bump — until then, treat
+this section as the authoritative minimum.
+
 ## Core checks
 
 ### `flutter analyze`


### PR DESCRIPTION
## Summary

The merged **xml 6.6.1 → 7.0.1** bump raised the project's effective SDK floor:
`xml 7.0.1` requires Dart `^3.11.0`. Anything older cannot run the project at
all, and the resolver blames a transitive package rather than the SDK:

```
Because xml 7.0.1 requires SDK version ^3.11.0 and no versions of xml match
>7.0.1 <8.0.0, xml ^7.0.1 is forbidden.
So, because parkinsum_companion depends on xml ^7.0.1, version solving failed.
```

This documents the real requirement in the verification prerequisites.

## Why this is docs-only (scope decision)

`pubspec.yaml` still declares `sdk: ">=3.3.0 <4.0.0"`, which is now wrong by
eight minor versions. Correcting that line is trivial — **but it also raises the
package's language version, which switches `dart format` to the newer style and
reformats 269 files.** I verified that in CI: with the floor raised, the
formatting check fails across essentially the whole codebase.

A whole-repo formatter migration should be a deliberate, standalone commit, not
a side effect of a dependency bump — it would otherwise bury every other review
signal in a 269-file diff. So this PR documents reality and leaves the manifest
change to that future commit.

## Why CI never surfaced this

`subosito/flutter-action` is configured with `channel: stable` and **no
version**, so CI always resolves on a new-enough SDK and never sees the drift.
That same floating toolchain is why a newer stable silently introduced the
`unawaited_return_in_try_block` lint that failed CI earlier today with no code
change on our side.

## Follow-ups this surfaces

1. **Formatter migration** — raise `environment.sdk` to `>=3.11.0` and run
   `dart format .` on Dart ≥ 3.11 as one dedicated commit.
2. **Pin the CI Flutter version** — makes toolchain moves explicit and
   reviewable instead of arriving as surprise lint/format failures.

## Validation

Docs-only; no code, dependency, or manifest change. `dart format
--set-exit-if-changed .` clean.

⚠️ Note: this machine runs **Dart 3.10.8**, below the project's effective floor,
so `flutter pub get` / `analyze` / `test` cannot run here at all right now. That
limitation is itself the finding this PR documents; CI remains the validation
path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)