### PR TITLE
Match safety-router phrases as whole tokens; scope the CI format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,11 @@ jobs:
         run: flutter pub get
 
       # CI should report formatting drift without rewriting files in the runner.
+      # Scoped to source dirs: `dart format .` ignores analysis_options'
+      # analyzer excludes, so a stray build/ directory (platform SourcePackages,
+      # generated example code) would be formatted and fail the check.
       - name: Check Dart formatting
-        run: dart format --output=none --set-exit-if-changed .
+        run: dart format --output=none --set-exit-if-changed lib test tool
 
       - name: Analyze Flutter project
         run: flutter analyze

--- a/lib/domain/usecases/contribution_safety_router.dart
+++ b/lib/domain/usecases/contribution_safety_router.dart
@@ -306,6 +306,29 @@ class ContributionSafetyRouter {
 
   // --- keyword scanning -----------------------------------------------------
 
+  /// Whole-token phrase match.
+  ///
+  /// A plain `contains` produced false positives on identifiers that merely
+  /// embed a phrase: the scoring feature `medication_schedule_fit` matched the
+  /// `medication_schedule` PHI phrase, and `mrna` matched `mrn`. Boundaries
+  /// treat `_` and alphanumerics as word characters, so snake_case identifiers
+  /// only match when the phrase is the complete token.
+  ///
+  /// Deliberately narrow: it removes substring noise without weakening any
+  /// real match — `medication_schedule: ...` and `mrn: ...` still fire.
+  static final Map<String, RegExp> _phraseMatchers = {};
+
+  bool _containsPhrase(String hay, String phrase) {
+    final matcher = _phraseMatchers.putIfAbsent(
+      phrase,
+      () => RegExp(
+        '(?<![A-Za-z0-9_])${RegExp.escape(phrase)}(?![A-Za-z0-9_])',
+        caseSensitive: false,
+      ),
+    );
+    return matcher.hasMatch(hay);
+  }
+
   void _scan(
     ContributionChange c,
     String hay,
@@ -317,7 +340,7 @@ class ContributionSafetyRouter {
     String review,
   ) {
     for (final phrase in phrases) {
-      if (hay.contains(phrase)) {
+      if (_containsPhrase(hay, phrase)) {
         categories.add(category);
         findings.add(
           _f(

--- a/test/contribution_safety_router_test.dart
+++ b/test/contribution_safety_router_test.dart
@@ -273,4 +273,54 @@ void main() {
             as Map<String, dynamic>;
     scanNoPhiKeys(decoded);
   });
+
+  // --- Keyword matching precision -----------------------------------------
+  //
+  // Phrases are matched as whole tokens. A plain substring match flagged any
+  // identifier that merely embedded a phrase, which is how the scoring feature
+  // `medication_schedule_fit` was reported as PHI risk.
+
+  test('identifier embedding a PHI phrase is not flagged', () {
+    final r = route([
+      change(
+        'lib/domain/entities/food_recommendation.dart',
+        added: "'medication_schedule_fit': medicationScheduleFit,",
+      ),
+    ]);
+    expect(
+      hasCategory(r, ContributionRiskCategory.phiRisk),
+      isFalse,
+      reason: 'a scoring-feature key is not a medication schedule',
+    );
+  });
+
+  test('the real PHI phrase is still flagged', () {
+    for (final line in const [
+      "'medication_schedule': loadedSchedule,",
+      'the medication schedule for this user',
+      'mrn: 123456',
+    ]) {
+      final r = route([change('lib/data/example.dart', added: line)]);
+      expect(
+        hasCategory(r, ContributionRiskCategory.phiRisk),
+        isTrue,
+        reason: 'should still flag: $line',
+      );
+    }
+  });
+
+  test('short phrases do not match longer words', () {
+    // `mrn` previously matched `mrna`, plausible in this domain.
+    final r = route([
+      change('lib/data/example.dart', added: 'mrna transcript counts'),
+    ]);
+    expect(hasCategory(r, ContributionRiskCategory.phiRisk), isFalse);
+  });
+
+  test('phrase matching is case-insensitive', () {
+    final r = route([
+      change('lib/data/example.dart', added: 'Patient Name: synthetic'),
+    ]);
+    expect(hasCategory(r, ContributionRiskCategory.phiRisk), isTrue);
+  });
 }

--- a/tool/run_contribution_safety_router.dart
+++ b/tool/run_contribution_safety_router.dart
@@ -63,10 +63,6 @@ const List<String> _allowlistedPaths = [
   // Injects adversarial prescriptive strings as fuzz inputs to prove the
   // deterministic gates reject them.
   'lib/domain/usecases/synthetic_scenario_fuzzer.dart',
-  // Scoring-feature key `medication_schedule_fit` substring-matches the
-  // medication_schedule PHI pattern; it is a ranking feature name, not a
-  // schedule. Detector precision could be tightened instead — see PR notes.
-  'lib/domain/entities/food_recommendation.dart',
 ];
 
 final RegExp _docExt = RegExp(r'\.(md|markdown)$');


### PR DESCRIPTION
## Summary

Two follow-ups recorded during the formatter migration (#109).

## 1. Keyword matching precision — fixing the detector instead of allowlisting around it

`_scan` compared with `hay.contains(phrase)`, so **any identifier that merely
embedded a phrase was reported**:

| Content | Phrase | Before | After |
| --- | --- | --- | --- |
| `'medication_schedule_fit': ...` | `medication_schedule` | ❌ flagged as PHI | ✅ clean |
| `mrna transcript counts` | `mrn` | ❌ flagged as PHI | ✅ clean |
| `'medication_schedule': loaded` | `medication_schedule` | ✅ flagged | ✅ flagged |
| `Patient Name: synthetic` | `patient name` | ✅ flagged | ✅ flagged |

Phrases now match as **whole tokens**, with `_` and alphanumerics treated as word
characters so snake_case identifiers only match when the phrase is the complete
token. Matchers are cached per phrase.

**This removes the need for the allowlist entry** added in #109 for
`food_recommendation.dart` — that file is fully scanned again instead of having
its findings silently downgraded to INFO. Fixing the detector is strictly better
than allowlisting a `lib/` entity around a known false positive.

**`_scanSourceAccess` deliberately keeps substring matching.** Its phrases are
prose — `"production-ready"`, `"license cleared"` — where looseness is
*protective*: `"production-readiness"` should still match. Tightening it there
would create misses, so the change is scoped to the identifier-noise case.

Four tests pin the behaviour, including that `mrn` no longer matches `mrna` and
that matching stays case-insensitive.

## 2. CI format check scope

`dart format .` does **not** honour `analysis_options`' analyzer excludes, so a
stray `build/` directory (platform SourcePackages, generated example code) gets
formatted and fails the check — locally it already reports 516 files instead of
312. Scoped to `lib test tool`, matching what the excludes intend.

## Validation

On Flutter 3.47.0 / Dart 3.13.0:
- `dart format --set-exit-if-changed lib test tool` clean
- `flutter analyze` → No issues found
- `flutter test --concurrency=1` → **773 passed** (up from 769)
- Governance gates pass; `contribution:route` exits 0 with the allowlist entry removed
- Workflow YAML parses; `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)