### PR TITLE
Pin the CI Flutter version instead of tracking stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,14 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # Pinned deliberately. An unpinned `channel: stable` silently tracks
+          # whatever Flutter is current, which produced three surprise CI
+          # failures with no code change on our side: a new `unawaited_return_
+          # in_try_block` warning, a repo-wide `dart format` style change, and
+          # two new lint rules. Pinning makes a toolchain move an explicit,
+          # reviewable commit. Dependabot does not bump this; raise it
+          # intentionally alongside a green run.
+          flutter-version: '3.47.0'
           cache: true
 
       - name: Install Flutter dependencies
@@ -79,6 +87,14 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # Pinned deliberately. An unpinned `channel: stable` silently tracks
+          # whatever Flutter is current, which produced three surprise CI
+          # failures with no code change on our side: a new `unawaited_return_
+          # in_try_block` warning, a repo-wide `dart format` style change, and
+          # two new lint rules. Pinning makes a toolchain move an explicit,
+          # reviewable commit. Dependabot does not bump this; raise it
+          # intentionally alongside a green run.
+          flutter-version: '3.47.0'
           cache: true
 
       - name: Set up Node.js

--- a/.github/workflows/public-release-preflight.yml
+++ b/.github/workflows/public-release-preflight.yml
@@ -20,6 +20,14 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # Pinned deliberately. An unpinned `channel: stable` silently tracks
+          # whatever Flutter is current, which produced three surprise CI
+          # failures with no code change on our side: a new `unawaited_return_
+          # in_try_block` warning, a repo-wide `dart format` style change, and
+          # two new lint rules. Pinning makes a toolchain move an explicit,
+          # reviewable commit. Dependabot does not bump this; raise it
+          # intentionally alongside a green run.
+          flutter-version: '3.47.0'
           cache: true
 
       - run: npm ci


### PR DESCRIPTION
## Summary

Both workflows used `channel: stable` with **no version**, so CI silently ran on
whatever Flutter happened to be current. That produced **three failures today
with no code change on our side**:

| What broke | Cause |
| --- | --- |
| CI turned red on `main`-derived branches | A newer stable added the `unawaited_return_in_try_block` warning |
| 269-file formatting failure | A newer formatter changed style once the language version moved |
| `flutter analyze` exit 1 | Two new lint rules produced 38 findings |

Every one of those was a *legitimate* finding — the un-awaited `Future` was a
real error-handling bug. But arriving unannounced makes it impossible to tell a
genuine regression from a toolchain move, and it means a green PR can go red
overnight without anyone touching it.

## Change

Pin to **3.47.0** — the version this work is verified against — in all three
setup steps (two in `ci.yml`, one in `public-release-preflight.yml`).

Upgrades become an explicit, reviewable commit that lands with a green run,
rather than arriving as a surprise.

Note that Dependabot's `github-actions` ecosystem bumps the *action reference*
(`subosito/flutter-action@v2`), **not** this input — so the pin has to be raised
intentionally. That's the point, but it's worth knowing it won't self-update.

## Validation

- Both workflow files parse; `ci.yml` keeps its three jobs (`flutter`,
  `node-preflight`, `governance-gates`) and the preflight workflow its one.
- Pinned version matches the verified local toolchain (Flutter 3.47.0 /
  Dart 3.13.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)