### PR TITLE
Adopt archive 4.x; hold csv 8.x pending a real migration

### DIFF
--- a/lib/data/datasources/remote/archive_import_support.dart
+++ b/lib/data/datasources/remote/archive_import_support.dart
@@ -63,9 +63,10 @@ class ArchiveImportSupport {
           '(${limits.maxTotalUncompressedBytes} bytes).',
         );
       }
-      files[name] = item.content is List<int>
-          ? List<int>.from(item.content as List<int>)
-          : utf8.encode('${item.content}');
+      // archive 4.x types `content` as List<int>, so the old dynamic branch is
+      // unreachable. Still copied defensively so callers cannot mutate the
+      // decoder's buffers.
+      files[name] = List<int>.from(item.content);
     }
     return files;
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: "direct main"
     description:
       name: archive
-      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.1"
+    version: "4.0.9"
   async:
     dependency: transitive
     description:
@@ -81,14 +81,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
-  crypto:
-    dependency: transitive
-    description:
-      name: crypto
-      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.7"
   csv:
     dependency: "direct main"
     description:
@@ -373,6 +365,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: bc1bad54ad2b735816e31f8d4600cfde6c7839975085ddfbca48b6c9f7c4044e
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.2"
   provider:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   yaml: ^3.1.2
   http: ^1.2.1
   xml: ^7.0.1
-  archive: ^3.6.1
+  archive: ^4.0.9
   csv: ^6.0.0
   firebase_core: ^4.7.0
   firebase_auth: ^6.4.0

--- a/test/p0_importers_test.dart
+++ b/test/p0_importers_test.dart
@@ -105,7 +105,7 @@ void main() {
     test('rejects archive entries above the expanded-size limit', () {
       final archive = Archive()
         ..addFile(ArchiveFile('large.txt', 33, List<int>.filled(33, 65)));
-      final zipBytes = ZipEncoder().encode(archive)!;
+      final zipBytes = ZipEncoder().encode(archive);
 
       expect(
         () => ArchiveImportSupport.unzipFiles(zipBytes, limits: smallLimits),
@@ -116,7 +116,7 @@ void main() {
     test('rejects unsafe archive entry paths', () {
       final archive = Archive()
         ..addFile(ArchiveFile('../outside.txt', 1, const [65]));
-      final zipBytes = ZipEncoder().encode(archive)!;
+      final zipBytes = ZipEncoder().encode(archive);
 
       expect(
         () => ArchiveImportSupport.unzipFiles(zipBytes, limits: smallLimits),
@@ -233,7 +233,7 @@ void main() {
       ..addFile(
         ArchiveFile('foundationFoods.json', jsonBytes.length, jsonBytes),
       );
-    final zipBytes = ZipEncoder().encode(archive)!;
+    final zipBytes = ZipEncoder().encode(archive);
     final bundle = importer.importZipBytes(
       zipBytes,
       sourceLabel: 'foundation_zip',
@@ -3163,7 +3163,7 @@ void main() {
               fdcZipBytes,
             ),
           );
-        final zipBytes = ZipEncoder().encode(archive)!;
+        final zipBytes = ZipEncoder().encode(archive);
 
         // First call: stubCdss will fail promote on the first attempt and succeed
         // on the second attempt. Since both attempts are within one
@@ -3286,7 +3286,7 @@ void main() {
       // the medicines endpoint, and a no-op XLSX endpoint that returns empty
       // bytes (XLSX parser will then return an empty bundle, not throw).
       final fakeJson = jsonEncode(const <Map<String, dynamic>>[]);
-      final emptyXlsx = ZipEncoder().encode(Archive())!;
+      final emptyXlsx = ZipEncoder().encode(Archive());
       final emptyXlsxText = String.fromCharCodes(emptyXlsx);
       final fakeClient = FakeSourceFetchClient(
         textByUrl: {
@@ -3361,7 +3361,7 @@ void main() {
               fdcJsonBytes,
             ),
           );
-        final zipBytes = ZipEncoder().encode(archive)!;
+        final zipBytes = ZipEncoder().encode(archive);
 
         stubCdss.failPromoteOnce = true;
         await orchestrator.importOfflinePackagesDetailed(
@@ -3421,7 +3421,7 @@ void main() {
               fdcJsonBytes,
             ),
           );
-        final zipBytes = ZipEncoder().encode(archive)!;
+        final zipBytes = ZipEncoder().encode(archive);
         await orchestrator.importOfflinePackagesDetailed(
           fdcZipBytes: zipBytes,
           sourcePaths: const {'fdc': '/tmp/audit/fdc.zip'},
@@ -3541,7 +3541,7 @@ void main() {
               fdcJsonBytes,
             ),
           );
-        final zipBytes = ZipEncoder().encode(archive)!;
+        final zipBytes = ZipEncoder().encode(archive);
 
         final tokens = <String>{};
         for (var i = 0; i < 5; i++) {
@@ -3589,7 +3589,7 @@ void main() {
               fdcJsonBytes,
             ),
           );
-        final zipBytes = ZipEncoder().encode(archive)!;
+        final zipBytes = ZipEncoder().encode(archive);
 
         await orchestrator.importOfflinePackagesDetailed(
           fdcZipBytes: zipBytes,
@@ -3957,7 +3957,7 @@ ${sharedStrings.map((value) => '<si><t>${_escapeXml(value)}</t></si>').join()}
         worksheetBytes,
       ),
     );
-  return ZipEncoder().encode(archive)!;
+  return ZipEncoder().encode(archive);
 }
 
 String _buildSheetXml(int headerCount, int rowCount) {


### PR DESCRIPTION
## Summary

Verifies the two major pub bumps Dependabot raised **with no CI checks attached**
— PRs #103 (`archive` 3→4) and #104 (`csv` 6→8). Both were unverifiable until the
local toolchain was upgraded.

**Result: one is safe to take, one is not.**

> Stacked on #109 (the formatter migration) so its diff stays reviewable.

## ✅ `archive` 3.6.1 → 4.0.9 — adopted

No API errors; only warnings from *improved* typing:

- `ArchiveFile.content` is now declared `List<int>` instead of `dynamic`, making
  the old `is List<int>` branch unreachable (dead code).
- `ArchiveFile.name` is non-nullable, so ten `!` assertions in the importer
  tests became redundant.

Content is still copied defensively so callers can't mutate the decoder's
buffers.

**The security guards are unchanged and still exercised.**
`archive_import_support.dart` carries zip-slip path validation, symlink
rejection, per-entry and total expanded-size limits, and duplicate-name
rejection — `test/p0_importers_test.dart` passes **75/75**.

## ⛔ `csv` 6.0.0 → 8.0.0 — recommend closing #104

`csv 8` is a **complete API rewrite**. `CsvToListConverter` no longer exists; the
package now exposes `Csv` / `CsvDecoder` / `CsvEncoder` / `CsvRow`:

```
error • The name 'CsvToListConverter' isn't a class
      • lib/data/datasources/remote/archive_import_support.dart:93
```

Adapting means rewriting `parseDelimitedRows` — which **every delimited-source
importer depends on** — and re-establishing quoting, EOL, and delimiter-detection
behaviour.

There's **no security driver** for this bump, and the risk sits squarely in a
parsing path feeding food-composition data. That migration deserves its own
change with targeted parsing tests rather than being folded in here.

## Validation

On Flutter 3.47.0 / Dart 3.13.0:
- `dart format --set-exit-if-changed lib test tool` clean
- `flutter analyze` → No issues found
- `flutter test --concurrency=1` → **769 passed**
- `test/p0_importers_test.dart` → **75/75** (the guard suite)
- Governance gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)