### PR TITLE
Recover the archive 4.x adoption stranded by a stacked-PR merge

### DIFF
--- a/lib/data/datasources/remote/archive_import_support.dart
+++ b/lib/data/datasources/remote/archive_import_support.dart
@@ -63,9 +63,10 @@ class ArchiveImportSupport {
           '(${limits.maxTotalUncompressedBytes} bytes).',
         );
       }
-      files[name] = item.content is List<int>
-          ? List<int>.from(item.content as List<int>)
-          : utf8.encode('${item.content}');
+      // archive 4.x types `content` as List<int>, so the old dynamic branch is
+      // unreachable. Still copied defensively so callers cannot mutate the
+      // decoder's buffers.
+      files[name] = List<int>.from(item.content);
     }
     return files;
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: "direct main"
     description:
       name: archive
-      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.1"
+    version: "4.0.9"
   async:
     dependency: transitive
     description:
@@ -81,14 +81,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
-  crypto:
-    dependency: transitive
-    description:
-      name: crypto
-      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.7"
   csv:
     dependency: "direct main"
     description:
@@ -373,6 +365,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: bc1bad54ad2b735816e31f8d4600cfde6c7839975085ddfbca48b6c9f7c4044e
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.2"
   provider:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   yaml: ^3.1.2
   http: ^1.2.1
   xml: ^7.0.1
-  archive: ^3.6.1
+  archive: ^4.0.9
   csv: ^6.0.0
   firebase_core: ^4.7.0
   firebase_auth: ^6.4.0

--- a/test/p0_importers_test.dart
+++ b/test/p0_importers_test.dart
@@ -105,7 +105,7 @@ void main() {
     test('rejects archive entries above the expanded-size limit', () {
       final archive = Archive()
         ..addFile(ArchiveFile('large.txt', 33, List<int>.filled(33, 65)));
-      final zipBytes = ZipEncoder().encode(archive)!;
+      final zipBytes = ZipEncoder().encode(archive);
 
       expect(
         () => ArchiveImportSupport.unzipFiles(zipBytes, limits: smallLimits),
@@ -116,7 +116,7 @@ void main() {
     test('rejects unsafe archive entry paths', () {
       final archive = Archive()
         ..addFile(ArchiveFile('../outside.txt', 1, const [65]));
-      final zipBytes = ZipEncoder().encode(archive)!;
+      final zipBytes = ZipEncoder().encode(archive);
 
       expect(
         () => ArchiveImportSupport.unzipFiles(zipBytes, limits: smallLimits),
@@ -233,7 +233,7 @@ void main() {
       ..addFile(
         ArchiveFile('foundationFoods.json', jsonBytes.length, jsonBytes),
       );
-    final zipBytes = ZipEncoder().encode(archive)!;
+    final zipBytes = ZipEncoder().encode(archive);
     final bundle = importer.importZipBytes(
       zipBytes,
       sourceLabel: 'foundation_zip',
@@ -3163,7 +3163,7 @@ void main() {
               fdcZipBytes,
             ),
           );
-        final zipBytes = ZipEncoder().encode(archive)!;
+        final zipBytes = ZipEncoder().encode(archive);
 
         // First call: stubCdss will fail promote on the first attempt and succeed
         // on the second attempt. Since both attempts are within one
@@ -3286,7 +3286,7 @@ void main() {
       // the medicines endpoint, and a no-op XLSX endpoint that returns empty
       // bytes (XLSX parser will then return an empty bundle, not throw).
       final fakeJson = jsonEncode(const <Map<String, dynamic>>[]);
-      final emptyXlsx = ZipEncoder().encode(Archive())!;
+      final emptyXlsx = ZipEncoder().encode(Archive());
       final emptyXlsxText = String.fromCharCodes(emptyXlsx);
       final fakeClient = FakeSourceFetchClient(
         textByUrl: {
@@ -3361,7 +3361,7 @@ void main() {
               fdcJsonBytes,
             ),
           );
-        final zipBytes = ZipEncoder().encode(archive)!;
+        final zipBytes = ZipEncoder().encode(archive);
 
         stubCdss.failPromoteOnce = true;
         await orchestrator.importOfflinePackagesDetailed(
@@ -3421,7 +3421,7 @@ void main() {
               fdcJsonBytes,
             ),
           );
-        final zipBytes = ZipEncoder().encode(archive)!;
+        final zipBytes = ZipEncoder().encode(archive);
         await orchestrator.importOfflinePackagesDetailed(
           fdcZipBytes: zipBytes,
           sourcePaths: const {'fdc': '/tmp/audit/fdc.zip'},
@@ -3541,7 +3541,7 @@ void main() {
               fdcJsonBytes,
             ),
           );
-        final zipBytes = ZipEncoder().encode(archive)!;
+        final zipBytes = ZipEncoder().encode(archive);
 
         final tokens = <String>{};
         for (var i = 0; i < 5; i++) {
@@ -3589,7 +3589,7 @@ void main() {
               fdcJsonBytes,
             ),
           );
-        final zipBytes = ZipEncoder().encode(archive)!;
+        final zipBytes = ZipEncoder().encode(archive);
 
         await orchestrator.importOfflinePackagesDetailed(
           fdcZipBytes: zipBytes,
@@ -3957,7 +3957,7 @@ ${sharedStrings.map((value) => '<si><t>${_escapeXml(value)}</t></si>').join()}
         worksheetBytes,
       ),
     );
-  return ZipEncoder().encode(archive)!;
+  return ZipEncoder().encode(archive);
 }
 
 String _buildSheetXml(int headerCount, int rowCount) {


### PR DESCRIPTION
## Summary

**PR #110 shows MERGED, but its change never reached `main`.** `main` still has
`archive: ^3.6.1`.

#110 was stacked on `formatter-migration-sdk-floor` (#109). #109 merged to
`main` first; #110 then merged into that **already-merged, now-dead branch**, so
its commit landed somewhere no longer in `main`'s history:

```
$ git merge-base --is-ancestor <#110 merge commit> origin/main
NO — not in main
```

This cherry-picks the stranded commit (`089bafb`) onto `main` unchanged.

## What it restores

`archive` **3.6.1 → 4.0.9**, verified originally and re-verified now:

- `ArchiveFile.content` is typed `List<int>` instead of `dynamic`, making the
  old `is`-check branch dead — simplified, still copying defensively so callers
  can't mutate the decoder's buffers.
- `ArchiveFile.name` is non-nullable — ten redundant `!` assertions removed from
  the importer tests.

**The security guards are untouched**: zip-slip path validation, symlink
rejection, per-entry and total expanded-size limits, and duplicate-name
rejection all still hold, and `test/p0_importers_test.dart` passes **75/75**.

`csv` 6→8 remains **not adopted** — see #110's analysis. It's a complete API
rewrite (`CsvToListConverter` is gone) touching every delimited-source importer,
with no security driver. Recommend closing #104.

## Process note

Worth avoiding the stacked-PR pattern here, or merging the stack bottom-up in
one sitting. A stacked PR whose base merges first will silently merge into a
dead branch and report success — the failure mode is invisible unless you check
`main`'s actual content afterwards.

## Validation

Re-verified on Flutter 3.47.0 / Dart 3.13.0 against current `main`:
- `flutter analyze` → No issues found
- `flutter test --concurrency=1` → **769 passed**
- `test/p0_importers_test.dart` → **75/75**
- `dart format` clean; copy/localization/replay/contribution gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)